### PR TITLE
Fix/rewrite broken benchmarks by checking operation return values

### DIFF
--- a/global.hpp
+++ b/global.hpp
@@ -56,6 +56,12 @@
 #define likely(x) __builtin_expect(x, 1)
 #define unlikely(x) __builtin_expect(x, 0)
 
+#ifdef NDEBUG
+#define USED_IN_DEBUG __attribute__((unused))
+#else
+#define USED_IN_DEBUG
+#endif
+
 #if defined(__GNUG__) && !defined(__clang__)
 #define USE_STD_PMR
 #endif

--- a/micro_benchmark_mutex.cpp
+++ b/micro_benchmark_mutex.cpp
@@ -15,18 +15,17 @@ namespace {
 std::unique_ptr<unodb::mutex_db> test_db;
 
 void parallel_get_worker(unodb::key start, unodb::key length) {
-  for (unodb::key i = start; i < start + length; ++i) {
-    benchmark::DoNotOptimize(test_db->get(i));
-  }
+  for (unodb::key i = start; i < start + length; ++i)
+    unodb::benchmark::get_existing_key(*test_db, i);
 }
 
 void parallel_get(benchmark::State &state) {
   test_db = std::make_unique<unodb::mutex_db>();
   const auto tree_size = static_cast<unodb::key>(state.range(1));
-  for (unodb::key i = 0; i < tree_size; ++i) {
-    (void)test_db->insert(
-        i, unodb::benchmark::values[i % unodb::benchmark::values.size()]);
-  }
+  for (unodb::key i = 0; i < tree_size; ++i)
+    unodb::benchmark::insert_key(
+        *test_db, i,
+        unodb::benchmark::values[i % unodb::benchmark::values.size()]);
 
   const auto num_of_threads = static_cast<std::size_t>(state.range(0));
   const unodb::key length = tree_size / num_of_threads;
@@ -49,21 +48,23 @@ void parallel_get(benchmark::State &state) {
 }
 
 void parallel_insert_worker(unodb::key start, unodb::key length) {
-  for (unodb::key i = start; i < start + length; ++i) {
-    benchmark::DoNotOptimize(test_db->insert(
-        i, unodb::benchmark::values[i % unodb::benchmark::values.size()]));
-  }
+  for (unodb::key i = start; i < start + length; ++i)
+    unodb::benchmark::insert_key(
+        *test_db, i,
+        unodb::benchmark::values[i % unodb::benchmark::values.size()]);
 }
 
 void parallel_insert_disjoint_ranges(benchmark::State &state) {
-  test_db = std::make_unique<unodb::mutex_db>();
-
   const auto num_of_threads = static_cast<std::size_t>(state.range(0));
   const auto tree_size = static_cast<unodb::key>(state.range(1));
   const unodb::key length = tree_size / num_of_threads;
-  std::vector<std::thread> threads{num_of_threads};
 
   for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::thread> threads{num_of_threads};
+    test_db = std::make_unique<unodb::mutex_db>();
+    state.ResumeTiming();
+
     for (std::size_t i = 1; i < num_of_threads; ++i) {
       const unodb::key start = i * length;
       threads[i] = std::thread{parallel_insert_worker, start, length};
@@ -74,31 +75,33 @@ void parallel_insert_disjoint_ranges(benchmark::State &state) {
     for (std::size_t i = 1; i < num_of_threads; ++i) {
       threads[i].join();
     }
+
+    unodb::benchmark::destroy_tree(*test_db, state);
   }
 
   test_db.reset(nullptr);
 }
 
 void parallel_delete_worker(unodb::key start, unodb::key length) {
-  for (unodb::key i = start; i < start + length; ++i) {
-    benchmark::DoNotOptimize(test_db->remove(i));
-  }
+  for (unodb::key i = start; i < start + length; ++i)
+    unodb::benchmark::delete_key(*test_db, i);
 }
 
 void parallel_delete_disjoint_ranges(benchmark::State &state) {
-  test_db = std::make_unique<unodb::mutex_db>();
-
   const auto tree_size = static_cast<unodb::key>(state.range(1));
-  for (unodb::key i = 0; i < tree_size; ++i) {
-    (void)test_db->insert(
-        i, unodb::benchmark::values[i % unodb::benchmark::values.size()]);
-  }
-
   const auto num_of_threads = static_cast<std::size_t>(state.range(0));
   const unodb::key length = tree_size / num_of_threads;
-  std::vector<std::thread> threads{num_of_threads};
 
   for (auto _ : state) {
+    state.PauseTiming();
+    std::vector<std::thread> threads{num_of_threads};
+    test_db = std::make_unique<unodb::mutex_db>();
+    for (unodb::key i = 0; i < tree_size; ++i)
+      unodb::benchmark::insert_key(
+          *test_db, i,
+          unodb::benchmark::values[i % unodb::benchmark::values.size()]);
+    state.ResumeTiming();
+
     for (std::size_t i = 1; i < num_of_threads; ++i) {
       const unodb::key start = i * length;
       threads[i] = std::thread{parallel_delete_worker, start, length};
@@ -109,6 +112,8 @@ void parallel_delete_disjoint_ranges(benchmark::State &state) {
     for (std::size_t i = 1; i < num_of_threads; ++i) {
       threads[i].join();
     }
+
+    unodb::benchmark::destroy_tree(*test_db, state);
   }
 
   test_db.reset(nullptr);


### PR DESCRIPTION
Introduce benchmark utilities that assert, in debug builds, where the tree
operation succeeded as it should. This uncovered a bunch of bugs in benchmarks:

- several benchmarks initialized and did not clear the tree between the runs,
  resulting in i.e. successful inserts during the 1st iteration and already
  existing key returns on every next one;

- benchmark::State::iterations() was not considered for items processed
  statistics;