### PR TITLE
Travis-CI: move cppcheck testing from Bionic to macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ os_setups:
           sourceline: 'ppa:mhier/libboost-latest'
         packages: &bionic_compilation_packages
           - boost1.70
-          - cppcheck
   gcc7_setup: &gcc7
     os: linux
     compiler: gcc
@@ -70,6 +69,8 @@ os_setups:
       homebrew:
         packages:
           - cmake
+          - cppcheck
+        update: true
 
 env:
   global:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,20 +339,21 @@ if(CPPCHECK_AGGRESSIVE)
   set(CPPCHECK_CHECKS "--inconclusive")
 else()
   set(CPPCHECK_CHECKS
-    "--suppress=unreadVariable" # False positive: on key2_i
-    "--suppress=syntaxError" # False positive on test_art.cpp:148
-    "--suppress=ignoredReturnValue" # False positive on ctors with std::move arg
+    # False positive on Google Test TEST macro and compilers are much better
+    # for syntax checking anyway
+    "--suppress=syntaxError"
     # False positive on pointer unions being passed by value
-    "--suppress=passedByValue"
-    # False positive on benchmark::State arg
-    "--suppress=constParameter")
+    "--suppress=passedByValue")
 endif()
 
 find_program(CPPCHECK_EXE NAMES "cppcheck" DOC "Path to cppcheck executable")
 if(NOT CPPCHECK_EXE)
   message(STATUS "cppcheck not found")
 else()
-  message(STATUS "cppcheck found: ${CPPCHECK_EXE}")
+  execute_process(COMMAND "${CPPCHECK_EXE}" "--version" OUTPUT_VARIABLE
+    CPPCHECK_VERSION_OUTPUT)
+  message(STATUS
+    "cppcheck found: ${CPPCHECK_EXE}, --version: ${CPPCHECK_VERSION_OUTPUT}")
   set(DO_CPPCHECK "${CPPCHECK_EXE}" "--enable=warning,style,performance,portability"
     "--error-exitcode=2" "-D__x86_64")
   list(APPEND DO_CPPCHECK "${CPPCHECK_CHECKS}")


### PR DESCRIPTION
Travis-CI Bionic carries cppcheck version 1.82, which is too old for this
codebase. There does not seem to be any (safelisted) PPAs to get it from, thus
move cppcheck testing over to macOS, where its latest version is packaged in
Homebrew. For this to work completely, run brew update too - otherwise 1.89 gets
used.

At the same time cleanup cppcheck suppression list for 1.90 and make CMake print
cppcheck version it found.