### PR TITLE
Add GCC 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-xenial-8
+            # TODO(laurynas): add llvm-toolchain-xenial-9 once available
             - sourceline: 'ppa:mhier/libboost-latest'
           packages:
+            # TODO(laurynas): install only what's needed for each job
             - g++-7
             - g++-8
             - boost1.68

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,14 @@ endif()
 
 configure_file(config.hpp.in config.hpp)
 
-find_package(Boost REQUIRED COMPONENTS container)
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS_EQUAL 8)
+  find_package(Boost REQUIRED COMPONENTS container)
+else()
+  message(STATUS "Using GCC 9+, using std::pmr instead of boost::pmr")
+endif()
 
 # TODO(laurynas): convert benchmark dependency to a git submodule
+# TODO(laurynas): GCC 9?
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   message(STATUS "Not looking for Google benchmark library due to compiling with GCC on macOS")
 else()

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Unodb is a adaptive radix tree implementation, done as my playground for various
 *   CMake, at least 3.12
 *   Guidelines Support Library for gsl::span, imported as a git
     submodule.
-*   Boost.Container library. Version 1.69 gives UBSan errors
-    ([bug report 1][boostub1], [bug report 2][boostub2]). Currently it
-    is being tested with 1.60, 1.68, & 1.69 (w/o sanitizers).
+*   Unless GCC version 9 is used, Boost.Container library. Version
+    1.69 gives UBSan errors ([bug report 1][boostub1], [bug report
+    2][boostub2]). Currently it is being tested with 1.60, 1.68, &
+    1.69 (w/o sanitizers).
 *   clang-format, at least 8.0
 *   Google Test for tests, imported as a git submodule.
 *   (optional) lcov
@@ -42,7 +43,9 @@ compiler warnings is set very high, and can be relaxed, especially for
 clang-tidy, as need arises.
 
 To enable Address, Leak, and Undefined Behavior sanitizers, add
-`-DSANITIZE=ON` CMake option.
+`-DSANITIZE=ON` CMake option. Using this with GCC 9, where std::pmr
+from libstdc++ is used instead of boost::pmr, will result in UBSan
+false positives due to [this][libstdc++ub].
 
 To invoke include-what-you-use, add `-DIWYU=ON` CMake option. It will
 take effect if CMake configures to build project with clang.
@@ -68,6 +71,8 @@ doi:10.1109/ICDE.2013.6544812
 [boostub1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80963
 
 [boostub2]: https://bugs.llvm.org/show_bug.cgi?id=39191
+
+[libstdc++ub]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90442
 
 [gc++style]: https://google.github.io/styleguide/cppguide.html "Google C++ Style Guide"
 

--- a/global.hpp
+++ b/global.hpp
@@ -35,4 +35,16 @@
 #define RESTORE_CLANG_WARNINGS()
 #endif
 
+#if defined(__GNUG__) && !defined(__clang__)
+#define DISABLE_GCC_WARNING(x) \
+  _Pragma("GCC diagnostic push") DO_PRAGMA(GCC diagnostic ignored x)
+#define RESTORE_GCC_WARNINGS() _Pragma("GCC diagnostic pop")
+#else
+#define DISABLE_GCC_WARNING(x)
+#define RESTORE_GCC_WARNINGS()
+#endif
+
+#define likely(x) __builtin_expect(x, 1)
+#define unlikely(x) __builtin_expect(x, 0)
+
 #endif  // UNODB_GLOBAL_HPP_

--- a/micro_benchmark.cpp
+++ b/micro_benchmark.cpp
@@ -114,7 +114,7 @@ void dense_full_scan(benchmark::State &state) {
       for (unodb::key_type j = 0;
            j < static_cast<unodb::key_type>(state.range(0)); j++) {
         benchmark::DoNotOptimize(test_db.get(j));
-    }
+      }
   state.SetItemsProcessed(state.range(0) * full_scan_multiplier);
 }
 
@@ -161,8 +161,7 @@ void dense_tree_increasing_keys(benchmark::State &state) {
   state.SetItemsProcessed(dense_tree_increasing_keys_delete_insert_pairs * 2);
 }
 
-void dense_insert_value_lengths_args(
-    benchmark::internal::Benchmark *b) {
+void dense_insert_value_lengths_args(benchmark::internal::Benchmark *b) {
   for (auto i = 100; i <= 1000000; i *= 8)
     for (auto j = 0; j < static_cast<int64_t>(values.size()); j++)
       b->Args({i, j});
@@ -208,9 +207,7 @@ BENCHMARK(sparse_insert_mem_check_dups_allowed)
 BENCHMARK(sparse_insert_no_mem_check_dups_allowed)
     ->Range(100, 10000000)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK(dense_full_scan)
-    ->Range(100, 50000000)
-    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(dense_full_scan)->Range(100, 50000000)->Unit(benchmark::kMicrosecond);
 BENCHMARK(dense_tree_sparse_deletes)
     ->ArgNames({"", "deletes"})
     ->Apply(dense_tree_sparse_deletes_args)

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -76,8 +76,7 @@ void tree_verifier::insert(unodb::key_type k, unodb::value_view v) {
   const auto mem_use_before = test_db.get_current_memory_use();
   try {
     ASSERT_TRUE(test_db.insert(k, v));
-  }
-  catch (const std::bad_alloc &) {
+  } catch (const std::bad_alloc &) {
     const auto mem_use_after = test_db.get_current_memory_use();
     ASSERT_EQ(mem_use_before, mem_use_after);
     throw;


### PR DESCRIPTION
- add DISABLE_GCC_WARNING/RESTORE_GCC_WARNING facility and use it to
  disable a cold attribute suggestion on one method;
- do not require Boost if building with GCC 9 and hide PMR types
  behind aliases which resolve to Boost or std as needed;
- introduce likely/unlikely macros and use them instead of
  BOOST_LIKELY/BOOST_UNLIKELY;
- update README.md accordingly;
- add a few TODOs;
- fix up some formatting issues.