### PR TITLE
Add support for LLVM 9

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,11 +8,14 @@ AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -21,6 +24,7 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:   
+  AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -127,6 +131,7 @@ ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false

--- a/.cmake-build.el
+++ b/.cmake-build.el
@@ -8,7 +8,10 @@
   (gcc7-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7")
 
   (gcc8-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8")
-  (gcc8-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8"))
+  (gcc8-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8")
+
+  (llvm-release "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++")
+  (llvm-debug "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++"))
 
  (cmake-build-run-configs
   (test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,19 +36,19 @@ os_setups:
         packages:
           - *bionic_base_packages
           - g++-8
-  clang8_setup: &clang8
+  clang9_setup: &clang9
     os: linux
     compiler: clang
     addons:
       apt:
         sources:
           - *bionic_base_sources
-          - llvm-toolchain-bionic-8
+          - llvm-toolchain-bionic-9
         packages:
           - *bionic_base_packages
-          - clang-8
-          - clang-tidy-8
-          - clang-tools-8
+          - clang-9
+          - clang-tidy-9
+          - clang-tools-9
   coverage_setup: &coverage
     # Current lcov version does not understand coverage data produced by GCC 8
     # nor by clang 8, hence GCC 7
@@ -101,38 +101,38 @@ matrix:
       <<: *gcc8
       env:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8" BUILD_TYPE=Debug SANITIZE=ON
-    - name: "Bionic clang 8 Release"
-      <<: *clang8
+    - name: "Bionic clang 9 Release"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release
-    - name: "Bionic clang 8 Release with ASan/UBSan"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release
+    - name: "Bionic clang 9 Release with ASan/UBSan"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release SANITIZE=ON
-    - name: "Bionic clang 8 Release with TSan/UBSan"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release SANITIZE=ON
+    - name: "Bionic clang 9 Release with TSan/UBSan"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release SANITIZE_THREAD=ON
-    - name: "Bionic clang 8 Debug"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "Bionic clang 9 Debug"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug
-    - name: "Bionic clang 8 Debug with ASan/UBSan"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug
+    - name: "Bionic clang 9 Debug with ASan/UBSan"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug SANITIZE=ON
-    - name: "Bionic clang 8 Debug with TSan/UBSan"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug SANITIZE=ON
+    - name: "Bionic clang 9 Debug with TSan/UBSan"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug SANITIZE_THREAD=ON
-    - name: "Bionic clang 8 static analysis Release"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "Bionic clang 9 static analysis Release"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Release SCAN_BUILD=scan-build-8
-    - name: "Bionic clang 8 static analysis Debug"
-      <<: *clang8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release SCAN_BUILD=scan-build-9
+    - name: "Bionic clang 9 static analysis Debug"
+      <<: *clang9
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8" BUILD_TYPE=Debug SCAN_BUILD=scan-build-8
+        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug SCAN_BUILD=scan-build-9
     - name: "macOS XCode 11.3 Release"
       <<: *macos
       env:
@@ -185,8 +185,8 @@ script:
   - cd build
   - EXTRA_CMAKE_OPTIONS=""
   - sudo rm -rf /usr/local/clang-7.0.0
-  - if [[ "$CC" == "clang-8" ]]; then
-      sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8 50;
+  - if [[ "$CC" == "clang-9" ]]; then
+      sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 50;
     fi
   - if [[ "$CC" == "gcc-7" && "$COVERAGE" == "ON" ]]; then
       EXTRA_CMAKE_OPTIONS+="-DGCOV_PATH=/usr/bin/gcov-7 ";

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ else()
       "-cppcoreguidelines-pro-type-reinterpret-cast,"
       "-cppcoreguidelines-pro-type-static-cast-downcast,"
       "-cppcoreguidelines-pro-type-union-access,"
+      "-fuchsia-default-arguments-calls,"
       "-fuchsia-overloaded-operator,"
       "-google-readability-braces-around-statements,"
       "-google-runtime-references,"
@@ -303,6 +304,7 @@ else()
       "-llvm-include-order,"
       "-misc-non-private-member-variables-in-classes,"
       "-modernize-use-equals-default," # Until foo() noexcept = default is accepted by clang
+      "-modernize-use-trailing-return-type,"
       "-readability-braces-around-statements,"
       "-readability-named-parameter,"
       "-readability-magic-numbers")
@@ -367,6 +369,7 @@ else()
   string(CONCAT CPPLINT_DISABLED_TESTS "--filter="
     "-build/c++11," # <thread> is an unapproved C++11 header
     "-build/include_order,"
+    "-readability/nolint," # clang-tidy owns NOLINT
     "-runtime/references,"
     "-whitespace/braces") # Does not understand C++17 structured bindings and we use
                           # clang-format anyway

--- a/art.cpp
+++ b/art.cpp
@@ -25,6 +25,7 @@ static_assert(std::is_trivially_copyable_v<unodb::detail::art_key>);
 static_assert(sizeof(unodb::detail::art_key) == sizeof(unodb::key));
 
 static_assert(sizeof(unodb::detail::raw_leaf_ptr) ==
+              // NOLINTNEXTLINE(bugprone-sizeof-expression)
               sizeof(unodb::detail::node_ptr::header));
 static_assert(sizeof(unodb::detail::node_ptr) == sizeof(void *));
 

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-TEST(ART, single_node_tree_empty_value) {
+TEST(ART, SingleNodeTreeEmptyValue) {
   tree_verifier<unodb::db> verifier{1024};
   verifier.check_absent_keys({1});
   verifier.insert(1, {});
@@ -21,7 +21,7 @@ TEST(ART, single_node_tree_empty_value) {
   verifier.check_absent_keys({0});
 }
 
-TEST(ART, single_node_tree_nonempty_value) {
+TEST(ART, SingleNodeTreeNonemptyValue) {
   tree_verifier<unodb::db> verifier{1024};
   verifier.insert(1, test_values[2]);
 
@@ -29,7 +29,7 @@ TEST(ART, single_node_tree_nonempty_value) {
   verifier.check_absent_keys({0, 2});
 }
 
-TEST(ART, too_long_value) {
+TEST(ART, TooLongValue) {
   std::byte fake_val{0x00};
   unodb::value_view too_long{
       &fake_val,
@@ -43,7 +43,7 @@ TEST(ART, too_long_value) {
   verifier.check_absent_keys({1});
 }
 
-TEST(ART, expand_leaf_to_node4) {
+TEST(ART, ExpandLeafToNode4) {
   tree_verifier<unodb::db> verifier{1024};
 
   verifier.insert(0, test_values[1]);
@@ -53,7 +53,7 @@ TEST(ART, expand_leaf_to_node4) {
   verifier.check_absent_keys({2});
 }
 
-TEST(ART, duplicate_key) {
+TEST(ART, DuplicateKey) {
   tree_verifier<unodb::db> verifier{1024};
 
   verifier.insert(0, test_values[0]);
@@ -63,7 +63,7 @@ TEST(ART, duplicate_key) {
   verifier.check_present_values();
 }
 
-TEST(ART, insert_to_full_node4) {
+TEST(ART, InsertToFullNode4) {
   tree_verifier<unodb::db> verifier{1024};
 
   verifier.insert_key_range(0, 4);
@@ -72,7 +72,7 @@ TEST(ART, insert_to_full_node4) {
   verifier.check_absent_keys({5, 4});
 }
 
-TEST(ART, two_node4) {
+TEST(ART, TwoNode4) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert(1, test_values[0]);
@@ -84,7 +84,7 @@ TEST(ART, two_node4) {
   verifier.check_absent_keys({0xFF00, 2});
 }
 
-TEST(ART, db_insert_node_recursion) {
+TEST(ART, DbInsertNodeRecursion) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert(1, test_values[0]);
@@ -99,7 +99,7 @@ TEST(ART, db_insert_node_recursion) {
   verifier.check_absent_keys({0xFF0100, 0xFF0000, 2});
 }
 
-TEST(ART, node16) {
+TEST(ART, Node16) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert_key_range(0, 5);
@@ -108,7 +108,7 @@ TEST(ART, node16) {
   verifier.check_absent_keys({6, 0x0100, 0xFFFFFFFFFFFFFFFFULL});
 }
 
-TEST(ART, full_node16) {
+TEST(ART, FullNode16) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(0, 16);
@@ -117,7 +117,7 @@ TEST(ART, full_node16) {
   verifier.check_present_values();
 }
 
-TEST(ART, node16_key_prefix_split) {
+TEST(ART, Node16KeyPrefixSplit) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(10, 5);
@@ -129,7 +129,7 @@ TEST(ART, node16_key_prefix_split) {
   verifier.check_absent_keys({9, 0x10FF});
 }
 
-TEST(ART, node16_key_insert_order_descending) {
+TEST(ART, Node16KeyInsertOrderDescending) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert(5, test_values[0]);
@@ -143,7 +143,7 @@ TEST(ART, node16_key_insert_order_descending) {
   verifier.check_absent_keys({6});
 }
 
-TEST(ART, node48) {
+TEST(ART, Node48) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(0, 17);
@@ -152,7 +152,7 @@ TEST(ART, node48) {
   verifier.check_absent_keys({17});
 }
 
-TEST(ART, full_node48) {
+TEST(ART, FullNode48) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(0, 48);
@@ -161,7 +161,7 @@ TEST(ART, full_node48) {
   verifier.check_absent_keys({49});
 }
 
-TEST(ART, node48_key_prefix_split) {
+TEST(ART, Node48KeyPrefixSplit) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(10, 17);
@@ -173,7 +173,7 @@ TEST(ART, node48_key_prefix_split) {
   verifier.check_absent_keys({9, 27, 0x100019, 0x100100, 0x110000});
 }
 
-TEST(ART, node256) {
+TEST(ART, Node256) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(1, 49);
@@ -182,7 +182,7 @@ TEST(ART, node256) {
   verifier.check_absent_keys({50});
 }
 
-TEST(ART, full_node256) {
+TEST(ART, FullNode256) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(0, 256);
@@ -191,7 +191,7 @@ TEST(ART, full_node256) {
   verifier.check_absent_keys({256});
 }
 
-TEST(ART, node256_key_prefix_split) {
+TEST(ART, Node256KeyPrefixSplit) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(20, 49);
@@ -203,7 +203,7 @@ TEST(ART, node256_key_prefix_split) {
   verifier.check_absent_keys({19, 69, 0x100019, 0x100100, 0x110000});
 }
 
-TEST(ART, try_delete_from_empty) {
+TEST(ART, TryDeleteFromEmpty) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.attempt_remove_missing_keys({1});
@@ -211,7 +211,7 @@ TEST(ART, try_delete_from_empty) {
   verifier.check_absent_keys({1});
 }
 
-TEST(ART, single_node_tree_delete) {
+TEST(ART, SingleNodeTreeDelete) {
   tree_verifier<unodb::db> verifier{1024};
 
   verifier.insert(1, test_values[0]);
@@ -222,7 +222,7 @@ TEST(ART, single_node_tree_delete) {
   verifier.check_absent_keys({1});
 }
 
-TEST(ART, node4_attempt_delete_absent) {
+TEST(ART, Node4AttemptDeleteAbsent) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(1, 4);
@@ -230,7 +230,7 @@ TEST(ART, node4_attempt_delete_absent) {
   verifier.check_absent_keys({0, 6, 0xFF00000});
 }
 
-TEST(ART, node4_full_delete_middle_n_beginning) {
+TEST(ART, Node4FullDeleteMiddleAndBeginning) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert_key_range(1, 4);
@@ -244,7 +244,7 @@ TEST(ART, node4_full_delete_middle_n_beginning) {
   verifier.check_absent_keys({1, 0, 2, 5});
 }
 
-TEST(ART, node4_full_delete_end_n_middle) {
+TEST(ART, Node4FullDeleteEndAndMiddle) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert_key_range(1, 4);
@@ -258,7 +258,7 @@ TEST(ART, node4_full_delete_end_n_middle) {
   verifier.check_absent_keys({2, 4, 0, 5});
 }
 
-TEST(ART, node4_shrink_to_single_leaf) {
+TEST(ART, Node4ShrinkToSingleLeaf) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert_key_range(1, 2);
@@ -267,7 +267,7 @@ TEST(ART, node4_shrink_to_single_leaf) {
   verifier.check_absent_keys({1});
 }
 
-TEST(ART, node4_delete_lower_node) {
+TEST(ART, Node4DeleteLowerNode) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert_key_range(0, 2);
@@ -279,7 +279,7 @@ TEST(ART, node4_delete_lower_node) {
   verifier.check_absent_keys({0, 2, 0xFF01});
 }
 
-TEST(ART, node4_delete_key_prefix_merge) {
+TEST(ART, Node4DeleteKeyPrefixMerge) {
   tree_verifier<unodb::db> verifier{2048};
 
   verifier.insert_key_range(0x8001, 2);
@@ -291,7 +291,7 @@ TEST(ART, node4_delete_key_prefix_merge) {
   verifier.check_absent_keys({0x90AA, 0x8003});
 }
 
-TEST(ART, node16_delete_beginning_middle_end) {
+TEST(ART, Node16DeleteBeginningMiddleEnd) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(1, 16);
@@ -303,7 +303,7 @@ TEST(ART, node16_delete_beginning_middle_end) {
   verifier.check_absent_keys({0, 1, 5, 16, 17});
 }
 
-TEST(ART, node16_shrink_to_node4_delete_middle) {
+TEST(ART, Node16ShrinkToNode4DeleteMiddle) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(1, 5);
@@ -313,7 +313,7 @@ TEST(ART, node16_shrink_to_node4_delete_middle) {
   verifier.check_absent_keys({0, 2, 6});
 }
 
-TEST(ART, node16_shrink_to_node4_delete_beginning) {
+TEST(ART, Node16ShrinkToNode4DeleteBeginning) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(1, 5);
@@ -323,7 +323,7 @@ TEST(ART, node16_shrink_to_node4_delete_beginning) {
   verifier.check_absent_keys({0, 1, 6});
 }
 
-TEST(ART, node16_shrink_to_node4_delete_end) {
+TEST(ART, Node16ShrinkToNode4DeleteEnd) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(1, 5);
@@ -333,7 +333,7 @@ TEST(ART, node16_shrink_to_node4_delete_end) {
   verifier.check_absent_keys({0, 5, 6});
 }
 
-TEST(ART, node16_key_prefix_merge) {
+TEST(ART, Node16KeyPrefixMerge) {
   tree_verifier<unodb::db> verifier{4096};
 
   verifier.insert_key_range(10, 5);
@@ -347,7 +347,7 @@ TEST(ART, node16_key_prefix_merge) {
   verifier.check_absent_keys({9, 16, 0x1020});
 }
 
-TEST(ART, node48_delete_beginning_middle_end) {
+TEST(ART, Node48DeleteBeginningMiddleEnd) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(1, 48);
@@ -359,7 +359,7 @@ TEST(ART, node48_delete_beginning_middle_end) {
   verifier.check_absent_keys({0, 1, 30, 48, 49});
 }
 
-TEST(ART, node48_shrink_to_node16_delete_middle) {
+TEST(ART, Node48ShrinkToNode16DeleteMiddle) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(0x80, 17);
@@ -369,7 +369,7 @@ TEST(ART, node48_shrink_to_node16_delete_middle) {
   verifier.check_absent_keys({0x7F, 0x85, 0x91});
 }
 
-TEST(ART, node48_shrink_to_node16_delete_beginning) {
+TEST(ART, Node48ShrinkToNode16DeleteBeginning) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(1, 17);
@@ -379,7 +379,7 @@ TEST(ART, node48_shrink_to_node16_delete_beginning) {
   verifier.check_absent_keys({0, 1, 18});
 }
 
-TEST(ART, node48_shrink_to_node16_delete_end) {
+TEST(ART, Node48ShrinkToNode16DeleteEnd) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(1, 17);
@@ -389,7 +389,7 @@ TEST(ART, node48_shrink_to_node16_delete_end) {
   verifier.check_absent_keys({0, 17, 18});
 }
 
-TEST(ART, node48_key_prefix_merge) {
+TEST(ART, Node48KeyPrefixMerge) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert_key_range(10, 17);
@@ -403,7 +403,7 @@ TEST(ART, node48_key_prefix_merge) {
   verifier.check_absent_keys({9, 0x2010, 28});
 }
 
-TEST(ART, node256_delete_beginning_middle_end) {
+TEST(ART, Node256DeleteBeginningMiddleEnd) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(1, 256);
@@ -415,7 +415,7 @@ TEST(ART, node256_delete_beginning_middle_end) {
   verifier.check_absent_keys({0, 1, 180, 256});
 }
 
-TEST(ART, node256_shrink_to_node48_delete_middle) {
+TEST(ART, Node256ShrinkToNode48DeleteMiddle) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(1, 49);
@@ -425,7 +425,7 @@ TEST(ART, node256_shrink_to_node48_delete_middle) {
   verifier.check_absent_keys({0, 25, 50});
 }
 
-TEST(ART, node256_shrink_to_node48_delete_beginning) {
+TEST(ART, Node256ShrinkToNode48DeleteBeginning) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(1, 49);
@@ -435,7 +435,7 @@ TEST(ART, node256_shrink_to_node48_delete_beginning) {
   verifier.check_absent_keys({0, 1, 50});
 }
 
-TEST(ART, node256_shrink_to_node48_delete_end) {
+TEST(ART, Node256ShrinkToNode48DeleteEnd) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(1, 49);
@@ -445,7 +445,7 @@ TEST(ART, node256_shrink_to_node48_delete_end) {
   verifier.check_absent_keys({0, 49, 50});
 }
 
-TEST(ART, node256_key_prefix_merge) {
+TEST(ART, Node256KeyPrefixMerge) {
   tree_verifier<unodb::db> verifier{20480};
 
   verifier.insert_key_range(10, 49);
@@ -459,7 +459,7 @@ TEST(ART, node256_key_prefix_merge) {
   verifier.check_absent_keys({9, 0x2010, 60});
 }
 
-TEST(ART, missing_key_with_present_prefix) {
+TEST(ART, MissingKeyWithPresentPrefix) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert(0x010000, test_values[0]);
@@ -469,7 +469,7 @@ TEST(ART, missing_key_with_present_prefix) {
   verifier.attempt_remove_missing_keys({0x000002, 0x010100, 0x010002});
 }
 
-TEST(ART, missing_key_matching_inode_path) {
+TEST(ART, MissingKeyMatchingInodePath) {
   tree_verifier<unodb::db> verifier{10240};
 
   verifier.insert(0x0100, test_values[0]);
@@ -477,39 +477,39 @@ TEST(ART, missing_key_matching_inode_path) {
   verifier.attempt_remove_missing_keys({0x0101, 0x0202});
 }
 
-TEST(ART, memory_limit_below_minimum) {
+TEST(ART, MemoryLimitBelowMinimum) {
   tree_verifier<unodb::db> verifier{1};
   verifier.test_insert_until_memory_limit();
 }
 
 // It was one leaf at the time of writing the test, this is not
 // guaranteed later
-TEST(ART, memory_limit_one_leaf) {
+TEST(ART, MemoryLimitOneLeaf) {
   tree_verifier<unodb::db> verifier{20};
   verifier.test_insert_until_memory_limit();
 }
 
-TEST(ART, memory_limit_one_node4) {
+TEST(ART, MemoryLimitOneNode4) {
   tree_verifier<unodb::db> verifier{80};
   verifier.test_insert_until_memory_limit();
 }
 
-TEST(ART, memory_limit_one_node16) {
+TEST(ART, MemoryLimitOneNode16) {
   tree_verifier<unodb::db> verifier{320};
   verifier.test_insert_until_memory_limit();
 }
 
-TEST(ART, memory_limit_one_node48) {
+TEST(ART, MemoryLimitOneNode48) {
   tree_verifier<unodb::db> verifier{1024};
   verifier.test_insert_until_memory_limit();
 }
 
-TEST(ART, memory_limit_one_node256) {
+TEST(ART, MemoryLimitOneNode256) {
   tree_verifier<unodb::db> verifier{4096};
   verifier.test_insert_until_memory_limit();
 }
 
-TEST(ART, memory_accounting_duplicate_key_insert) {
+TEST(ART, MemoryAccountingDuplicateKeyInsert) {
   tree_verifier<unodb::db> verifier{2048};
   verifier.insert(0, test_values[0]);
   ASSERT_FALSE(verifier.get_db().insert(0, test_values[1]));
@@ -517,7 +517,7 @@ TEST(ART, memory_accounting_duplicate_key_insert) {
   ASSERT_EQ(verifier.get_db().get_current_memory_use(), 0);
 }
 
-TEST(ART, node48_insert_into_deleted_slot) {
+TEST(ART, Node48InsertIntoDeletedSlot) {
   tree_verifier<unodb::db> verifier{4096};
   verifier.insert(16865361447928765957ULL, test_values[0]);
   verifier.insert(7551546784238320931ULL, test_values[1]);
@@ -542,7 +542,7 @@ TEST(ART, node48_insert_into_deleted_slot) {
   verifier.check_present_values();
 }
 
-TEST(ART, memory_accounting_growing_node_exception) {
+TEST(ART, MemoryAccountingGrowingNodeException) {
   tree_verifier<unodb::db> verifier{1024};
 
   verifier.insert_key_range(0, 4);
@@ -558,7 +558,7 @@ TEST(ART, memory_accounting_growing_node_exception) {
   verifier.check_absent_keys({10});
 }
 
-TEST(ART, memory_accounting_leaf_to_node4_exception) {
+TEST(ART, MemoryAccountingLeafToNode4Exception) {
   tree_verifier<unodb::db> verifier{50};
 
   verifier.insert(0, test_values[0]);
@@ -569,7 +569,7 @@ TEST(ART, memory_accounting_leaf_to_node4_exception) {
   verifier.check_absent_keys({1});
 }
 
-TEST(ART, memory_accounting_prefix_split_exception) {
+TEST(ART, MemoryAccountingPrefixSplitException) {
   tree_verifier<unodb::db> verifier{140};
 
   verifier.insert(1, test_values[0]);

--- a/test_art_fuzz_deepstate.cpp
+++ b/test_art_fuzz_deepstate.cpp
@@ -83,7 +83,7 @@ void dump_tree(const unodb::db &tree) {
 // We consider this to be a TEST macro internal implementation detail
 DISABLE_CLANG_WARNING("-Wmissing-noreturn")
 
-TEST(ART, DeepState_fuzz) {
+TEST(ART, DeepStateFuzz) {
   const auto mem_limit =
       static_cast<std::size_t>(DeepState_IntInRange(0, maximum_art_mem));
   LOG(TRACE) << "ART memory limit is " << static_cast<std::uint64_t>(mem_limit);

--- a/test_art_mutex_concurrency.cpp
+++ b/test_art_mutex_concurrency.cpp
@@ -17,7 +17,7 @@ void parallel_insert_thread(tree_verifier<unodb::mutex_db> *verifier,
   verifier->insert_preinserted_key_range(start_key, count);
 }
 
-TEST(ART_mutex_concurrency, parallel_insert_one_tree) {
+TEST(ARTMutexConcurrency, ParallelInsertOneTree) {
   constexpr auto num_of_threads = 4;
   constexpr auto total_keys = 1024;
 
@@ -43,7 +43,7 @@ void parallel_remove_thread(tree_verifier<unodb::mutex_db> *verifier,
   }
 }
 
-TEST(ART_mutex_concurrency, parallel_tear_down_one_tree) {
+TEST(ARTMutexConcurrency, ParallelTearDownOneTree) {
   constexpr auto num_of_threads = 8;
   constexpr auto total_keys = 2048;
 
@@ -81,7 +81,7 @@ void key_range_op_thread(tree_verifier<unodb::mutex_db> *verifier,
   }
 }
 
-TEST(ART_mutex_concurrency, node4_parallel_ops) {
+TEST(ARTMutexConcurrency, Node4ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 6;
 
@@ -96,7 +96,7 @@ TEST(ART_mutex_concurrency, node4_parallel_ops) {
   }
 }
 
-TEST(ART_mutex_concurrency, node16_parallel_ops) {
+TEST(ARTMutexConcurrency, Node16ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 12;
 
@@ -111,7 +111,7 @@ TEST(ART_mutex_concurrency, node16_parallel_ops) {
   }
 }
 
-TEST(ART_mutex_concurrency, node48_parallel_ops) {
+TEST(ARTMutexConcurrency, Node48ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 32;
 
@@ -126,7 +126,7 @@ TEST(ART_mutex_concurrency, node48_parallel_ops) {
   }
 }
 
-TEST(ART_mutex_concurrency, node256_parallel_ops) {
+TEST(ARTMutexConcurrency, Node256ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 208;
 
@@ -162,7 +162,7 @@ void random_op_thread(tree_verifier<unodb::mutex_db> *verifier,
   }
 }
 
-TEST(ART_mutex_concurrency, parallel_random_insert_delete_get) {
+TEST(ARTMutexConcurrency, ParallelRandomInsertDeleteGet) {
   constexpr auto num_of_threads = 4 * 3;
   constexpr auto initial_keys = 2048;
   constexpr auto ops_per_thread = 10000;


### PR DESCRIPTION
- .clang-format: redump Google config with clang-format 9, tweak IncludeBlocks
  back to preserve

- Add new LLVM configurations to .cmake-build.el

- Update to LLVM 9 in Travis-CI configuration

- Disable some new clang-tidy checks that do not make sense here

- Disable one generally-useful new clang-tidy check inline in the source code
  where the usage is intended

- Disable cpplint unknown inline NOLINT checks due to clash with clang-tidy
  cause by the above

- Rename Google Test test names from snake_case to CamelCase, as underscores are
  forbidden in Google Test suite and test names