### PR TITLE
Trade the ability to call db::insert during stack unwinding to fewer …

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1330,8 +1330,9 @@ class raii_leaf_creator {
   raii_leaf_creator(art_key k, unodb::value_view v, unodb::db &db_instance_)
       : leaf{leaf::create(k, v, db_instance_)},
         leaf_size{leaf::size(leaf.get())},
-        db_instance{db_instance_},
-        exceptions_at_ctor{std::uncaught_exceptions()} {}
+        db_instance{db_instance_} {
+    assert(std::uncaught_exceptions() == 0);
+  }
 
   raii_leaf_creator(const raii_leaf_creator &) = delete;
   raii_leaf_creator(raii_leaf_creator &&) = delete;
@@ -1342,7 +1343,7 @@ class raii_leaf_creator {
   ~raii_leaf_creator() noexcept {
     assert(get_called);
 
-    if (likely(exceptions_at_ctor == std::uncaught_exceptions())) return;
+    if (likely(std::uncaught_exceptions() == 0)) return;
     db_instance.decrease_memory_use(leaf_size);
 
     assert(db_instance.leaf_count > 0);
@@ -1362,7 +1363,6 @@ class raii_leaf_creator {
   leaf_unique_ptr leaf;
   const std::size_t leaf_size;
   unodb::db &db_instance;
-  const int exceptions_at_ctor;
 #ifndef NDEBUG
   bool get_called{false};
 #endif

--- a/art.hpp
+++ b/art.hpp
@@ -158,6 +158,7 @@ class db final {
   [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
 
   // Modifying
+  // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
   [[nodiscard]] bool insert(key k, value_view v);
 
   [[nodiscard]] bool remove(key k);


### PR DESCRIPTION
…std::uncaught_exceptions calls

std::uncaugt_exceptions() is expensive as it goes through TLS. Thus replace its
call in raii_leaf_creator constructor with the (asserted) assumption that it
always must be zero there, i.e. db::insert cannot be called during stack
unwinding with an active unhandled exception in flight.

Performance results:

Baseline:

$ perf stat -d ./micro_benchmark_node4
2020-06-01 06:18:06
Running ./micro_benchmark_node4
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.36, 0.62, 0.24
---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_insert/100         9.45 us         9.48 us        73812 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=10.5465M/s size=12.6289k
full_node4_sequential_insert/512         55.3 us         55.3 us        12599 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=9.26076M/s size=64.5156k
full_node4_sequential_insert/4096         484 us          484 us         1448 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=8.46393M/s size=515.984k
full_node4_sequential_insert/32768       4833 us         4833 us          145 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=6.77946M/s size=4.03127M
full_node4_sequential_insert/65535      10675 us        10675 us           66 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=6.13937M/s size=8.06238M
full_node4_random_insert/100             13.7 us         13.7 us        51130 items_per_second=7.30491M/s
full_node4_random_insert/512             71.5 us         71.5 us         9797 items_per_second=7.16024M/s
full_node4_random_insert/4096             638 us          638 us         1096 items_per_second=6.41818M/s
full_node4_random_insert/32768           6387 us         6387 us          108 items_per_second=5.13026M/s
full_node4_random_insert/65535          13946 us        13946 us           50 items_per_second=4.69922M/s
node4_full_scan/100                      3.23 us         3.23 us       216655 items_per_second=30.9387M/s
node4_full_scan/512                      27.4 us         27.4 us        25401 items_per_second=18.7015M/s
node4_full_scan/4096                      258 us          258 us         2720 items_per_second=15.9044M/s
node4_full_scan/32768                    2757 us         2757 us          254 items_per_second=11.8835M/s
node4_full_scan/65535                    5745 us         5745 us          122 items_per_second=11.408M/s
node4_random_gets/100                    58.7 us         59.0 us        11879 items_per_second=16.958k/s
node4_random_gets/512                     309 us          310 us         2257 items_per_second=3.22439k/s
node4_random_gets/4096                   2602 us         2611 us          268 items_per_second=382.96/s
node4_random_gets/32768                 22047 us        22123 us           32 items_per_second=45.2024/s
node4_random_gets/65535                 44098 us        44250 us           16 items_per_second=22.599/s
full_node4_sequential_delete/100         7.24 us         7.22 us        96540 items_per_second=13.8411M/s
full_node4_sequential_delete/512         37.9 us         37.9 us        18493 items_per_second=13.5201M/s
full_node4_sequential_delete/4096         344 us          344 us         2036 items_per_second=11.9139M/s
full_node4_sequential_delete/32768       3164 us         3164 us          221 items_per_second=10.355M/s
full_node4_sequential_delete/65535       6597 us         6597 us          106 items_per_second=9.93398M/s
full_node4_random_deletes/100            10.6 us         10.6 us        65811 items_per_second=9.40387M/s
full_node4_random_deletes/512            62.0 us         62.0 us        11305 items_per_second=8.26298M/s
full_node4_random_deletes/4096            606 us          606 us         1155 items_per_second=6.75409M/s
full_node4_random_deletes/32768          6911 us         6911 us          101 items_per_second=4.74152M/s
full_node4_random_deletes/65535         17830 us        17829 us           39 items_per_second=3.6757M/s

 Performance counter stats for './micro_benchmark_node4':

         45,522.21 msec task-clock                #    1.000 CPUs utilized
                85      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           344,533      page-faults               #    0.008 M/sec
   155,014,878,666      cycles                    #    3.405 GHz                      (33.33%)
    48,870,568,004      stalled-cycles-frontend   #   31.53% frontend cycles idle     (44.44%)
    33,867,321,531      stalled-cycles-backend    #   21.85% backend cycles idle      (44.45%)
   247,857,249,195      instructions              #    1.60  insn per cycle
                                                  #    0.20  stalled cycles per insn  (55.57%)
    58,229,502,539      branches                  # 1279.145 M/sec                    (55.57%)
       951,477,625      branch-misses             #    1.63% of all branches          (55.56%)
    67,011,493,628      L1-dcache-loads           # 1472.061 M/sec                    (55.53%)
     1,126,567,543      L1-dcache-load-misses     #    1.68% of all L1-dcache hits    (22.21%)
       288,333,689      LLC-loads                 #    6.334 M/sec                    (22.21%)
   <not supported>      LLC-load-misses

      45.540909739 seconds time elapsed

      40.618438000 seconds user
       4.904294000 seconds sys

With the change:

---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_insert/100         9.63 us         9.64 us        72505 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=10.3761M/s size=12.6289k
full_node4_sequential_insert/512         57.0 us         57.0 us        12210 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=8.98076M/s size=64.5156k
full_node4_sequential_insert/4096         499 us          499 us         1403 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=8.20199M/s size=515.984k
full_node4_sequential_insert/32768       4909 us         4909 us          143 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=6.67511M/s size=4.03127M
full_node4_sequential_insert/65535      10867 us        10867 us           64 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=6.03091M/s size=8.06238M
full_node4_random_insert/100             13.6 us         13.6 us        51325 items_per_second=7.32766M/s
full_node4_random_insert/512             71.2 us         71.2 us         9844 items_per_second=7.19223M/s
full_node4_random_insert/4096             632 us          632 us         1107 items_per_second=6.47934M/s
full_node4_random_insert/32768           6355 us         6355 us          111 items_per_second=5.15659M/s
full_node4_random_insert/65535          13858 us        13858 us           51 items_per_second=4.72897M/s
node4_full_scan/100                      3.32 us         3.32 us       209091 items_per_second=30.0799M/s
node4_full_scan/512                      27.9 us         27.9 us        25013 items_per_second=18.349M/s
node4_full_scan/4096                      253 us          253 us         2770 items_per_second=16.2179M/s
node4_full_scan/32768                    2826 us         2826 us          248 items_per_second=11.5955M/s
node4_full_scan/65535                    5858 us         5857 us          119 items_per_second=11.1883M/s
node4_random_gets/100                    59.1 us         59.2 us        11820 items_per_second=16.8839k/s
node4_random_gets/512                     311 us          311 us         2251 items_per_second=3.21432k/s
node4_random_gets/4096                   2608 us         2614 us          268 items_per_second=382.55/s
node4_random_gets/32768                 22055 us        22106 us           32 items_per_second=45.2376/s
node4_random_gets/65535                 44148 us        44245 us           16 items_per_second=22.6015/s
full_node4_sequential_delete/100         6.86 us         6.86 us       101792 items_per_second=14.568M/s
full_node4_sequential_delete/512         35.9 us         35.9 us        19478 items_per_second=14.2703M/s
full_node4_sequential_delete/4096         321 us          321 us         2184 items_per_second=12.7796M/s
full_node4_sequential_delete/32768       2927 us         2927 us          239 items_per_second=11.1943M/s
full_node4_sequential_delete/65535       6108 us         6107 us          115 items_per_second=10.7304M/s
full_node4_random_deletes/100            10.3 us         10.3 us        67933 items_per_second=9.7052M/s
full_node4_random_deletes/512            60.3 us         60.3 us        11615 items_per_second=8.49524M/s
full_node4_random_deletes/4096            594 us          594 us         1179 items_per_second=6.8944M/s
full_node4_random_deletes/32768          6742 us         6742 us          104 items_per_second=4.86005M/s
full_node4_random_deletes/65535         17485 us        17484 us           40 items_per_second=3.7482M/s

 Performance counter stats for './micro_benchmark_node4':

         45,894.98 msec task-clock                #    1.000 CPUs utilized
                81      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           345,181      page-faults               #    0.008 M/sec
   156,281,945,186      cycles                    #    3.405 GHz                      (33.33%)
    48,823,402,017      stalled-cycles-frontend   #   31.24% frontend cycles idle     (44.44%)
    34,306,591,676      stalled-cycles-backend    #   21.95% backend cycles idle      (44.44%)
   253,065,033,963      instructions              #    1.62  insn per cycle
                                                  #    0.19  stalled cycles per insn  (55.55%)
    59,117,174,210      branches                  # 1288.097 M/sec                    (55.56%)
       944,898,806      branch-misses             #    1.60% of all branches          (55.56%)
    67,197,753,834      L1-dcache-loads           # 1464.164 M/sec                    (55.54%)
     1,165,845,276      L1-dcache-load-misses     #    1.73% of all L1-dcache hits    (22.22%)
       290,511,423      LLC-loads                 #    6.330 M/sec                    (22.21%)
   <not supported>      LLC-load-misses

      45.913558563 seconds time elapsed

      41.038905000 seconds user
       4.856343000 seconds sys

Google Benchmark U-test (inserts only):

full_node4_sequential_insert/100_pvalue                   0.0006          0.0006      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/512_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/4096_pvalue                  0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/32768_pvalue                 0.0027          0.0027      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/65535_pvalue                 0.0134          0.0134      U Test, Repetitions: 9 vs 9
full_node4_random_insert/100_pvalue                       0.0521          0.0521      U Test, Repetitions: 9 vs 9
full_node4_random_insert/512_pvalue                       0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/4096_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/32768_pvalue                     0.0015          0.0015      U Test, Repetitions: 9 vs 9
full_node4_random_insert/65535_pvalue                     0.0637          0.0637      U Test, Repetitions: 9 vs 9