### PR TITLE
Implement node size statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ All ART classes implement the same API:
 * `bool remove(key k)`, returning whether delete was successful (i.e. the
   key was found in the tree).
 * `clear`, making the tree empty.
-* `std::size_t get_current_memory_use()`, returning current memory use by
-  internal nodes in bytes, only accounted if memory limit was specified in
-  constructor, otherwise always zero.
 * `bool empty()`, returning whether the tree is empty.
 * `void dump(std::ostream &)`, dumping the tree representation into output
   stream.
+* Several getters for assorted tree info, such as current memory use, and
+  counters of various internal tree  operations (i.e. number of times Node4 grew
+  to Node16, key prefix was split, etc - check the source code).
 
 The are two ART classes available:
 

--- a/art.hpp
+++ b/art.hpp
@@ -146,26 +146,86 @@ union node_ptr {
 
 class db final {
  public:
+  // Creation and destruction
   explicit db(std::size_t memory_limit_ = 0) noexcept
       : memory_limit{memory_limit_} {}
 
   ~db() noexcept;
 
+  // Querying
   [[nodiscard]] get_result get(key k) const noexcept;
 
+  [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
+
+  // Modifying
   [[nodiscard]] bool insert(key k, value_view v);
 
   [[nodiscard]] bool remove(key k);
 
   void clear();
 
-  void dump(std::ostream &os) const;
+  // Stats
 
-  [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
-
+  // Return current memory use by tree nodes in bytes, only accounted if memory
+  // limit was specified in the constructor, otherwise always zero.
   [[nodiscard]] auto get_current_memory_use() const noexcept {
     return current_memory_use;
   }
+
+  [[nodiscard]] auto get_leaf_count() const noexcept { return leaf_count; }
+
+  [[nodiscard]] auto get_inode4_count() const noexcept { return inode4_count; }
+
+  [[nodiscard]] auto get_inode16_count() const noexcept {
+    return inode16_count;
+  }
+
+  [[nodiscard]] auto get_inode48_count() const noexcept {
+    return inode48_count;
+  }
+
+  [[nodiscard]] auto get_inode256_count() const noexcept {
+    return inode256_count;
+  }
+
+  [[nodiscard]] auto get_created_inode4_count() const noexcept {
+    return created_inode4_count;
+  }
+
+  [[nodiscard]] auto get_inode4_to_inode16_count() const noexcept {
+    return inode4_to_inode16_count;
+  }
+
+  [[nodiscard]] auto get_inode16_to_inode48_count() const noexcept {
+    return inode16_to_inode48_count;
+  }
+
+  [[nodiscard]] auto get_inode48_to_inode256_count() const noexcept {
+    return inode48_to_inode256_count;
+  }
+
+  [[nodiscard]] auto get_deleted_inode4_count() const noexcept {
+    return deleted_inode4_count;
+  }
+
+  [[nodiscard]] auto get_inode16_to_inode4_count() const noexcept {
+    return inode16_to_inode4_count;
+  }
+
+  [[nodiscard]] auto get_inode48_to_inode16_count() const noexcept {
+    return inode48_to_inode16_count;
+  }
+
+  [[nodiscard]] auto get_inode256_to_inode48_count() const noexcept {
+    return inode256_to_inode48_count;
+  }
+
+  [[nodiscard]] auto get_key_prefix_splits() const noexcept {
+    return key_prefix_splits;
+  }
+
+  // Debugging
+  void dump(std::ostream &os) const;
 
  private:
   [[nodiscard]] static get_result get_from_subtree(
@@ -187,6 +247,24 @@ class db final {
 
   std::size_t current_memory_use{0};
   const std::size_t memory_limit;
+
+  std::uint64_t leaf_count{0};
+  std::uint64_t inode4_count{0};
+  std::uint64_t inode16_count{0};
+  std::uint64_t inode48_count{0};
+  std::uint64_t inode256_count{0};
+
+  std::uint64_t created_inode4_count{0};
+  std::uint64_t inode4_to_inode16_count{0};
+  std::uint64_t inode16_to_inode48_count{0};
+  std::uint64_t inode48_to_inode256_count{0};
+
+  std::uint64_t deleted_inode4_count{0};
+  std::uint64_t inode16_to_inode4_count{0};
+  std::uint64_t inode48_to_inode16_count{0};
+  std::uint64_t inode256_to_inode48_count{0};
+
+  std::uint64_t key_prefix_splits{0};
 
   friend struct detail::leaf;
   friend class detail::raii_leaf_creator;

--- a/micro_benchmark.cpp
+++ b/micro_benchmark.cpp
@@ -4,6 +4,7 @@
 
 #include <limits>
 #include <random>
+#include <string>
 #include <vector>
 
 #include <benchmark/benchmark.h>
@@ -15,7 +16,11 @@ namespace {
 
 class batched_random_key_source final {
  public:
-  batched_random_key_source() : random_keys(random_batch_size) { refill(); }
+  batched_random_key_source(
+      unodb::key max_value = std::numeric_limits<unodb::key>::max())
+      : random_key_dist{0ULL, max_value} {
+    refill();
+  }
 
   auto get(benchmark::State &state) {
     if (random_key_ptr == random_keys.cend()) {
@@ -35,16 +40,67 @@ class batched_random_key_source final {
 
   static constexpr auto random_batch_size = 10000;
 
-  std::vector<unodb::key> random_keys;
+  std::vector<unodb::key> random_keys{random_batch_size};
   std::vector<unodb::key>::const_iterator random_key_ptr;
 
   std::random_device rd;
   std::mt19937 gen{rd()};
-  std::uniform_int_distribution<unodb::key> random_key_dist{
-      0ULL, std::numeric_limits<unodb::key>::max()};
+  std::uniform_int_distribution<unodb::key> random_key_dist;
 };
 
+class growing_tree_node_stats final {
+ public:
+  void get(const unodb::db &test_db) noexcept {
+    leaf_count = test_db.get_leaf_count();
+    inode4_count = test_db.get_inode4_count();
+    inode16_count = test_db.get_inode16_count();
+    inode48_count = test_db.get_inode48_count();
+    inode256_count = test_db.get_inode256_count();
+    created_inode4_count = test_db.get_created_inode4_count();
+    inode4_to_inode16_count = test_db.get_inode4_to_inode16_count();
+    inode16_to_inode48_count = test_db.get_inode16_to_inode48_count();
+    inode48_to_inode256_count = test_db.get_inode48_to_inode256_count();
+    key_prefix_splits = test_db.get_key_prefix_splits();
+  }
+
+  void publish(benchmark::State &state) const noexcept {
+    state.counters["L"] = static_cast<double>(leaf_count);
+    state.counters["4"] = static_cast<double>(inode4_count);
+    state.counters["16"] = static_cast<double>(inode16_count);
+    state.counters["48"] = static_cast<double>(inode48_count);
+    state.counters["256"] = static_cast<double>(inode256_count);
+    state.counters["+4"] = static_cast<double>(created_inode4_count);
+    state.counters["4^"] = static_cast<double>(inode4_to_inode16_count);
+    state.counters["16^"] = static_cast<double>(inode16_to_inode48_count);
+    state.counters["48^"] = static_cast<double>(inode48_to_inode256_count);
+    state.counters["KPfS"] = static_cast<double>(key_prefix_splits);
+  }
+
+ private:
+  std::uint64_t leaf_count{0};
+  std::uint64_t inode4_count{0};
+  std::uint64_t inode16_count{0};
+  std::uint64_t inode48_count{0};
+  std::uint64_t inode256_count{0};
+  std::uint64_t created_inode4_count{0};
+  std::uint64_t inode4_to_inode16_count{0};
+  std::uint64_t inode16_to_inode48_count{0};
+  std::uint64_t inode48_to_inode256_count{0};
+  std::uint64_t key_prefix_splits{0};
+};
+
+void set_size_counter(benchmark::State &state, const std::string &label,
+                      std::size_t value) {
+  // state.SetLabel might be a better logical fit but the automatic k/M/G
+  // suffix is too nice
+  state.counters[label] = benchmark::Counter(
+      static_cast<double>(value), benchmark::Counter::Flags::kDefaults,
+      benchmark::Counter::OneK::kIs1024);
+}
+
 void dense_insert_no_mem_check(benchmark::State &state) {
+  growing_tree_node_stats growing_tree_stats;
+
   for (auto _ : state) {
     state.PauseTiming();
     unodb::db test_db;
@@ -55,16 +111,19 @@ void dense_insert_no_mem_check(benchmark::State &state) {
       unodb::benchmark::insert_key(
           test_db, i, unodb::value_view{unodb::benchmark::value100});
 
+    state.PauseTiming();
+    growing_tree_stats.get(test_db);
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(0));
-  // TODO(laurynas): add node size / enlarge / shrink stats
+  growing_tree_stats.publish(state);
 }
 
 void dense_insert_mem_check(benchmark::State &state) {
   std::size_t tree_size = 0;
+
   for (auto _ : state) {
     state.PauseTiming();
     unodb::db test_db{1000ULL * 1000 * 1000 * 1000};
@@ -74,23 +133,20 @@ void dense_insert_mem_check(benchmark::State &state) {
     for (unodb::key i = 0; i < static_cast<unodb::key>(state.range(0)); ++i)
       unodb::benchmark::insert_key(
           test_db, i, unodb::value_view{unodb::benchmark::value100});
-    tree_size = test_db.get_current_memory_use();
 
+    state.PauseTiming();
+    tree_size = test_db.get_current_memory_use();
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(0));
-  // state.SetLabel might be a better logical fit but the automatic k/M/G
-  // suffix is too nice
-  // Once Google Benchmark > 1.4.1 is released, use
-  // benchmark::Counter::OneK::kIs1024 and drop "(k=1000)"
-  state.counters["Size(k=1000)"] =
-      benchmark::Counter(static_cast<double>(tree_size));
+  set_size_counter(state, "size", tree_size);
 }
 
 void sparse_insert_no_mem_check_dups_allowed(benchmark::State &state) {
   batched_random_key_source random_keys;
+  growing_tree_node_stats growing_tree_stats;
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -104,15 +160,19 @@ void sparse_insert_no_mem_check_dups_allowed(benchmark::State &state) {
           test_db, random_key, unodb::value_view{unodb::benchmark::value100});
     }
 
+    state.PauseTiming();
+    growing_tree_stats.get(test_db);
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(0));
+  growing_tree_stats.publish(state);
 }
 
 void sparse_insert_mem_check_dups_allowed(benchmark::State &state) {
   batched_random_key_source random_keys;
+  std::size_t tree_size = 0;
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -126,9 +186,12 @@ void sparse_insert_mem_check_dups_allowed(benchmark::State &state) {
           test_db, random_key, unodb::value_view{unodb::benchmark::value100});
     }
 
+    state.PauseTiming();
+    tree_size = test_db.get_current_memory_use();
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
+  set_size_counter(state, "size", tree_size);
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(0));
 }
@@ -136,11 +199,13 @@ void sparse_insert_mem_check_dups_allowed(benchmark::State &state) {
 constexpr auto full_scan_multiplier = 50;
 
 void dense_full_scan(benchmark::State &state) {
-  unodb::db test_db;
+  unodb::db test_db{1000ULL * 1000 * 1000 * 1000};
   const auto key_limit = static_cast<unodb::key>(state.range(0));
+
   for (unodb::key i = 0; i < key_limit; ++i)
     unodb::benchmark::insert_key(test_db, i,
                                  unodb::value_view{unodb::benchmark::value100});
+  std::size_t tree_size = test_db.get_current_memory_use();
 
   for (auto _ : state)
     for (auto i = 0; i < full_scan_multiplier; ++i)
@@ -149,35 +214,50 @@ void dense_full_scan(benchmark::State &state) {
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(0) * full_scan_multiplier);
+  set_size_counter(state, "size", tree_size);
 }
-
 void dense_tree_sparse_deletes_args(benchmark::internal::Benchmark *b) {
-  for (auto i = 1000; i <= 5000000; i *= 8)
-    for (auto j = 800; j <= 5000000; j *= 8) {
-      if (j > i) break;
-      b->Args({i, j});
-    }
+  for (auto i = 1000; i <= 5000000; i *= 8) {
+    b->Args({i, 800});
+    b->Args({i, i});
+  }
 }
 
 void dense_tree_sparse_deletes(benchmark::State &state) {
-  batched_random_key_source random_keys;
+  // Node shrinking stats almost always zero, thus this test only tests
+  // non-shrinking Node256 delete
+  std::size_t start_tree_size = 0;
+  std::size_t end_tree_size = 0;
+  std::uint64_t start_leaf_count = 0;
+  std::uint64_t end_leaf_count = 0;
 
   for (auto _ : state) {
     state.PauseTiming();
-    unodb::db test_db;
+    batched_random_key_source random_keys{
+        static_cast<unodb::key>(state.range(0) - 1)};
+    unodb::db test_db{1000ULL * 1000 * 1000 * 1000};
     for (unodb::key i = 0; i < static_cast<unodb::key>(state.range(0)); ++i)
       unodb::benchmark::insert_key(
           test_db, i, unodb::value_view{unodb::benchmark::value100});
+    start_tree_size = test_db.get_current_memory_use();
+    start_leaf_count = test_db.get_leaf_count();
     state.ResumeTiming();
 
     for (auto j = 0; j < state.range(1); ++j) {
       const auto random_key = random_keys.get(state);
       unodb::benchmark::delete_key_if_exists(test_db, random_key);
     }
+
+    end_tree_size = test_db.get_current_memory_use();
+    end_leaf_count = test_db.get_leaf_count();
   }
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(1));
+  set_size_counter(state, "start size", start_tree_size);
+  set_size_counter(state, "end size", end_tree_size);
+  state.counters["start L"] = static_cast<double>(start_leaf_count);
+  state.counters["end L"] = static_cast<double>(end_leaf_count);
 }
 
 constexpr auto dense_tree_increasing_keys_delete_insert_pairs = 1000000;
@@ -204,6 +284,7 @@ void dense_tree_increasing_keys(benchmark::State &state) {
           unodb::value_view{unodb::benchmark::value100});
     }
 
+    state.PauseTiming();
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
@@ -231,16 +312,16 @@ void dense_insert_value_lengths(benchmark::State &state) {
           test_db, i,
           unodb::benchmark::values[static_cast<decltype(
               unodb::benchmark::values)::size_type>(state.range(1))]);
-    tree_size = test_db.get_current_memory_use();
 
+    state.PauseTiming();
+    tree_size = test_db.get_current_memory_use();
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
   // TODO(laurynas): use value lengths with SetBytesProcessed instead?
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
                           state.range(0));
-  state.counters["Size(k=1000)"] =
-      benchmark::Counter(static_cast<double>(tree_size));
+  set_size_counter(state, "size", tree_size);
 }
 
 void dense_insert_dup_attempts(benchmark::State &state) {
@@ -257,6 +338,7 @@ void dense_insert_dup_attempts(benchmark::State &state) {
       unodb::benchmark::insert_key_ignore_dups(
           test_db, i, unodb::value_view{unodb::benchmark::value100});
 
+    state.PauseTiming();
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
@@ -269,10 +351,10 @@ void dense_insert_dup_attempts(benchmark::State &state) {
 // TODO(laurynas): only dense Node256 trees have reasonable coverage, need
 // to handle sparse Node4/Node16/Node48 trees too
 BENCHMARK(dense_insert_mem_check)
-    ->Range(100, 50000000)
+    ->Range(100, 30000000)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(dense_insert_no_mem_check)
-    ->Range(100, 50000000)
+    ->Range(100, 30000000)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(sparse_insert_mem_check_dups_allowed)
     ->Range(100, 10000000)
@@ -280,20 +362,20 @@ BENCHMARK(sparse_insert_mem_check_dups_allowed)
 BENCHMARK(sparse_insert_no_mem_check_dups_allowed)
     ->Range(100, 10000000)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK(dense_full_scan)->Range(100, 50000000)->Unit(benchmark::kMicrosecond);
+BENCHMARK(dense_full_scan)->Range(100, 20000000)->Unit(benchmark::kMicrosecond);
 BENCHMARK(dense_tree_sparse_deletes)
     ->ArgNames({"", "deletes"})
     ->Apply(dense_tree_sparse_deletes_args)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(dense_tree_increasing_keys)
-    ->Range(100, 50000000)
+    ->Range(100, 30000000)
     ->Unit(benchmark::kMillisecond);
 BENCHMARK(dense_insert_value_lengths)
     ->ArgNames({"", "value len log10"})
     ->Apply(dense_insert_value_lengths_args)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(dense_insert_dup_attempts)
-    ->Range(100, 50000000)
+    ->Range(100, 30000000)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/micro_benchmark.hpp
+++ b/micro_benchmark.hpp
@@ -70,7 +70,7 @@ void delete_key_if_exists(Db &db, unodb::key k) {
 
 template <class Db>
 void destroy_tree(Db &db, ::benchmark::State &state) noexcept {
-  state.PauseTiming();
+  // Timer must be stopped on entry
   db.clear();
   ::benchmark::ClobberMemory();
   state.ResumeTiming();

--- a/micro_benchmark_mutex.cpp
+++ b/micro_benchmark_mutex.cpp
@@ -76,6 +76,7 @@ void parallel_insert_disjoint_ranges(benchmark::State &state) {
       threads[i].join();
     }
 
+    state.PauseTiming();
     unodb::benchmark::destroy_tree(*test_db, state);
   }
 
@@ -113,6 +114,7 @@ void parallel_delete_disjoint_ranges(benchmark::State &state) {
       threads[i].join();
     }
 
+    state.PauseTiming();
     unodb::benchmark::destroy_tree(*test_db, state);
   }
 
@@ -121,8 +123,7 @@ void parallel_delete_disjoint_ranges(benchmark::State &state) {
 
 // Something small for Travis CI quick checks
 constexpr auto small_tree_size = 70000;
-// Do not OOM on a 16GB Linux test server
-constexpr auto large_tree_size = 5000000;
+constexpr auto large_tree_size = 3000000;
 
 static void ranges(benchmark::internal::Benchmark *b, int max_concurrency) {
   for (auto i = 1; i <= max_concurrency; i *= 2) b->Args({i, small_tree_size});

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -12,14 +12,22 @@ namespace unodb {
 
 class mutex_db final {
  public:
+  // Creation and destruction
   explicit mutex_db(std::size_t memory_limit = 0) noexcept
       : db_{memory_limit} {}
 
+  // Querying
   [[nodiscard]] auto get(key k) const noexcept {
     const std::lock_guard guard{mutex};
     return db_.get(k);
   }
 
+  [[nodiscard]] auto empty() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.empty();
+  }
+
+  // Modifying
   [[nodiscard]] auto insert(key k, value_view v) {
     const std::lock_guard guard{mutex};
     return db_.insert(k, v);
@@ -35,19 +43,86 @@ class mutex_db final {
     db_.clear();
   }
 
-  void dump(std::ostream &os) const {
-    const std::lock_guard guard{mutex};
-    db_.dump(os);
-  }
-
-  [[nodiscard]] auto empty() const noexcept {
-    const std::lock_guard guard{mutex};
-    return db_.empty();
-  }
-
+  // Stats
   [[nodiscard]] auto get_current_memory_use() const noexcept {
     const std::lock_guard guard{mutex};
     return db_.get_current_memory_use();
+  }
+
+  [[nodiscard]] auto get_leaf_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_leaf_count();
+  }
+
+  [[nodiscard]] auto get_inode4_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode4_count();
+  }
+
+  [[nodiscard]] auto get_inode16_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode16_count();
+  }
+
+  [[nodiscard]] auto get_inode48_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode48_count();
+  }
+
+  [[nodiscard]] auto get_inode256_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode256_count();
+  }
+
+  [[nodiscard]] auto get_created_inode4_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_created_inode4_count();
+  }
+
+  [[nodiscard]] auto get_inode4_to_inode16_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode4_to_inode16_count();
+  }
+
+  [[nodiscard]] auto get_inode16_to_inode48_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode16_to_inode48_count();
+  }
+
+  [[nodiscard]] auto get_inode48_to_inode256_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode48_to_inode256_count();
+  }
+
+  [[nodiscard]] auto get_deleted_inode4_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_deleted_inode4_count();
+  }
+
+  [[nodiscard]] auto get_inode16_to_inode4_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode16_to_inode4_count();
+  }
+
+  [[nodiscard]] auto get_inode48_to_inode16_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode48_to_inode16_count();
+  }
+
+  [[nodiscard]] auto get_inode256_to_inode48_count() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_inode256_to_inode48_count();
+  }
+
+  [[nodiscard]] auto get_key_prefix_splits() const noexcept {
+    const std::lock_guard guard{mutex};
+    return db_.get_key_prefix_splits();
+  }
+
+  // Debugging
+  void dump(std::ostream &os) const {
+    const std::lock_guard guard{mutex};
+    db_.dump(os);
   }
 
  private:

--- a/test_art_mutex_concurrency.cpp
+++ b/test_art_mutex_concurrency.cpp
@@ -21,7 +21,7 @@ TEST(ARTMutexConcurrency, ParallelInsertOneTree) {
   constexpr auto num_of_threads = 4;
   constexpr auto total_keys = 1024;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.preinsert_key_range_to_verifier_only(0, total_keys);
   std::array<std::thread, num_of_threads> threads;
   unodb::key i = 0;
@@ -47,7 +47,7 @@ TEST(ARTMutexConcurrency, ParallelTearDownOneTree) {
   constexpr auto num_of_threads = 8;
   constexpr auto total_keys = 2048;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.insert_key_range(0, total_keys);
   unodb::key i = 0;
   std::array<std::thread, num_of_threads> threads;
@@ -85,7 +85,7 @@ TEST(ARTMutexConcurrency, Node4ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 6;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.insert_key_range(0, 3, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -100,7 +100,7 @@ TEST(ARTMutexConcurrency, Node16ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 12;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.insert_key_range(0, 10, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -115,7 +115,7 @@ TEST(ARTMutexConcurrency, Node48ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 32;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.insert_key_range(0, 32, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -130,7 +130,7 @@ TEST(ARTMutexConcurrency, Node256ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 208;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.insert_key_range(0, 152, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -167,7 +167,7 @@ TEST(ARTMutexConcurrency, ParallelRandomInsertDeleteGet) {
   constexpr auto initial_keys = 2048;
   constexpr auto ops_per_thread = 10000;
 
-  tree_verifier<unodb::mutex_db> verifier;
+  tree_verifier<unodb::mutex_db> verifier{0, true};
   verifier.insert_key_range(0, initial_keys, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {


### PR DESCRIPTION
Added counters for leaves, each individual node type, number of times leaf has
been converted to a Node4 with leaf, number of times a Node4 was created and
destroyed, each internal node type enlargement and shrinking occurrences, key
prefix splits.

Shuffle db and mutex_db class method declarations into sections for
organization.

Use the stats in the micro benchmarks, informing some bugfixes and tweaks there
on the way. Fix a bug where dense_tree_sparse_deletes generated random keys to
delete falling outside the tree key range by introducing a range limiter for
batched_random_key_source. Change that test to delete only the minimum and
maximum number of keys, as middle values give no extra new information. Use new
Google Benchmark kIs1024 flag to remove (k=1000) from the output. Make upper
tree limit size smaller as it gives no extra new information.

Use the stats in the tests, asserting that certain events have happened when
they should have. Fix a tree_verifier bug where a sequence of initial tree state
check, operation, eventual tree state check was racy and made no sense for
concurrent tests - by disabling it there.