### PR TITLE
Convert node_ptr from unique_ptr union to raw pointer union

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,7 @@ else()
       "-cppcoreguidelines-pro-bounds-pointer-arithmetic,"
       # Because VALGRIND_MALLOCLIKE_BLOCK expands to C-style cast, and we have
       # -Wold-style-cast anyway
+      "-cppcoreguidelines-pro-type-const-cast,"
       "-cppcoreguidelines-pro-type-cstyle-cast,"
       "-cppcoreguidelines-pro-type-member-init,"
       "-cppcoreguidelines-pro-type-reinterpret-cast,"
@@ -305,7 +306,9 @@ else()
   set(CPPCHECK_CHECKS
     "--suppress=unreadVariable" # False positive: on key2_i
     "--suppress=syntaxError" # False positive on test_art.cpp:148
-    "--suppress=ignoredReturnValue") # False positive on ctors with std::move arg
+    "--suppress=ignoredReturnValue" # False positive on ctors with std::move arg
+    # False positive on pointer unions being passed by value
+    "--suppress=passedByValue")
 endif()
 
 find_program(CPPCHECK_EXE NAMES "cppcheck" DOC "Path to cppcheck executable")

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -48,8 +48,8 @@ RESTORE_CLANG_WARNINGS()
 
 class tree_verifier final {
  public:
-  explicit tree_verifier(std::size_t memory_limit = 0) noexcept :
-      test_db{memory_limit} { }
+  explicit tree_verifier(std::size_t memory_limit = 0) noexcept
+      : test_db{memory_limit} {}
 
   void insert(unodb::key_type k, unodb::value_view v);
 


### PR DESCRIPTION
The main effect is that the tree in-memory is traversed by raw pointers now, and
any node/subtree deletion operations have to be explicit.

Introduce a unique_ptr-based union, delete_node_ptr_at_scope_exit, to be used as
a deleter on scope exit, which was previously handled by node_ptr.

Fix single_value_leaf_type to be std::byte instead of std::byte[] as with these
changes std::unique_ptr<std::byte[]> would not do what we want.

Add a destructor to db class to handle tree destruction now that unique_ptr
recursive destruction is no longer available. Add internal_node::delete_subtree
for the same goal.

Replace placement new operators in node children pointer manipulation with
simple assignments.

This is a prerequisite for OLC concurrency.