### PR TITLE
Introduce unodb::detail::tree_depth value type

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -81,7 +81,37 @@ class inode_256;
 
 enum class node_type : std::uint8_t;
 
-using tree_depth = unsigned;
+class tree_depth final {
+ public:
+  using value_type = unsigned;
+
+  explicit tree_depth(value_type value_ = 0) noexcept : value{value_} {
+    assert(value <= art_key::size);
+  }
+
+  tree_depth(const tree_depth &other) noexcept : value{other.value} {
+    assert(value <= art_key::size);
+  }
+
+  [[nodiscard]] operator value_type() const noexcept {
+    assert(value <= art_key::size);
+    return value;
+  }
+
+  tree_depth &operator++() noexcept {
+    ++value;
+    assert(value <= art_key::size);
+    return *this;
+  }
+
+  void operator+=(value_type delta) noexcept {
+    value += delta;
+    assert(value <= art_key::size);
+  }
+
+ private:
+  value_type value;
+};
 
 // A pointer to some kind of node. It can be accessed either as a node header,
 // to query the right node type, a leaf, or as one of the internal nodes. This


### PR DESCRIPTION
Previously tree_depth was an alias of unsigned. We want to introduce an
invariant for these values-bound the range-but adding asserts at each call site
results in duplicated code and it's too easy to miss relevant call sites.

Thus wrap the number in a small helper class where the invariant can be checked
locally.

Add a couple of other semi-related asserts too.