### PR TITLE
Add test coverage for tree dump facility

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1435,7 +1435,6 @@ void db::decrease_memory_use(std::size_t delta) noexcept {
 
 namespace {
 
-// TODO(laurynas): add tests for dump_node, by writing to ostrstream
 void dump_node(std::ostream &os, const unodb::node_ptr &node) {
   os << "node at: " << &node;
   if (node.header == nullptr) {

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -116,6 +116,12 @@ void tree_verifier::check_present_values() const noexcept {
   for (const auto &[key, value] : values) {
     ASSERT_VALUE_FOR_KEY(key, value);
   }
+#ifndef NDEBUG
+  // Dump the tree to a string. Do not attempt to check the dump format, only
+  // that dumping does not crash
+  std::stringstream dump_sink;
+  test_db.dump(dump_sink);
+#endif
 }
 
 void tree_verifier::check_absent_keys(

--- a/test_art_fuzz_deepstate.cpp
+++ b/test_art_fuzz_deepstate.cpp
@@ -1,5 +1,8 @@
 // Copyright 2019 Laurynas Biveinis
 
+#ifndef NDEBUG
+#include <sstream>
+#endif
 #include <unordered_map>
 
 #include <deepstate/DeepState.hpp>
@@ -61,6 +64,17 @@ unodb::key_type get_key(unodb::key_type max_key_value,
     return keys[existing_key_i];
   }
   return DeepState_UInt64InRange(0, max_key_value);
+}
+
+void dump_tree(const unodb::db &tree) {
+#ifndef NDEBUG
+  // Dump the tree to a string. Do not attempt to check the dump format, only
+  // that dumping does not crash
+  std::stringstream dump_sink;
+  tree.dump(dump_sink);
+#else
+  (void)tree;
+#endif
 }
 
 }  // namespace
@@ -125,6 +139,7 @@ TEST(ART, DeepState_fuzz) {
             }
           } catch (const std::bad_alloc &) {
           }
+          dump_tree(test_db);
           LOG(TRACE) << "Current mem use: "
                      << static_cast<uint64_t>(test_db.get_current_memory_use());
         },
@@ -160,6 +175,7 @@ TEST(ART, DeepState_fuzz) {
             ASSERT(oracle_delete_result == 0)
                 << "If delete failed, oracle delete must fail too";
           }
+          dump_tree(test_db);
           LOG(TRACE) << "Current mem use: "
                      << static_cast<uint64_t>(test_db.get_current_memory_use());
         });


### PR DESCRIPTION
Extend both gunit and fuzzer tests. Dump the tree to a string stream,
do not try to check its contents, only that the dumping does not
crash.