### PR TITLE
Switch to Boost 1.70/1.71

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
             # TODO(laurynas): install only what's needed for each job
             - g++-7
             - g++-8
-            - boost1.68
+            - boost1.70
             - valgrind
             - clang-8
             - clang-tools-8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,14 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
   message(STATUS "Using GCC 9+, using std::pmr instead of boost::pmr")
   SET(USE_BOOST FALSE)
 else()
+  # Workaround https://github.com/boostorg/boost_install/issues/13: Homebrew
+  # Boost 1.71 installs single-thread and MT build to the same prefix, resulting
+  # in -
+  # CMake Warning at /usr/local/lib/cmake/boost_container-1.71.0/libboost_container-variant-shared.cmake:59 (message):
+  # Target Boost::container already has an imported location
+  # '/usr/local/lib/libboost_container-mt.dylib', which will be overwritten
+  # with '/usr/local/lib/libboost_container.dylib'
+  set(Boost_NO_BOOST_CMAKE ON)
   find_package(Boost REQUIRED COMPONENTS container)
   SET(USE_BOOST TRUE)
 endif()

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ C++ tools and ideas.
   9.0.
 * CMake, at least 3.12
 * Guidelines Support Library for gsl::span, imported as a git submodule.
-* Unless GCC version 9 is used, Boost.Container library. Version 1.69 gives
-  UBSan errors ([bug report 1][boostub1],  [bug report 2][boostub2]). Currently
-  it is being tested with 1.60, 1.68, & 1.69 (w/o sanitizers).
+* Unless GCC version 9 is used, Boost.Container library. Currently 1.70 and 1.71
+  are being tested. Version 1.69 gives UBSan errors ([bug report 1][boostub1],
+  [bug report 2][boostub2]).
 * clang-format, at least 8.0
 * Google Test for tests, imported as a git submodule.
 * (optional) lcov


### PR DESCRIPTION
- Update Travis CI config to boost 1.70 from 1.68. I was not able to find a
  1.71-carrying PPA at the moment. That version is being tested through macOS
  configs.

- Add a workaround for Homebrew Boost 1.71 package bug in CMake config