### PR TITLE
Add trivial mutex-serialized implementation of concurrent ART

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: bionic
 env:
   global:
     - SANITIZE=OFF
+    - SANITIZE_THREAD=OFF
     - SCAN_BUILD=
     - COVERAGE=OFF
 
@@ -34,37 +35,55 @@ matrix:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Release
       compiler: gcc
     - <<: *linux-base
-      name: "Bionic GCC 8 Release with sanitizers"
+      name: "Bionic GCC 8 Release with ASan/UBSan"
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Release SANITIZE=ON
+    - <<: *linux-base
+      name: "Bionic GCC 8 Release with TSan/UBSan"
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Release SANITIZE_THREAD=ON
     - <<: *linux-base
       name: "Bionic GCC 8 Debug"
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Debug
     - <<: *linux-base
-      name: "Bionic GCC 8 Debug with sanitizers"
+      name: "Bionic GCC 8 Debug with ASan/UBSan"
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Debug SANITIZE=ON
+    - <<: *linux-base
+      name: "Bionic GCC 8 Debug with TSan/UBSan"
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Debug SANITIZE_THREAD=ON
     - <<: *linux-base
       name: "Bionic clang 8 Release"
       compiler: clang
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release
     - <<: *linux-base
-      name: "Bionic clang 8 Release with sanitizers"
+      name: "Bionic clang 8 Release with ASan/UBSan"
       compiler: clang
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release SANITIZE=ON
+    - <<: *linux-base
+      name: "Bionic clang 8 Release with TSan/UBSan"
+      compiler: clang
+      env:
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release SANITIZE_THREAD=ON
     - <<: *linux-base
       name: "Bionic clang 8 Debug"
       compiler: clang
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug
     - <<: *linux-base
-      name: "Bionic clang 8 Debug with sanitizers"
+      name: "Bionic clang 8 Debug with ASan/UBSan"
       compiler: clang
       env:
         - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug SANITIZE=ON
+    - <<: *linux-base
+      name: "Bionic clang 8 Debug with TSan/UBSan"
+      compiler: clang
+      env:
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug SANITIZE_THREAD=ON
     - <<: *linux-base
       name: "Bionic clang 8 static analysis Release"
       compiler: clang
@@ -87,17 +106,25 @@ matrix:
       env:
         - BUILD_TYPE=Release
     - <<: *macos-base
-      name: "macOS XCode 11.0 Release with sanitizers"
+      name: "macOS XCode 11.0 Release with ASan/UBSan"
       env:
         - BUILD_TYPE=Release SANITIZE=ON
+    - <<: *macos-base
+      name: "macOS XCode 11.0 Release with TSan/UBSan"
+      env:
+        - BUILD_TYPE=Release SANITIZE_THREAD=ON
     - <<: *macos-base
       name: "macOS XCode 11.0 Debug"
       env:
         - BUILD_TYPE=Debug
     - <<: *macos-base
-      name: "macOS XCode 11.0 Debug with sanitizers"
+      name: "macOS XCode 11.0 Debug with ASan/UBSan"
       env:
         - BUILD_TYPE=Debug SANITIZE=ON
+    - <<: *macos-base
+      name: "macOS XCode 11.0 Debug with TSan/UBSan"
+      env:
+        - BUILD_TYPE=Debug SANITIZE_THREAD=ON
     - <<: *linux-base
       name: "Bionic GCC 7 Release"
       compiler: gcc
@@ -134,7 +161,7 @@ script:
   - if [[ "$CC" == "gcc-7" && "$COVERAGE" == "ON" ]]; then
       EXTRA_CMAKE_OPTIONS+="-DGCOV_PATH=/usr/bin/gcov-7 ";
     fi
-  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DSANITIZE=${SANITIZE} -DCOVERAGE=${COVERAGE} ${EXTRA_CMAKE_OPTIONS}
+  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DSANITIZE=${SANITIZE} -DSANITIZE_THREAD=${SANITIZE_THREAD} -DCOVERAGE=${COVERAGE} ${EXTRA_CMAKE_OPTIONS}
   - ${SCAN_BUILD} make -j3
   - if [[ ! -z "${SCAN_BUILD}" ]]; then
       travis_terminate 0;
@@ -145,6 +172,7 @@ script:
       make -j3 coverage;
       bash <(curl -s https://codecov.io/bash) -f coverage-coverage.info || echo "Codecov did not collect coverage reports";
     fi
-  - if [[ "$SANITIZE" == "OFF" && "$COVERAGE" == "OFF" && "$TRAVIS_OS_NAME" != "osx" ]]; then
+  - if [[ "$SANITIZE" == "OFF" && "$SANITIZE_THREAD" == "OFF" && "$COVERAGE" == "OFF" && "$TRAVIS_OS_NAME" != "osx" ]]; then
       valgrind --error-exitcode=1 ./test_art;
+      valgrind --error-exitcode=1 ./test_art_mutex_concurrency;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,23 +112,33 @@ else()
   if(NOT COVERAGE)
     list(APPEND CXX_FLAGS "-O3")
   else()
-    list(APPEND CXX_FLAGS "-Og")
+    list(APPEND CXX_FLAGS "-O0")
   endif()
 endif()
 
-option(SANITIZE "Enable AddressSanitizer and UndefinedBehaviorSanitizer runtime checks")
-if(SANITIZE)
-  set(GCC_EXTRA_SANITIZE_FLAGS "-fsanitize=pointer-compare"
-    "-fsanitize=pointer-subtract" "-fsanitize=leak"
-    "-fsanitize-address-use-after-scope")
-  list(APPEND CXX_FLAGS
-    "-fno-omit-frame-pointer" "-fno-optimize-sibling-calls" "-fsanitize=address"
-    "-fsanitize=undefined")
-  set(LD_FLAGS "-fsanitize=address" "-fsanitize=undefined")
+macro(ADD_TO_GNU_CXX_LD_FLAGS)
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    list(APPEND CXX_FLAGS "${GCC_EXTRA_SANITIZE_FLAGS}")
-    list(APPEND LD_FLAGS "${GCC_EXTRA_SANITIZE_FLAGS}")
+    list(APPEND CXX_FLAGS ${ARGV})
+    list(APPEND LD_FLAGS ${ARGV})
   endif()
+endmacro()
+
+macro(SET_COMMON_SANITIZER_FLAGS)
+  list(APPEND CXX_FLAGS "-fsanitize=undefined" "-fno-omit-frame-pointer"
+    "-fno-optimize-sibling-calls")
+  set(LD_FLAGS "-fsanitize=undefined")
+  string(CONCAT UBSAN_OPTIONS "UBSAN_OPTIONS="
+    "print_stacktrace=1")
+endmacro()
+
+option(SANITIZE
+  "Enable AddressSanitizer and UndefinedBehaviorSanitizer runtime checks")
+if(SANITIZE)
+  set_common_sanitizer_flags()
+  list(APPEND CXX_FLAGS "-fsanitize=address")
+  list(APPEND LD_FLAGS "-fsanitize=address")
+  add_to_gnu_cxx_ld_flags("-fsanitize=leak" "-fsanitize-address-use-after-scope"
+    "-fsanitize=pointer-compare" "-fsanitize=pointer-subtract")
   string(CONCAT ASAN_OPTIONS "ASAN_OPTIONS="
     "check_initialization_order=true:detect_stack_use_after_return=true:"
     "alloc_dealloc_mismatch=true:strict_string_checks=true")
@@ -151,23 +161,37 @@ if(SANITIZE)
     "print_stacktrace=1")
 endif()
 
+option(SANITIZE_THREAD
+  "Enable ThreadSanitizer and UndefinedBehaviorSanitizer runtime checks")
+if(SANITIZE_THREAD)
+  set_common_sanitizer_flags()
+  list(APPEND CXX_FLAGS "-fsanitize=thread")
+  list(APPEND LD_FLAGS "-fsanitize=thread")
+endif()
+
 function(SET_SANITIZER_TARGET_PROPERTIES TARGET)
   if(SANITIZE)
     set_tests_properties(${TARGET} PROPERTIES ENVIRONMENT "${ASAN_OPTIONS}")
+  endif()
+  if(SANITIZE OR SANITIZE_THREAD)
     set_property(TEST ${TARGET} APPEND PROPERTY ENVIRONMENT "${UBSAN_OPTIONS}")
   endif()
 endfunction()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  SET(DEBUG "ON")
+  set(DEBUG "ON")
 endif()
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 configure_file(config.hpp.in config.hpp)
+
+find_package(Threads REQUIRED)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
     "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 9)
   message(STATUS "Using GCC 9+, using std::pmr instead of boost::pmr")
-  SET(USE_BOOST FALSE)
+  set(USE_BOOST FALSE)
 else()
   # Workaround https://github.com/boostorg/boost_install/issues/13: Homebrew
   # Boost 1.71 installs single-thread and MT build to the same prefix, resulting
@@ -178,7 +202,7 @@ else()
   # with '/usr/local/lib/libboost_container.dylib'
   set(Boost_NO_BOOST_CMAKE ON)
   find_package(Boost REQUIRED COMPONENTS container)
-  SET(USE_BOOST TRUE)
+  set(USE_BOOST TRUE)
 endif()
 
 # TODO(laurynas): convert benchmark dependency to a git submodule
@@ -230,10 +254,10 @@ endif()
 
 if(DEEPSTATE_HPP_PATH)
   if(DEEPSTATE_LIB_PATH)
-    SET(DEEPSTATE_OK TRUE)
+    set(DEEPSTATE_OK TRUE)
   endif()
   if(DEEPSTATE_LF_LIB_PATH)
-    SET(DEEPSTATE_LF_OK TRUE)
+    set(DEEPSTATE_LF_OK TRUE)
   endif()
 endif()
 
@@ -316,7 +340,9 @@ else()
     "--suppress=syntaxError" # False positive on test_art.cpp:148
     "--suppress=ignoredReturnValue" # False positive on ctors with std::move arg
     # False positive on pointer unions being passed by value
-    "--suppress=passedByValue")
+    "--suppress=passedByValue"
+    # False positive on benchmark::State arg
+    "--suppress=constParameter")
 endif()
 
 find_program(CPPCHECK_EXE NAMES "cppcheck" DOC "Path to cppcheck executable")
@@ -335,6 +361,7 @@ if(NOT CPPLINT_EXE)
 else()
   message(STATUS "cpplint found: ${CPPLINT_EXE}")
   string(CONCAT CPPLINT_DISABLED_TESTS "--filter="
+    "-build/c++11," # <thread> is an unapproved C++11 header
     "-build/include_order,"
     "-runtime/references,"
     "-whitespace/braces") # Does not understand C++17 structured bindings and we use
@@ -382,7 +409,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   endif()
 endfunction()
 
-add_library(unodb art.cpp art.hpp art_key_value.hpp global.hpp)
+add_library(unodb art.cpp art.hpp art_key_value.hpp global.hpp mutex_art.hpp)
 common_target_properties(unodb)
 target_include_directories(unodb SYSTEM PUBLIC "${GSL_INCLUDES}")
 if(USE_BOOST)
@@ -394,6 +421,7 @@ set_target_properties(unodb PROPERTIES CXX_EXTENSIONS OFF)
 if(DO_CLANG_TIDY)
   set_target_properties(unodb PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
 endif()
+target_link_libraries(unodb PUBLIC Threads::Threads)
 
 add_subdirectory(googletest)
 
@@ -417,20 +445,32 @@ function(ADD_COVERAGE_TARGET)
     DEPENDS ${ARG_DEPENDENCY})
 endfunction()
 
-add_executable(test_art test_art.cpp)
-common_target_properties(test_art)
-target_link_libraries(test_art PRIVATE unodb gtest_main)
+add_library(test_utils STATIC test_utils.hpp test_utils.cpp)
+common_target_properties(test_utils)
+target_link_libraries(test_utils PRIVATE unodb gtest_main)
 if(DO_CLANG_TIDY)
-  set_target_properties(test_art PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY_TEST}")
+  set_target_properties(test_utils PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY_TEST}")
 endif()
-add_test(NAME test_art COMMAND test_art)
-set_sanitizer_target_properties(test_art)
+
+function(ADD_TEST_TARGET TARGET)
+  add_executable("${TARGET}" "${TARGET}.cpp")
+  common_target_properties("${TARGET}")
+  target_link_libraries("${TARGET}" PRIVATE unodb gtest_main test_utils)
+  if(DO_CLANG_TIDY)
+    set_target_properties("${TARGET}" PROPERTIES CXX_LANG_TIDY
+      "${DO_CLANG_TIDY_TEST}")
+  endif()
+  add_test(NAME "${TARGET}" COMMAND "${TARGET}")
+  set_sanitizer_target_properties("${TARGET}")
+endfunction()
+
+add_test_target(test_art)
+add_test_target(test_art_mutex_concurrency)
 
 if(COVERAGE)
-  add_custom_target(test_art_for_coverage ctest -R test_art$$
-    DEPENDS test_art)
-  add_dependencies(test_art_for_coverage test_art)
-  add_coverage_target(TARGET coverage DEPENDENCY test_art_for_coverage)
+  add_custom_target(tests_for_coverage ctest -E test_art_fuzz_deepstate
+    DEPENDS test_art test_art_mutex_concurrency)
+  add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)
 endif()
 
 function(COMMON_DEEPSTATE_TARGET_PROPERTIES TARGET)
@@ -492,10 +532,16 @@ if(DEEPSTATE_LF_OK)
   endif()
 endif()
 
+function(ADD_BENCHMARK_TARGET TARGET)
+  add_executable("${TARGET}" "${TARGET}.cpp")
+  common_target_properties("${TARGET}")
+  target_include_directories("${TARGET}" SYSTEM PRIVATE
+    "${benchmark_INCLUDE_DIRS}")
+  target_link_libraries("${TARGET}" PRIVATE benchmark::benchmark_main)
+  target_link_libraries("${TARGET}" PRIVATE unodb)
+endfunction()
+
 if(benchmark_FOUND)
-  add_executable(micro_benchmark micro_benchmark.cpp)
-  common_target_properties(micro_benchmark)
-  target_include_directories(micro_benchmark SYSTEM PRIVATE "${benchmark_INCLUDE_DIRS}")
-  target_link_libraries(micro_benchmark PRIVATE benchmark::benchmark_main)
-  target_link_libraries(micro_benchmark PRIVATE unodb)
+  add_benchmark_target(micro_benchmark)
+  add_benchmark_target(micro_benchmark_mutex)
 endif()

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ the ART paper.
 Values are treated opaquely. They are passed as non-owning objects of
 `value_view` type, which is `gsl::span<std::byte>`, and insertion copies them
 internally. The same applies for `get`: a non-owning `value_view` is returned.
+How long would it remain valid depends on the ART concurrency flavor.
 
-The API implemented by `db` class:
+All ART classes implement the same API:
 
 * constructor, with optional memory limit parameter, exceeding which will throw
   `std::bad_alloc`.
@@ -41,8 +42,11 @@ The API implemented by `db` class:
 * `void dump(std::ostream &)`, only available if `NDEBUG` is not defined,
   dumping the tree representation into output stream.
 
-The class is unsychronized, to be using in single-thread context or with
-external synchronization.
+The are two ART classes available:
+
+* `db`: unsychronized ART tree, to be used in single-thread context or with
+  external synchronization.
+* `mutex_db`: single global mutex-synchronized ART tree.
 
 ## Dependencies
 
@@ -79,7 +83,10 @@ is set very high, and can be relaxed, especially for clang-tidy, as need arises.
 To enable Address, Leak, and Undefined Behavior sanitizers, add `-DSANITIZE=ON`
 CMake option. Using this with GCC 9, where std::pmr from libstdc++ is used
 instead of boost::pmr, will result in UBSan false positives due to
-[this][libstdc++ub].
+[this][libstdc++ub]. This option is incompatible with `-DSANITIZE_THREAD=ON`.
+
+To enable Thread and Undefined Behavior sanitizers, add `-DSANITIZE_THREAD=ON`
+CMake option. It is incompatible with `-DSANITIZE=ON` option.
 
 To invoke include-what-you-use, add `-DIWYU=ON` CMake option. It will take
 effect if CMake configures to build project with clang.

--- a/art.hpp
+++ b/art.hpp
@@ -12,8 +12,6 @@
 #include <optional>
 #include <vector>
 
-#include <gsl/span>
-
 #include "art_key_value.hpp"
 
 namespace unodb {

--- a/micro_benchmark.cpp
+++ b/micro_benchmark.cpp
@@ -2,23 +2,16 @@
 
 #include "global.hpp"
 
-#include "art.hpp"
+#include <limits>
+#include <random>
+#include <vector>
 
 #include <benchmark/benchmark.h>
-#include <random>
+
+#include "art.hpp"
+#include "micro_benchmark.hpp"
 
 namespace {
-
-constexpr auto value1 = std::array<std::byte, 1>{};
-constexpr auto value10 = std::array<std::byte, 10>{};
-constexpr auto value100 = std::array<std::byte, 100>{};
-constexpr auto value1000 = std::array<std::byte, 1000>{};
-constexpr auto value10000 = std::array<std::byte, 10000>{};
-
-constexpr std::array<unodb::value_view, 5> values = {
-    unodb::value_view{value1}, unodb::value_view{value10},
-    unodb::value_view{value100}, unodb::value_view{value1000},
-    unodb::value_view{value10000}};
 
 class batched_random_key_source {
  public:

--- a/micro_benchmark.hpp
+++ b/micro_benchmark.hpp
@@ -1,0 +1,21 @@
+// Copyright 2019 Laurynas Biveinis
+#ifndef MICRO_BENCHMARK_HPP_
+#define MICRO_BENCHMARK_HPP_
+
+#include <array>
+#include <cstddef>
+
+#include "art_key_value.hpp"
+
+constexpr auto value1 = std::array<std::byte, 1>{};
+constexpr auto value10 = std::array<std::byte, 10>{};
+constexpr auto value100 = std::array<std::byte, 100>{};
+constexpr auto value1000 = std::array<std::byte, 1000>{};
+constexpr auto value10000 = std::array<std::byte, 10000>{};
+
+constexpr std::array<unodb::value_view, 5> values = {
+    unodb::value_view{value1}, unodb::value_view{value10},
+    unodb::value_view{value100}, unodb::value_view{value1000},
+    unodb::value_view{value10000}};
+
+#endif  // MICRO_BENCHMARK_HPP_

--- a/micro_benchmark_mutex.cpp
+++ b/micro_benchmark_mutex.cpp
@@ -1,0 +1,101 @@
+// Copyright 2019 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "art.hpp"
+#include "micro_benchmark.hpp"
+#include "mutex_art.hpp"
+
+#include <benchmark/benchmark.h>
+
+namespace {
+
+std::unique_ptr<unodb::mutex_db> test_db;
+
+constexpr auto parallel_get_tree_size = 10000000;
+
+void parallel_get(benchmark::State &state) {
+  if (state.thread_index == 0) {
+    test_db = std::make_unique<unodb::mutex_db>();
+    for (unodb::key_type i = 0;
+         i < static_cast<unodb::key_type>(parallel_get_tree_size); ++i) {
+      (void)test_db->insert(i, values[i % values.size()]);
+    }
+  }
+
+  const auto length = parallel_get_tree_size / state.threads;
+  const auto start = state.thread_index * length;
+  for (auto _ : state) {
+    for (unodb::key_type i = static_cast<unodb::key_type>(start);
+         i < static_cast<unodb::key_type>(start + length); ++i) {
+      benchmark::DoNotOptimize(test_db->get(i));
+    }
+  }
+
+  if (state.thread_index == 0) {
+    test_db.reset(nullptr);
+  }
+}
+
+constexpr auto parallel_insert_tree_size = 10000000;
+
+void parallel_insert_disjoint_ranges(benchmark::State &state) {
+  if (state.thread_index == 0) {
+    test_db = std::make_unique<unodb::mutex_db>();
+  }
+
+  const auto length = parallel_insert_tree_size / state.threads;
+  const auto start = state.thread_index * length;
+  for (auto _ : state) {
+    for (unodb::key_type i = static_cast<unodb::key_type>(start);
+         i < static_cast<unodb::key_type>(start + length); ++i) {
+      benchmark::DoNotOptimize(test_db->insert(i, values[i % values.size()]));
+    }
+  }
+
+  if (state.thread_index == 0) {
+    test_db.reset(nullptr);
+  }
+}
+
+constexpr auto parallel_delete_tree_size = 10000000;
+
+void parallel_delete_disjoint_ranges(benchmark::State &state) {
+  if (state.thread_index == 0) {
+    test_db = std::make_unique<unodb::mutex_db>();
+    for (unodb::key_type i = 0;
+         i < static_cast<unodb::key_type>(parallel_get_tree_size); ++i) {
+      (void)test_db->insert(i, values[i % values.size()]);
+    }
+  }
+
+  const auto length = parallel_delete_tree_size / state.threads;
+  const auto start = state.thread_index * length;
+  for (auto _ : state) {
+    for (unodb::key_type i = static_cast<unodb::key_type>(start);
+         i < static_cast<unodb::key_type>(start + length); ++i) {
+      benchmark::DoNotOptimize(test_db->remove(i));
+    }
+  }
+
+  if (state.thread_index == 0) {
+    test_db.reset(nullptr);
+  }
+}
+
+}  // namespace
+
+BENCHMARK(parallel_get)
+    ->ThreadRange(1, 4096)
+    ->Unit(benchmark::kMillisecond)
+    ->UseRealTime();
+BENCHMARK(parallel_insert_disjoint_ranges)
+    ->ThreadRange(1, 512)
+    ->Unit(benchmark::kMillisecond)
+    ->UseRealTime();
+BENCHMARK(parallel_delete_disjoint_ranges)
+    ->ThreadRange(1, 1024)
+    ->Unit(benchmark::kMillisecond)
+    ->UseRealTime();
+
+BENCHMARK_MAIN();

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -1,0 +1,60 @@
+// Copyright 2019 Laurynas Biveinis
+#ifndef UNODB_MUTEX_ART_HPP_
+#define UNODB_MUTEX_ART_HPP_
+
+#include "global.hpp"
+
+#include <mutex>
+
+#include "art.hpp"
+
+namespace unodb {
+
+class mutex_db final {
+ public:
+  using get_result = db::get_result;
+  using tree_depth_type = db::tree_depth_type;
+
+  explicit mutex_db(std::size_t memory_limit = 0) noexcept
+      : db_{memory_limit} {}
+
+  [[nodiscard]] auto get(key_type k) const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get(k);
+  }
+
+  [[nodiscard]] auto insert(key_type k, value_view v) {
+    const std::lock_guard guard{mutex};
+    return db_.insert(k, v);
+  }
+
+  [[nodiscard]] auto remove(key_type k) {
+    const std::lock_guard guard{mutex};
+    return db_.remove(k);
+  }
+
+#ifndef NDEBUG
+  void dump(std::ostream &os) const {
+    const std::lock_guard guard{mutex};
+    db_.dump(os);
+  }
+#endif
+
+  [[nodiscard]] auto empty() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.empty();
+  }
+
+  [[nodiscard]] auto get_current_memory_use() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_current_memory_use();
+  }
+
+ private:
+  db db_;
+  mutable std::mutex mutex;
+};
+
+}  // namespace unodb
+
+#endif  // UNODB_MUTEX_ART_HPP_

--- a/test_art_mutex_concurrency.cpp
+++ b/test_art_mutex_concurrency.cpp
@@ -1,0 +1,181 @@
+// Copyright 2019 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <random>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+#include "mutex_art.hpp"
+#include "test_utils.hpp"
+
+namespace {
+
+void parallel_insert_thread(tree_verifier<unodb::mutex_db> *verifier,
+                            unodb::key_type start_key, std::size_t count) {
+  verifier->insert_preinserted_key_range(start_key, count);
+}
+
+TEST(ART_mutex_concurrency, parallel_insert_one_tree) {
+  constexpr auto num_of_threads = 4;
+  constexpr auto total_keys = 1024;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.preinsert_key_range_to_verifier_only(0, total_keys);
+  std::array<std::thread, num_of_threads> threads;
+  unodb::key_type i = 0;
+  for (std::size_t j = 0; j < num_of_threads; ++j) {
+    threads[j] = std::thread{parallel_insert_thread, &verifier, i,
+                             total_keys / num_of_threads /*, (j == 0)*/};
+    i += total_keys / num_of_threads;
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+  verifier.check_present_values();
+}
+
+void parallel_remove_thread(tree_verifier<unodb::mutex_db> *verifier,
+                            unodb::key_type start_key, std::size_t count) {
+  for (std::size_t i = 0; i < count; ++i) {
+    verifier->remove(start_key + i, true);
+  }
+}
+
+TEST(ART_mutex_concurrency, parallel_tear_down_one_tree) {
+  constexpr auto num_of_threads = 8;
+  constexpr auto total_keys = 2048;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.insert_key_range(0, total_keys);
+  unodb::key_type i = 0;
+  std::array<std::thread, num_of_threads> threads;
+  for (std::size_t j = 0; j < num_of_threads; ++j) {
+    threads[j] = std::thread{parallel_remove_thread, &verifier, i,
+                             total_keys / num_of_threads};
+    i += total_keys / num_of_threads;
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+  verifier.assert_empty();
+}
+
+void key_range_op_thread(tree_verifier<unodb::mutex_db> *verifier,
+                         std::size_t thread_i, unsigned op_count) {
+  unodb::key_type key = thread_i / 3 * 3;
+  for (unsigned i = 0; i < op_count; ++i) {
+    switch (thread_i % 3) {
+      case 0: /* insert */
+        verifier->try_insert(key, test_value_1);
+        break;
+      case 1: /* remove */
+        verifier->try_remove(key);
+        break;
+      case 2: /* get */
+        verifier->try_get(key);
+        break;
+    }
+    key++;
+  }
+}
+
+TEST(ART_mutex_concurrency, node4_parallel_ops) {
+  constexpr auto num_of_threads = 9;
+  constexpr auto op_count = 6;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.insert_key_range(0, 3, true);
+  std::array<std::thread, num_of_threads> threads;
+  for (std::size_t i = 0; i < num_of_threads; ++i) {
+    threads[i] = std::thread{key_range_op_thread, &verifier, i, op_count};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+}
+
+TEST(ART_mutex_concurrency, node16_parallel_ops) {
+  constexpr auto num_of_threads = 9;
+  constexpr auto op_count = 12;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.insert_key_range(0, 10, true);
+  std::array<std::thread, num_of_threads> threads;
+  for (std::size_t i = 0; i < num_of_threads; ++i) {
+    threads[i] = std::thread{key_range_op_thread, &verifier, i, op_count};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+}
+
+TEST(ART_mutex_concurrency, node48_parallel_ops) {
+  constexpr auto num_of_threads = 9;
+  constexpr auto op_count = 32;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.insert_key_range(0, 32, true);
+  std::array<std::thread, num_of_threads> threads;
+  for (std::size_t i = 0; i < num_of_threads; ++i) {
+    threads[i] = std::thread{key_range_op_thread, &verifier, i, op_count};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+}
+
+TEST(ART_mutex_concurrency, node256_parallel_ops) {
+  constexpr auto num_of_threads = 9;
+  constexpr auto op_count = 208;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.insert_key_range(0, 152, true);
+  std::array<std::thread, num_of_threads> threads;
+  for (std::size_t i = 0; i < num_of_threads; ++i) {
+    threads[i] = std::thread{key_range_op_thread, &verifier, i, op_count};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+}
+
+void random_op_thread(tree_verifier<unodb::mutex_db> *verifier,
+                      std::size_t thread_i, unsigned op_count) {
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+  std::geometric_distribution<unodb::key_type> key_generator{0.5};
+  for (unsigned i = 0; i < op_count; ++i) {
+    const auto key{key_generator(gen)};
+    switch (thread_i % 3) {
+      case 0: /* insert */
+        verifier->try_insert(key, test_value_2);
+        break;
+      case 1: /* remove */
+        verifier->try_remove(key);
+        break;
+      case 2: /* get */
+        verifier->try_get(key);
+        break;
+    }
+  }
+}
+
+TEST(ART_mutex_concurrency, parallel_random_insert_delete_get) {
+  constexpr auto num_of_threads = 4 * 3;
+  constexpr auto initial_keys = 2048;
+  constexpr auto ops_per_thread = 10000;
+
+  tree_verifier<unodb::mutex_db> verifier;
+  verifier.insert_key_range(0, initial_keys, true);
+  std::array<std::thread, num_of_threads> threads;
+  for (std::size_t i = 0; i < num_of_threads; ++i) {
+    threads[i] = std::thread{random_op_thread, &verifier, i, ops_per_thread};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+}
+
+}  // namespace

--- a/test_utils.cpp
+++ b/test_utils.cpp
@@ -1,0 +1,30 @@
+// Copyright 2019 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "test_utils.hpp"
+
+#include <sstream>
+
+#include "gtest/gtest.h"
+
+#include "art.hpp"
+
+// warning: 'ScopedTrace' was marked unused but was used
+// [-Wused-but-marked-unused]
+DISABLE_CLANG_WARNING("-Wused-but-marked-unused")
+
+void assert_result_eq(unodb::key_type key, unodb::db::get_result result,
+                      unodb::value_view expected, int caller_line) noexcept {
+  std::ostringstream msg;
+  msg << "key = " << static_cast<unsigned>(key);
+  testing::ScopedTrace trace(__FILE__, caller_line, msg.str());
+  ASSERT_TRUE(result);
+  ASSERT_TRUE(std::equal(result->cbegin(), result->cend(), expected.cbegin(),
+                         expected.cend()));
+}
+
+RESTORE_CLANG_WARNINGS()
+
+template class tree_verifier<unodb::db>;
+template class tree_verifier<unodb::mutex_db>;

--- a/test_utils.hpp
+++ b/test_utils.hpp
@@ -1,0 +1,173 @@
+// Copyright 2019 Laurynas Biveinis
+#ifndef UNODB_TEST_UTILS_HPP_
+#define UNODB_TEST_UTILS_HPP_
+
+#include "global.hpp"
+
+#include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <new>
+#include <unordered_map>
+
+#include "gtest/gtest.h"
+
+#include "art.hpp"
+#include "mutex_art.hpp"
+
+constexpr auto test_value_1 = std::array<std::byte, 1>{std::byte{0x00}};
+constexpr auto test_value_2 =
+    std::array<std::byte, 2>{std::byte{0x00}, std::byte{0x02}};
+constexpr auto test_value_3 =
+    std::array<std::byte, 3>{std::byte{0x03}, std::byte{0x00}, std::byte{0x01}};
+constexpr auto test_value_4 = std::array<std::byte, 4>{
+    std::byte{0x04}, std::byte{0x01}, std::byte{0x00}, std::byte{0x02}};
+constexpr auto test_value_5 =
+    std::array<std::byte, 5>{std::byte{0x05}, std::byte{0xF4}, std::byte{0xFF},
+                             std::byte{0x00}, std::byte{0x01}};
+
+constexpr std::array<unodb::value_view, 5> test_values = {
+    unodb::value_view{test_value_1}, unodb::value_view{test_value_2},
+    unodb::value_view{test_value_3}, unodb::value_view{test_value_4},
+    unodb::value_view{test_value_5}};
+
+void assert_result_eq(unodb::key_type key, unodb::db::get_result result,
+                      unodb::value_view expected, int caller_line) noexcept;
+
+#define ASSERT_VALUE_FOR_KEY(key, expected) \
+  assert_result_eq(key, test_db.get(key), expected, __LINE__)
+
+template <class Db>
+class tree_verifier final {
+ public:
+  explicit tree_verifier(std::size_t memory_limit = 0) noexcept
+      : test_db{memory_limit}, memory_size_tracked(memory_limit != 0) {
+    assert_empty();
+  }
+
+  void insert(unodb::key_type k, unodb::value_view v,
+              bool bypass_verifier = false) {
+    const auto mem_use_before = test_db.get_current_memory_use();
+    try {
+      ASSERT_TRUE(test_db.insert(k, v));
+    } catch (const std::bad_alloc &) {
+      const auto mem_use_after = test_db.get_current_memory_use();
+      ASSERT_EQ(mem_use_before, mem_use_after);
+      throw;
+    }
+    ASSERT_FALSE(test_db.empty());
+    const auto mem_use_after =
+        memory_size_tracked ? test_db.get_current_memory_use() : 1;
+    ASSERT_TRUE(mem_use_before < mem_use_after);
+    if (!bypass_verifier) {
+      const auto insert_result = values.emplace(k, v);
+      ASSERT_TRUE(insert_result.second);
+    }
+  }
+
+  void insert_key_range(unodb::key_type start_key, size_t count,
+                        bool bypass_verifier = false) {
+    for (unodb::key_type key = start_key; key < start_key + count; ++key) {
+      insert(key, test_values[key % test_values.size()], bypass_verifier);
+    }
+  }
+
+  void try_insert(unodb::key_type k, unodb::value_view v) {
+    (void)test_db.insert(k, v);
+  }
+
+  void preinsert_key_range_to_verifier_only(unodb::key_type start_key,
+                                            std::size_t count) {
+    for (unodb::key_type key = start_key; key < start_key + count; ++key) {
+      const auto insert_result =
+          values.emplace(key, test_values[key % test_values.size()]);
+      ASSERT_TRUE(insert_result.second);
+    }
+  }
+
+  void insert_preinserted_key_range(unodb::key_type start_key,
+                                    std::size_t count) {
+    for (unodb::key_type key = start_key; key < start_key + count; ++key) {
+      ASSERT_TRUE(test_db.insert(key, test_values[key % test_values.size()]));
+    }
+  }
+
+  void remove(unodb::key_type k, bool bypass_verifier = false) {
+    if (!bypass_verifier) {
+      const auto remove_result = values.erase(k);
+      ASSERT_EQ(remove_result, 1);
+    }
+    const auto mem_use_before =
+        memory_size_tracked ? test_db.get_current_memory_use() : 1;
+    ASSERT_TRUE(test_db.remove(k));
+    const auto mem_use_after = test_db.get_current_memory_use();
+    ASSERT_TRUE(mem_use_after < mem_use_before);
+  }
+
+  void try_remove(unodb::key_type k) { (void)test_db.remove(k); }
+
+  void test_insert_until_memory_limit() {
+    ASSERT_THROW(insert_key_range(1, 100000), std::bad_alloc);
+    check_present_values();
+    check_absent_keys({0, values.size() + 1});
+    while (!values.empty()) {
+      const auto [key, value] = *values.cbegin();
+      remove(key);
+      check_absent_keys({key});
+      check_present_values();
+    }
+    ASSERT_EQ(test_db.get_current_memory_use(), 0);
+  }
+
+  void attempt_remove_missing_keys(
+      std::initializer_list<unodb::key_type> absent_keys) noexcept {
+    const auto mem_use_before = test_db.get_current_memory_use();
+    for (const auto &absent_key : absent_keys) {
+      const auto remove_result = values.erase(absent_key);
+      ASSERT_EQ(remove_result, 0);
+      ASSERT_FALSE(test_db.remove(absent_key));
+      ASSERT_EQ(mem_use_before, test_db.get_current_memory_use());
+    }
+  }
+
+  void try_get(unodb::key_type k) noexcept { (void)test_db.get(k); }
+
+  void check_present_values() const noexcept {
+    for (const auto &[key, value] : values) {
+      ASSERT_VALUE_FOR_KEY(key, value);
+    }
+#ifndef NDEBUG
+    // Dump the tree to a string. Do not attempt to check the dump format, only
+    // that dumping does not crash
+    std::stringstream dump_sink;
+    test_db.dump(dump_sink);
+#endif
+  }
+
+  void check_absent_keys(
+      std::initializer_list<unodb::key_type> absent_keys) const noexcept {
+    for (const auto &absent_key : absent_keys) {
+      ASSERT_TRUE(values.find(absent_key) == values.cend());
+      ASSERT_FALSE(test_db.get(absent_key));
+    }
+  }
+
+  void assert_empty() const noexcept {
+    ASSERT_TRUE(test_db.empty());
+    ASSERT_EQ(test_db.get_current_memory_use(), 0);
+  }
+
+  Db &get_db() noexcept { return test_db; }
+
+ private:
+  Db test_db;
+
+  std::unordered_map<unodb::key_type, unodb::value_view> values;
+
+  const bool memory_size_tracked;
+};
+
+extern template class tree_verifier<unodb::db>;
+extern template class tree_verifier<unodb::mutex_db>;
+
+#endif  // UNODB_TEST_UTILS_HPP_


### PR DESCRIPTION
- Add a scalability Google Benchmark test micro_benchmark_mutex

CMake:
- Introduce new option -DSANITIZE_THREAD=ON, factor out common code with
  -DSANITIZE=ON.
- Factor out Google Test-dependent code, use it for test_art and
  test_art_mutex_concurrency.
- Factor out Google Benchmark-dependent code, use it for micro_benchmark and
  micro_benchmark_mutex.
- Set up CMake thread support.

- Factor out common test framework out of test_art.cpp, use it for
  test_art_mutex_concurrency, which is a correctness-oriented test suite.

- New micro_benchmark.hpp header, for common utilities between
  micro_benchmark.cpp and micro_benchmark_mutex.cpp.

- Add ThreadSanitizer tests to Travis CI.