### PR TITLE
Add LLVM 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,21 @@ os_setups:
           - g++-9
           - libasan5-dbg
           - valgrind
-  clang9_setup: &clang9
+  clang10_setup: &clang10
     os: linux
     compiler: clang
     addons:
       apt:
         sources:
           - sourceline: 'ppa:mhier/libboost-latest'
-          - llvm-toolchain-bionic-9
+          - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
+            key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
         packages:
           - boost1.70
-          - clang-9
-          - clang-tidy-9
-          - clang-tools-9
+          - clang-10
+          - clang-tidy-10
+          - clang-tools-10
+          - llvm-10-dev
           - valgrind
   macos_setup: &macos
     os: osx
@@ -86,38 +88,38 @@ matrix:
       <<: *gcc9
       env:
         - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9" BUILD_TYPE=Debug SANITIZE_THREAD=ON
-    - name: "Bionic clang 9 Release"
-      <<: *clang9
+    - name: "Bionic clang 10 Release"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release
-    - name: "Bionic clang 9 Release with ASan/UBSan"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Release
+    - name: "Bionic clang 10 Release with ASan/UBSan"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release SANITIZE=ON
-    - name: "Bionic clang 9 Release with TSan/UBSan"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Release SANITIZE=ON
+    - name: "Bionic clang 10 Release with TSan/UBSan"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release SANITIZE_THREAD=ON
-    - name: "Bionic clang 9 Debug"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "Bionic clang 10 Debug"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug
-    - name: "Bionic clang 9 Debug with ASan/UBSan"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Debug
+    - name: "Bionic clang 10 Debug with ASan/UBSan"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug SANITIZE=ON
-    - name: "Bionic clang 9 Debug with TSan/UBSan"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Debug SANITIZE=ON
+    - name: "Bionic clang 10 Debug with TSan/UBSan"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug SANITIZE_THREAD=ON
-    - name: "Bionic clang 9 static analysis Release"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "Bionic clang 10 static analysis Release"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Release SCAN_BUILD=scan-build-9
-    - name: "Bionic clang 9 static analysis Debug"
-      <<: *clang9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Release SCAN_BUILD=scan-build-10
+    - name: "Bionic clang 10 static analysis Debug"
+      <<: *clang10
       env:
-        - MATRIX_EVAL="CC=clang-9 && CXX=clang++-9" BUILD_TYPE=Debug SCAN_BUILD=scan-build-9
+        - MATRIX_EVAL="CC=clang-10 && CXX=clang++-10" BUILD_TYPE=Debug SCAN_BUILD=scan-build-9
     - name: "macOS XCode 11.3 Release"
       <<: *macos
       env:
@@ -163,8 +165,8 @@ script:
   - cd build
   - EXTRA_CMAKE_OPTIONS=""
   - sudo rm -rf /usr/local/clang-7.0.0
-  - if [[ "$CC" == "clang-9" ]]; then
-      sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 50;
+  - if [[ "$CC" == "clang-10" ]]; then
+      sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-10 50;
     fi
   - if [[ "$CC" == "gcc-9" && "$COVERAGE" == "ON" ]]; then
       sudo cpanm install JSON;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
     "-Werror"
     # Warning groups
     "-Wall" "-Wextra" "-Wconversion" "-Wdelete-non-virtual-dtor" "-Wdeprecated"
-    "-Wgnu" "-Wimplicit" "-Wloop-analysis" "-Wpedantic" "-Wpragmas"
-    "-Wself-assign" "-Wshadow-all"
+    "-Wgnu" "-Wimplicit" "-Wloop-analysis" "-Wparentheses" "-Wpedantic"
+    "-Wpragmas" "-Wself-assign" "-Wshadow-all"
     # Individual warnings
     "-Wabstract-vbase-init" "-Warray-bounds-pointer-arithmetic" "-Wassign-enum"
     "-Watomic-implicit-seq-cst" "-Wbad-function-cast" "-Wc++2a-compat"
@@ -282,6 +282,7 @@ else()
       "-fuchsia-default-arguments,"
       "-clang-diagnostic-error,"
       "-cppcoreguidelines-avoid-magic-numbers,"
+      "-cppcoreguidelines-init-variables,"
       "-cppcoreguidelines-macro-usage," # Until it respects __LINE__ in macro definition
       "-cppcoreguidelines-non-private-member-variables-in-classes,"
       "-cppcoreguidelines-pro-bounds-array-to-pointer-decay,"

--- a/art.cpp
+++ b/art.cpp
@@ -1418,7 +1418,7 @@ get_result db::get_from_subtree(detail::node_ptr node, detail::art_key k,
       node.internal->node_key_prefix.length())
     return {};
   depth += node.internal->node_key_prefix.length();
-  const auto child = node.internal->find_child(k[depth]).second;
+  auto *const child = node.internal->find_child(k[depth]).second;
   if (child == nullptr) return {};
   return get_from_subtree(*child, k, depth + 1);
 }
@@ -1462,7 +1462,7 @@ bool db::insert_to_subtree(detail::art_key k, detail::node_ptr *node,
   }
   depth += node->internal->node_key_prefix.length();
 
-  const auto child = node->internal->find_child(k[depth]).second;
+  auto *const child = node->internal->find_child(k[depth]).second;
 
   if (child != nullptr) return insert_to_subtree(k, child, v, depth + 1);
 


### PR DESCRIPTION
- Switch Travis CI to LLVM version 10.

- Install llvm-10-dev so that LLVM LTO works too now.

- Disable clang-tidy 10 check "cppcoreguidelines-init-variables", while it's
  mostly a great check, there are a couple cases where we don' want that.

- Qualify some auto variables as auto *, a result of readability-qualified-auto
  clang-tidy check.