### PR TITLE
Introduce db::empty() method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,7 +382,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   endif()
 endfunction()
 
-add_library(unodb art.cpp art.hpp global.hpp)
+add_library(unodb art.cpp art.hpp art_key_value.hpp global.hpp)
 common_target_properties(unodb)
 target_include_directories(unodb SYSTEM PUBLIC "${GSL_INCLUDES}")
 if(USE_BOOST)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ The API implemented by `db` class:
   successful (i.e. the key was not already present).
 * `bool remove(key_type k)`, returning whether delete was successful (i.e. the
   key was found in the tree).
+* `std::size_t get_current_memory_use()`, returning current memory use by
+  internal nodes in bytes, only accounted if memory limit was specified in
+  constructor, otherwise always zero.
+* `bool empty()`, returning whether the tree is empty.
+* `void dump(std::ostream &)`, only available if `NDEBUG` is not defined,
+  dumping the tree representation into output stream.
 
 The class is unsychronized, to be using in single-thread context or with
 external synchronization.

--- a/art.hpp
+++ b/art.hpp
@@ -5,7 +5,7 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cassert>
-#include <cstddef>  // for uint64_t
+#include <cstddef>  // for uint8_t
 #include <cstdint>  // IWYU pragma: keep
 #include <cstring>
 #include <memory>
@@ -14,10 +14,9 @@
 
 #include <gsl/span>
 
-namespace unodb {
+#include "art_key_value.hpp"
 
-// Key type for public API
-using key_type = uint64_t;
+namespace unodb {
 
 // Internal ART key in binary-comparable format
 template <typename KeyType>
@@ -60,11 +59,6 @@ struct art_key final {
 };
 
 using art_key_type = art_key<key_type>;
-
-// Value type for public API. Values are passed as non-owning pointers to
-// memory with associated length (gsl::span). The memory is copied upon
-// insertion.
-using value_view = gsl::span<const std::byte>;
 
 struct node_header;
 
@@ -141,7 +135,9 @@ class db final {
   void dump(std::ostream &os) const;
 #endif
 
-  [[nodiscard]] std::size_t get_current_memory_use() const noexcept {
+  [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
+
+  [[nodiscard]] auto get_current_memory_use() const noexcept {
     return current_memory_use;
   }
 

--- a/art_key_value.hpp
+++ b/art_key_value.hpp
@@ -1,0 +1,23 @@
+// Copyright 2019 Laurynas Biveinis
+#ifndef UNODB_ART_KEY_VALUE_HPP_
+#define UNODB_ART_KEY_VALUE_HPP_
+
+#include "global.hpp"
+
+#include <cstdint>
+
+#include <gsl/span>
+
+namespace unodb {
+
+// Key type for public API
+using key_type = uint64_t;
+
+// Value type for public API. Values are passed as non-owning pointers to
+// memory with associated length (gsl::span). The memory is copied upon
+// insertion.
+using value_view = gsl::span<const std::byte>;
+
+}  // namespace unodb
+
+#endif  // UNODB_ART_KEY_VALUE_HPP_

--- a/test_art_fuzz_deepstate.cpp
+++ b/test_art_fuzz_deepstate.cpp
@@ -111,6 +111,7 @@ TEST(ART, DeepState_fuzz) {
     LOG(TRACE) << "Not limiting value length (" << max_value_length << ")";
 
   unodb::db test_db{mem_limit};
+  ASSERT(test_db.empty());
 
   std::vector<unodb::key_type> keys;
   values_type values;
@@ -129,6 +130,7 @@ TEST(ART, DeepState_fuzz) {
             const auto mem_use_after = test_db.get_current_memory_use();
             if (insert_result) {
               LOG(TRACE) << "Inserted key " << key;
+              ASSERT(!test_db.empty());
               ASSERT(mem_use_after > mem_use_before || mem_limit == 0);
               const auto oracle_insert_result = oracle.emplace(key, value);
               ASSERT(oracle_insert_result.second)
@@ -156,6 +158,7 @@ TEST(ART, DeepState_fuzz) {
           const auto search_result = test_db.get(key);
           const auto oracle_search_result = oracle.find(key);
           if (search_result) {
+            ASSERT(!test_db.empty());
             ASSERT(oracle_search_result != oracle.cend())
                 << "If search returned a value, oracle must contain that value";
             ASSERT(std::equal(search_result->cbegin(), search_result->cend(),
@@ -205,6 +208,7 @@ TEST(ART, DeepState_fuzz) {
     prev_mem_use = current_mem_use;
   }
   ASSERT(prev_mem_use == 0);
+  ASSERT(test_db.empty());
 }
 
 RESTORE_CLANG_WARNINGS()


### PR DESCRIPTION
- Split art_key_value.hpp from art.hpp, containing key_type and value_view types
- Expand README.md a bit
- Introduce db::empty() method, call it from tests as appropriate