### PR TITLE
Implement microbenchmarks for Node4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,20 +579,25 @@ endfunction()
 
 add_benchmark_target(micro_benchmark)
 set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
+add_benchmark_target(micro_benchmark_node4)
+set(micro_benchmark_node4_quick_arg "--benchmark_filter='/100'")
 add_benchmark_target(micro_benchmark_mutex)
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
 
 add_custom_target(benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex
-  DEPENDS micro_benchmark micro_benchmark_mutex)
+  DEPENDS micro_benchmark micro_benchmark_node4 micro_benchmark_mutex)
 
 add_custom_target(quick_benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
-  DEPENDS micro_benchmark micro_benchmark_mutex)
+  DEPENDS micro_benchmark micro_benchmark_node4 micro_benchmark_mutex)
 
 add_custom_target(valgrind
   valgrind --error-exitcode=1 --leak-check=full ./test_art;
@@ -600,6 +605,8 @@ add_custom_target(valgrind
   ./test_art_mutex_concurrency;
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark ${micro_benchmark_quick_arg};
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg};
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg};
   DEPENDS test_art test_art_mutex_concurrency micro_benchmark

--- a/micro_benchmark.cpp
+++ b/micro_benchmark.cpp
@@ -2,10 +2,7 @@
 
 #include "global.hpp"
 
-#include <limits>
-#include <random>
 #include <string>
-#include <vector>
 
 #include <benchmark/benchmark.h>
 
@@ -14,92 +11,8 @@
 
 namespace {
 
-class batched_random_key_source final {
- public:
-  batched_random_key_source(
-      unodb::key max_value = std::numeric_limits<unodb::key>::max())
-      : random_key_dist{0ULL, max_value} {
-    refill();
-  }
-
-  auto get(benchmark::State &state) {
-    if (random_key_ptr == random_keys.cend()) {
-      state.PauseTiming();
-      refill();
-      state.ResumeTiming();
-    }
-    return *(random_key_ptr++);
-  }
-
- private:
-  void refill() {
-    for (decltype(random_keys)::size_type i = 0; i < random_keys.size(); ++i)
-      random_keys[i] = random_key_dist(gen);
-    random_key_ptr = random_keys.cbegin();
-  }
-
-  static constexpr auto random_batch_size = 10000;
-
-  std::vector<unodb::key> random_keys{random_batch_size};
-  std::vector<unodb::key>::const_iterator random_key_ptr;
-
-  std::random_device rd;
-  std::mt19937 gen{rd()};
-  std::uniform_int_distribution<unodb::key> random_key_dist;
-};
-
-class growing_tree_node_stats final {
- public:
-  void get(const unodb::db &test_db) noexcept {
-    leaf_count = test_db.get_leaf_count();
-    inode4_count = test_db.get_inode4_count();
-    inode16_count = test_db.get_inode16_count();
-    inode48_count = test_db.get_inode48_count();
-    inode256_count = test_db.get_inode256_count();
-    created_inode4_count = test_db.get_created_inode4_count();
-    inode4_to_inode16_count = test_db.get_inode4_to_inode16_count();
-    inode16_to_inode48_count = test_db.get_inode16_to_inode48_count();
-    inode48_to_inode256_count = test_db.get_inode48_to_inode256_count();
-    key_prefix_splits = test_db.get_key_prefix_splits();
-  }
-
-  void publish(benchmark::State &state) const noexcept {
-    state.counters["L"] = static_cast<double>(leaf_count);
-    state.counters["4"] = static_cast<double>(inode4_count);
-    state.counters["16"] = static_cast<double>(inode16_count);
-    state.counters["48"] = static_cast<double>(inode48_count);
-    state.counters["256"] = static_cast<double>(inode256_count);
-    state.counters["+4"] = static_cast<double>(created_inode4_count);
-    state.counters["4^"] = static_cast<double>(inode4_to_inode16_count);
-    state.counters["16^"] = static_cast<double>(inode16_to_inode48_count);
-    state.counters["48^"] = static_cast<double>(inode48_to_inode256_count);
-    state.counters["KPfS"] = static_cast<double>(key_prefix_splits);
-  }
-
- private:
-  std::uint64_t leaf_count{0};
-  std::uint64_t inode4_count{0};
-  std::uint64_t inode16_count{0};
-  std::uint64_t inode48_count{0};
-  std::uint64_t inode256_count{0};
-  std::uint64_t created_inode4_count{0};
-  std::uint64_t inode4_to_inode16_count{0};
-  std::uint64_t inode16_to_inode48_count{0};
-  std::uint64_t inode48_to_inode256_count{0};
-  std::uint64_t key_prefix_splits{0};
-};
-
-void set_size_counter(benchmark::State &state, const std::string &label,
-                      std::size_t value) {
-  // state.SetLabel might be a better logical fit but the automatic k/M/G
-  // suffix is too nice
-  state.counters[label] = benchmark::Counter(
-      static_cast<double>(value), benchmark::Counter::Flags::kDefaults,
-      benchmark::Counter::OneK::kIs1024);
-}
-
 void dense_insert_no_mem_check(benchmark::State &state) {
-  growing_tree_node_stats growing_tree_stats;
+  unodb::benchmark::growing_tree_node_stats<unodb::db> growing_tree_stats;
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -116,7 +29,7 @@ void dense_insert_no_mem_check(benchmark::State &state) {
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
   growing_tree_stats.publish(state);
 }
@@ -139,14 +52,14 @@ void dense_insert_mem_check(benchmark::State &state) {
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
-  set_size_counter(state, "size", tree_size);
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
 }
 
 void sparse_insert_no_mem_check_dups_allowed(benchmark::State &state) {
-  batched_random_key_source random_keys;
-  growing_tree_node_stats growing_tree_stats;
+  unodb::benchmark::batched_prng random_keys;
+  unodb::benchmark::growing_tree_node_stats<unodb::db> growing_tree_stats;
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -165,13 +78,13 @@ void sparse_insert_no_mem_check_dups_allowed(benchmark::State &state) {
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
   growing_tree_stats.publish(state);
 }
 
 void sparse_insert_mem_check_dups_allowed(benchmark::State &state) {
-  batched_random_key_source random_keys;
+  unodb::benchmark::batched_prng random_keys;
   std::size_t tree_size = 0;
 
   for (auto _ : state) {
@@ -191,8 +104,8 @@ void sparse_insert_mem_check_dups_allowed(benchmark::State &state) {
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
-  set_size_counter(state, "size", tree_size);
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
 }
 
@@ -212,9 +125,9 @@ void dense_full_scan(benchmark::State &state) {
       for (unodb::key j = 0; j < key_limit; ++j)
         unodb::benchmark::get_existing_key(test_db, j);
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0) * full_scan_multiplier);
-  set_size_counter(state, "size", tree_size);
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
 }
 void dense_tree_sparse_deletes_args(benchmark::internal::Benchmark *b) {
   for (auto i = 1000; i <= 5000000; i *= 8) {
@@ -233,8 +146,8 @@ void dense_tree_sparse_deletes(benchmark::State &state) {
 
   for (auto _ : state) {
     state.PauseTiming();
-    batched_random_key_source random_keys{
-        static_cast<unodb::key>(state.range(0) - 1)};
+    unodb::benchmark::batched_prng random_keys{
+        static_cast<std::uint64_t>(state.range(0) - 1)};
     unodb::db test_db{1000ULL * 1000 * 1000 * 1000};
     for (unodb::key i = 0; i < static_cast<unodb::key>(state.range(0)); ++i)
       unodb::benchmark::insert_key(
@@ -252,10 +165,10 @@ void dense_tree_sparse_deletes(benchmark::State &state) {
     end_leaf_count = test_db.get_leaf_count();
   }
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(1));
-  set_size_counter(state, "start size", start_tree_size);
-  set_size_counter(state, "end size", end_tree_size);
+  unodb::benchmark::set_size_counter(state, "start size", start_tree_size);
+  unodb::benchmark::set_size_counter(state, "end size", end_tree_size);
   state.counters["start L"] = static_cast<double>(start_leaf_count);
   state.counters["end L"] = static_cast<double>(end_leaf_count);
 }
@@ -288,7 +201,7 @@ void dense_tree_increasing_keys(benchmark::State &state) {
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           dense_tree_increasing_keys_delete_insert_pairs * 2);
 }
 
@@ -319,9 +232,9 @@ void dense_insert_value_lengths(benchmark::State &state) {
   }
 
   // TODO(laurynas): use value lengths with SetBytesProcessed instead?
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
-  set_size_counter(state, "size", tree_size);
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
 }
 
 void dense_insert_dup_attempts(benchmark::State &state) {
@@ -342,14 +255,14 @@ void dense_insert_dup_attempts(benchmark::State &state) {
     unodb::benchmark::destroy_tree(test_db, state);
   }
 
-  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) *
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
 }
 
 }  // namespace
 
 // TODO(laurynas): only dense Node256 trees have reasonable coverage, need
-// to handle sparse Node4/Node16/Node48 trees too
+// to handle sparse Node16/Node48 trees too
 BENCHMARK(dense_insert_mem_check)
     ->Range(100, 30000000)
     ->Unit(benchmark::kMicrosecond);

--- a/micro_benchmark.hpp
+++ b/micro_benchmark.hpp
@@ -7,9 +7,14 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #ifndef NDEBUG
 #include <iostream>
 #endif
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
 
 #include <benchmark/benchmark.h>
 
@@ -23,10 +28,96 @@ constexpr auto value100 = std::array<std::byte, 100>{};
 constexpr auto value1000 = std::array<std::byte, 1000>{};
 constexpr auto value10000 = std::array<std::byte, 10000>{};
 
-constexpr std::array<unodb::value_view, 5> values = {
+inline constexpr std::array<unodb::value_view, 5> values = {
     unodb::value_view{value1}, unodb::value_view{value10},
     unodb::value_view{value100}, unodb::value_view{value1000},
     unodb::value_view{value10000}};
+
+class batched_prng final {
+  using result_type = std::uint64_t;
+
+ public:
+  batched_prng(result_type max_value = std::numeric_limits<result_type>::max())
+      : random_key_dist{0ULL, max_value} {
+    refill();
+  }
+
+  auto get(::benchmark::State &state) {
+    if (random_key_ptr == random_keys.cend()) {
+      state.PauseTiming();
+      refill();
+      state.ResumeTiming();
+    }
+    return *(random_key_ptr++);
+  }
+
+ private:
+  void refill() {
+    for (decltype(random_keys)::size_type i = 0; i < random_keys.size(); ++i)
+      random_keys[i] = random_key_dist(gen);
+    random_key_ptr = random_keys.cbegin();
+  }
+
+  static constexpr auto random_batch_size = 10000;
+
+  std::vector<result_type> random_keys{random_batch_size};
+  decltype(random_keys)::const_iterator random_key_ptr;
+
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+  std::uniform_int_distribution<result_type> random_key_dist;
+};
+
+template <class Db>
+class growing_tree_node_stats final {
+ public:
+  void get(const Db &test_db) noexcept {
+    leaf_count = test_db.get_leaf_count();
+    inode4_count = test_db.get_inode4_count();
+    inode16_count = test_db.get_inode16_count();
+    inode48_count = test_db.get_inode48_count();
+    inode256_count = test_db.get_inode256_count();
+    created_inode4_count = test_db.get_created_inode4_count();
+    inode4_to_inode16_count = test_db.get_inode4_to_inode16_count();
+    inode16_to_inode48_count = test_db.get_inode16_to_inode48_count();
+    inode48_to_inode256_count = test_db.get_inode48_to_inode256_count();
+    key_prefix_splits = test_db.get_key_prefix_splits();
+  }
+
+  void publish(::benchmark::State &state) const noexcept {
+    state.counters["L"] = static_cast<double>(leaf_count);
+    state.counters["4"] = static_cast<double>(inode4_count);
+    state.counters["16"] = static_cast<double>(inode16_count);
+    state.counters["48"] = static_cast<double>(inode48_count);
+    state.counters["256"] = static_cast<double>(inode256_count);
+    state.counters["+4"] = static_cast<double>(created_inode4_count);
+    state.counters["4^"] = static_cast<double>(inode4_to_inode16_count);
+    state.counters["16^"] = static_cast<double>(inode16_to_inode48_count);
+    state.counters["48^"] = static_cast<double>(inode48_to_inode256_count);
+    state.counters["KPfS"] = static_cast<double>(key_prefix_splits);
+  }
+
+ private:
+  std::uint64_t leaf_count{0};
+  std::uint64_t inode4_count{0};
+  std::uint64_t inode16_count{0};
+  std::uint64_t inode48_count{0};
+  std::uint64_t inode256_count{0};
+  std::uint64_t created_inode4_count{0};
+  std::uint64_t inode4_to_inode16_count{0};
+  std::uint64_t inode16_to_inode48_count{0};
+  std::uint64_t inode48_to_inode256_count{0};
+  std::uint64_t key_prefix_splits{0};
+};
+
+inline void set_size_counter(::benchmark::State &state,
+                             const std::string &label, std::size_t value) {
+  // state.SetLabel might be a better logical fit but the automatic k/M/G
+  // suffix is too nice
+  state.counters[label] = ::benchmark::Counter(
+      static_cast<double>(value), ::benchmark::Counter::Flags::kDefaults,
+      ::benchmark::Counter::OneK::kIs1024);
+}
 
 template <class Db>
 void insert_key(Db &db, unodb::key k, unodb::value_view v) {

--- a/micro_benchmark_node4.cpp
+++ b/micro_benchmark_node4.cpp
@@ -1,0 +1,217 @@
+// Copyright 2020 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+
+#include <benchmark/benchmark.h>
+
+#include "art.hpp"
+#include "art_common.hpp"
+#include "micro_benchmark.hpp"
+
+namespace {
+
+constexpr auto node4_key_zero_bits = 0xFCFCFCFC'FCFCFCFCULL;
+
+inline auto next_node4_key(unodb::key k) noexcept {
+  const auto result = ((k | node4_key_zero_bits) + 1) & ~node4_key_zero_bits;
+  assert(result > k);
+  return result;
+}
+
+inline auto number_to_node4_key(std::uint64_t i) noexcept {
+  const auto result = (i & 0x3) | ((i & 0xC) << (8 - 2)) |
+                      ((i & 0x30) << (16 - 4)) | ((i & 0xC0) << (24 - 6)) |
+                      ((i & 0x300) << (32 - 8)) | ((i & 0xC00) << (40 - 10)) |
+                      ((i & 0x3000) << (48 - 12)) |
+                      ((i & 0xC0000) << (56 - 14));
+  assert((result & node4_key_zero_bits) == 0);
+  return result;
+}
+
+void assert_node4_only_tree(const unodb::db &test_db USED_IN_DEBUG) noexcept {
+  assert(test_db.get_inode16_count() == 0);
+  assert(test_db.get_inode48_count() == 0);
+  assert(test_db.get_inode256_count() == 0);
+}
+
+void insert_sequentially(unodb::db &db, std::uint64_t number_of_keys) {
+  unodb::key insert_key = 0;
+  for (decltype(number_of_keys) i = 0; i < number_of_keys; ++i) {
+    unodb::benchmark::insert_key(db, insert_key,
+                                 unodb::value_view{unodb::benchmark::value100});
+    insert_key = next_node4_key(insert_key);
+  }
+  assert_node4_only_tree(db);
+}
+
+std::vector<unodb::key> generate_random_key_sequence(std::size_t count) {
+  std::vector<unodb::key> result;
+  result.reserve(count);
+
+  unodb::key insert_key = 0;
+  for (decltype(count) i = 0; i < count; ++i) {
+    result.push_back(insert_key);
+    insert_key = next_node4_key(insert_key);
+  }
+
+  return result;
+}
+
+void full_node4_sequential_insert(benchmark::State &state) {
+  unodb::benchmark::growing_tree_node_stats<unodb::db> growing_tree_stats;
+  std::size_t tree_size = 0;
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    unodb::db test_db{1000ULL * 1000 * 1000 * 1000};
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+
+    insert_sequentially(test_db, static_cast<std::uint64_t>(state.range(0)));
+
+    state.PauseTiming();
+    growing_tree_stats.get(test_db);
+    tree_size = test_db.get_current_memory_use();
+    unodb::benchmark::destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+  growing_tree_stats.publish(state);
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
+}
+
+void full_node4_random_insert(benchmark::State &state) {
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+
+  auto keys =
+      generate_random_key_sequence(static_cast<std::size_t>(state.range(0)));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::shuffle(keys.begin(), keys.end(), gen);
+    unodb::db test_db;
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+
+    for (const auto k : keys) {
+      unodb::benchmark::insert_key(
+          test_db, k, unodb::value_view{unodb::benchmark::value100});
+    }
+
+    state.PauseTiming();
+    assert_node4_only_tree(test_db);
+    unodb::benchmark::destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+}
+
+void node4_full_scan(benchmark::State &state) {
+  unodb::db test_db;
+  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+
+  insert_sequentially(test_db, number_of_keys);
+
+  for (auto _ : state) {
+    unodb::key k = 0;
+    for (std::uint64_t j = 0; j < number_of_keys; ++j) {
+      unodb::benchmark::get_existing_key(test_db, k);
+      k = next_node4_key(k);
+    }
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+}
+
+void node4_random_gets(benchmark::State &state) {
+  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+  unodb::benchmark::batched_prng random_key_positions{number_of_keys - 1};
+  unodb::db test_db;
+  insert_sequentially(test_db, number_of_keys);
+
+  for (auto _ : state) {
+    for (std::uint64_t i = 0; i < number_of_keys; ++i) {
+      const auto key_index = random_key_positions.get(state);
+      const auto key = number_to_node4_key(key_index);
+      unodb::benchmark::get_existing_key(test_db, key);
+    }
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()));
+}
+
+void full_node4_sequential_delete(benchmark::State &state) {
+  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    unodb::db test_db;
+    insert_sequentially(test_db, number_of_keys);
+    state.ResumeTiming();
+
+    unodb::key k = 0;
+    for (std::uint64_t j = 0; j < number_of_keys; ++j) {
+      unodb::benchmark::delete_key(test_db, k);
+      k = next_node4_key(k);
+    }
+
+    assert(test_db.empty());
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+}
+
+void full_node4_random_deletes(benchmark::State &state) {
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+
+  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+  auto keys = generate_random_key_sequence(number_of_keys);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    std::shuffle(keys.begin(), keys.end(), gen);
+    unodb::db test_db;
+    insert_sequentially(test_db, number_of_keys);
+    state.ResumeTiming();
+
+    for (const auto k : keys) {
+      unodb::benchmark::delete_key(test_db, k);
+    }
+
+    assert(test_db.empty());
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+}
+
+}  // namespace
+
+// A maximum Node4-only tree can hold 65K values
+BENCHMARK(full_node4_sequential_insert)
+    ->Range(100, 65535)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node4_random_insert)
+    ->Range(100, 65535)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(node4_full_scan)->Range(100, 65535)->Unit(benchmark::kMicrosecond);
+BENCHMARK(node4_random_gets)->Range(100, 65535)->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node4_sequential_delete)
+    ->Range(100, 65535)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node4_random_deletes)
+    ->Range(100, 65535)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
For that, refactor micro_benchmark.cpp:batched_random_key_source to a common
batched_prng, likewise move growing_tree_node_stats to a header.