### PR TITLE
Implement db::clear()

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All ART classes implement the same API:
   successful (i.e. the key was not already present).
 * `bool remove(key k)`, returning whether delete was successful (i.e. the
   key was found in the tree).
+* `clear`, making the tree empty.
 * `std::size_t get_current_memory_use()`, returning current memory use by
   internal nodes in bytes, only accounted if memory limit was specified in
   constructor, otherwise always zero.

--- a/art.cpp
+++ b/art.cpp
@@ -1558,6 +1558,12 @@ bool db::remove_from_subtree(detail::art_key k, detail::tree_depth depth,
   return true;
 }
 
+void db::clear() {
+  ::delete_subtree(root);
+  root = nullptr;
+  current_memory_use = 0;
+}
+
 DISABLE_GCC_WARNING("-Wsuggest-attribute=cold")
 void db::increase_memory_use(std::size_t delta) {
   if (memory_limit == 0 || delta == 0) return;

--- a/art.hpp
+++ b/art.hpp
@@ -157,6 +157,8 @@ class db final {
 
   [[nodiscard]] bool remove(key k);
 
+  void clear();
+
   void dump(std::ostream &os) const;
 
   [[nodiscard]] auto empty() const noexcept { return root == nullptr; }

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -30,6 +30,11 @@ class mutex_db final {
     return db_.remove(k);
   }
 
+  void clear() {
+    const std::lock_guard guard{mutex};
+    db_.clear();
+  }
+
   void dump(std::ostream &os) const {
     const std::lock_guard guard{mutex};
     db_.dump(os);

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -612,6 +612,32 @@ TYPED_TEST(ART, MemoryAccountingPrefixSplitException) {
   verifier.check_absent_keys({0xFF01});
 }
 
+TYPED_TEST(ART, ClearOnEmpty) {
+  tree_verifier<TypeParam> verifier;
+
+  verifier.clear();
+}
+
+TYPED_TEST(ART, Clear) {
+  tree_verifier<TypeParam> verifier;
+
+  verifier.insert(1, test_values[0]);
+
+  verifier.clear();
+
+  verifier.check_absent_keys({1});
+}
+
+TYPED_TEST(ART, ClearWithMemLimit) {
+  tree_verifier<TypeParam> verifier{13};
+
+  verifier.insert(0, empty_test_value);
+
+  verifier.clear();
+
+  verifier.check_absent_keys({0});
+}
+
 RESTORE_GCC_WARNINGS()
 
 }  // namespace

--- a/test_art_fuzz_deepstate.cpp
+++ b/test_art_fuzz_deepstate.cpp
@@ -169,6 +169,16 @@ TEST(ART, DeepStateFuzz) {
         },
         // Delete
         [&] {
+          // Delete everything with 0.1% probability
+          const auto clear = (DeepState_UIntInRange(0, 999) == 0);
+          if (clear) {
+            LOG(TRACE) << "Clearing the tree";
+            test_db.clear();
+            oracle.clear();
+            ASSERT(test_db.get_current_memory_use() == 0);
+            ASSERT(test_db.empty());
+            return;
+          }
           const auto key = get_key(max_key_value, keys);
           LOG(TRACE) << "Deleting key " << key;
           const auto mem_use_before = test_db.get_current_memory_use();

--- a/test_utils.hpp
+++ b/test_utils.hpp
@@ -25,11 +25,12 @@ constexpr auto test_value_4 = std::array<std::byte, 4>{
 constexpr auto test_value_5 =
     std::array<std::byte, 5>{std::byte{0x05}, std::byte{0xF4}, std::byte{0xFF},
                              std::byte{0x00}, std::byte{0x01}};
+constexpr auto empty_test_value = std::array<std::byte, 0>{};
 
-constexpr std::array<unodb::value_view, 5> test_values = {
+constexpr std::array<unodb::value_view, 6> test_values = {
     unodb::value_view{test_value_1}, unodb::value_view{test_value_2},
     unodb::value_view{test_value_3}, unodb::value_view{test_value_4},
-    unodb::value_view{test_value_5}};
+    unodb::value_view{test_value_5}, unodb::value_view{empty_test_value}};
 
 // warning: 'ScopedTrace' was marked unused but was used
 // [-Wused-but-marked-unused]
@@ -174,6 +175,13 @@ class tree_verifier final {
   void assert_empty() const noexcept {
     ASSERT_TRUE(test_db.empty());
     ASSERT_EQ(test_db.get_current_memory_use(), 0);
+  }
+
+  void clear() noexcept {
+    test_db.clear();
+    assert_empty();
+
+    values.clear();
   }
 
   Db &get_db() noexcept { return test_db; }


### PR DESCRIPTION
Add tests, including a DeepState fuzzer test (branch off delete with 0.1%
probability to clear), which already found a bug in my implementation. Add a
zero-length test value, rotate it in to the unit test usage.