### PR TITLE
Enable tree dumps for release builds too

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ All ART classes implement the same API:
   internal nodes in bytes, only accounted if memory limit was specified in
   constructor, otherwise always zero.
 * `bool empty()`, returning whether the tree is empty.
-* `void dump(std::ostream &)`, only available if `NDEBUG` is not defined,
-  dumping the tree representation into output stream.
+* `void dump(std::ostream &)`, dumping the tree representation into output
+  stream.
 
 The are two ART classes available:
 

--- a/art.hpp
+++ b/art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Laurynas Biveinis
+// Copyright 2019-2020 Laurynas Biveinis
 #ifndef UNODB_ART_HPP_
 #define UNODB_ART_HPP_
 
@@ -157,9 +157,7 @@ class db final {
 
   [[nodiscard]] bool remove(key k);
 
-#ifndef NDEBUG
   void dump(std::ostream &os) const;
-#endif
 
   [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
 

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Laurynas Biveinis
+// Copyright 2019-2020 Laurynas Biveinis
 #ifndef UNODB_MUTEX_ART_HPP_
 #define UNODB_MUTEX_ART_HPP_
 
@@ -30,12 +30,10 @@ class mutex_db final {
     return db_.remove(k);
   }
 
-#ifndef NDEBUG
   void dump(std::ostream &os) const {
     const std::lock_guard guard{mutex};
     db_.dump(os);
   }
-#endif
 
   [[nodiscard]] auto empty() const noexcept {
     const std::lock_guard guard{mutex};

--- a/test_art_fuzz_deepstate.cpp
+++ b/test_art_fuzz_deepstate.cpp
@@ -2,9 +2,7 @@
 
 #include "global.hpp"
 
-#ifndef NDEBUG
 #include <sstream>
-#endif
 #include <unordered_map>
 
 #include <deepstate/DeepState.hpp>
@@ -68,14 +66,10 @@ unodb::key get_key(unodb::key max_key_value,
 }
 
 void dump_tree(const unodb::db &tree) {
-#ifndef NDEBUG
   // Dump the tree to a string. Do not attempt to check the dump format, only
   // that dumping does not crash
   std::stringstream dump_sink;
   tree.dump(dump_sink);
-#else
-  (void)tree;
-#endif
 }
 
 }  // namespace

--- a/test_utils.cpp
+++ b/test_utils.cpp
@@ -1,30 +1,11 @@
-// Copyright 2019 Laurynas Biveinis
+// Copyright 2019-2020 Laurynas Biveinis
 
 #include "global.hpp"
 
 #include "test_utils.hpp"
 
-#include <sstream>
-
-#include <gtest/gtest.h>
-
 #include "art.hpp"
-
-// warning: 'ScopedTrace' was marked unused but was used
-// [-Wused-but-marked-unused]
-DISABLE_CLANG_WARNING("-Wused-but-marked-unused")
-
-void assert_result_eq(unodb::key key, unodb::get_result result,
-                      unodb::value_view expected, int caller_line) noexcept {
-  std::ostringstream msg;
-  msg << "key = " << static_cast<unsigned>(key);
-  testing::ScopedTrace trace(__FILE__, caller_line, msg.str());
-  ASSERT_TRUE(result);
-  ASSERT_TRUE(std::equal(result->cbegin(), result->cend(), expected.cbegin(),
-                         expected.cend()));
-}
-
-RESTORE_CLANG_WARNINGS()
+#include "mutex_art.hpp"
 
 template class tree_verifier<unodb::db>;
 template class tree_verifier<unodb::mutex_db>;


### PR DESCRIPTION
Remove #ifndef NDEBUG around tree dumping code.

Use this in the tests to dump the tree on get/remove failure.