### PR TITLE
Annotate some cold functions as cold, noinline

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -226,7 +226,7 @@ class db final {
   }
 
   // Debugging
-  void dump(std::ostream &os) const;
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const;
 
  private:
   [[nodiscard]] static get_result get_from_subtree(


### PR DESCRIPTION
Add a couple missing noexcept at the same time.

Baseline performance:

2020-06-02 07:36:37
Running ./micro_benchmark_node4
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.47, 0.61, 0.22
---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_insert/100         9.68 us         9.69 us        72033 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=10.3203M/s size=12.6289k
full_node4_sequential_insert/512         57.5 us         57.5 us        12110 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=8.90942M/s size=64.5156k
full_node4_sequential_insert/4096         502 us          502 us         1394 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=8.15357M/s size=515.984k
full_node4_sequential_insert/32768       4947 us         4947 us          142 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=6.62404M/s size=4.03127M
full_node4_sequential_insert/65535      10926 us        10926 us           64 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=5.99797M/s size=8.06238M
full_node4_random_insert/100             13.8 us         13.8 us        50561 items_per_second=7.22649M/s
full_node4_random_insert/512             72.3 us         72.3 us         9687 items_per_second=7.07718M/s
full_node4_random_insert/4096             642 us          642 us         1091 items_per_second=6.38465M/s
full_node4_random_insert/32768           6424 us         6424 us          109 items_per_second=5.10082M/s
full_node4_random_insert/65535          13954 us        13953 us           49 items_per_second=4.69673M/s
node4_full_scan/100                      3.36 us         3.36 us       207702 items_per_second=29.7968M/s
node4_full_scan/512                      27.8 us         27.8 us        25019 items_per_second=18.4492M/s
node4_full_scan/4096                      254 us          254 us         2749 items_per_second=16.0977M/s
node4_full_scan/32768                    2820 us         2820 us          248 items_per_second=11.6201M/s
node4_full_scan/65535                    5855 us         5855 us          120 items_per_second=11.1938M/s
node4_random_gets/100                    59.1 us         59.1 us        11847 items_per_second=16.923k/s
node4_random_gets/512                     310 us          311 us         2254 items_per_second=3.2202k/s
node4_random_gets/4096                   2606 us         2607 us          268 items_per_second=383.51/s
node4_random_gets/32768                 22123 us        22149 us           32 items_per_second=45.1486/s
node4_random_gets/65535                 44315 us        44367 us           16 items_per_second=22.5392/s
full_node4_sequential_delete/100         6.98 us         6.98 us       100073 items_per_second=14.3298M/s
full_node4_sequential_delete/512         36.0 us         36.0 us        19454 items_per_second=14.2213M/s
full_node4_sequential_delete/4096         321 us          321 us         2182 items_per_second=12.7667M/s
full_node4_sequential_delete/32768       2924 us         2924 us          239 items_per_second=11.2049M/s
full_node4_sequential_delete/65535       6247 us         6247 us          112 items_per_second=10.4909M/s
full_node4_random_deletes/100            10.2 us         10.2 us        68808 items_per_second=9.83582M/s
full_node4_random_deletes/512            59.8 us         59.8 us        11695 items_per_second=8.55516M/s
full_node4_random_deletes/4096            592 us          592 us         1182 items_per_second=6.91823M/s
full_node4_random_deletes/32768          6729 us         6729 us          104 items_per_second=4.86999M/s
full_node4_random_deletes/65535         17513 us        17513 us           40 items_per_second=3.74197M/s

 Performance counter stats for './micro_benchmark_node4':

         45,541.88 msec task-clock                #    1.000 CPUs utilized
                50      context-switches          #    0.001 K/sec
                 1      cpu-migrations            #    0.000 K/sec
           419,824      page-faults               #    0.009 M/sec
   155,077,429,027      cycles                    #    3.405 GHz                      (33.34%)
    49,676,589,442      stalled-cycles-frontend   #   32.03% frontend cycles idle     (44.45%)
    34,953,438,848      stalled-cycles-backend    #   22.54% backend cycles idle      (44.45%)
   247,135,930,471      instructions              #    1.59  insn per cycle
                                                  #    0.20  stalled cycles per insn  (55.56%)
    57,790,586,901      branches                  # 1268.955 M/sec                    (55.56%)
       974,967,946      branch-misses             #    1.69% of all branches          (55.55%)
    65,663,377,018      L1-dcache-loads           # 1441.824 M/sec                    (55.53%)
     1,140,233,154      L1-dcache-load-misses     #    1.74% of all L1-dcache hits    (22.22%)
       286,903,073      LLC-loads                 #    6.300 M/sec                    (22.22%)
   <not supported>      LLC-load-misses

      45.560079141 seconds time elapsed

      40.674068000 seconds user
       4.868247000 seconds sys

With the commit:

---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_insert/100         9.45 us         9.46 us        73876 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=10.5764M/s size=12.6289k
full_node4_sequential_insert/512         56.9 us         56.9 us        12301 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=8.99188M/s size=64.5156k
full_node4_sequential_insert/4096         500 us          500 us         1395 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=8.19655M/s size=515.984k
full_node4_sequential_insert/32768       4937 us         4937 us          142 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=6.63726M/s size=4.03127M
full_node4_sequential_insert/65535      10942 us        10942 us           64 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=5.98921M/s size=8.06238M
full_node4_random_insert/100             13.7 us         13.7 us        51093 items_per_second=7.29848M/s
full_node4_random_insert/512             71.8 us         71.8 us         9769 items_per_second=7.12765M/s
full_node4_random_insert/4096             637 us          637 us         1098 items_per_second=6.42677M/s
full_node4_random_insert/32768           6341 us         6340 us          112 items_per_second=5.16825M/s
full_node4_random_insert/65535          13840 us        13839 us           50 items_per_second=4.73544M/s
node4_full_scan/100                      3.36 us         3.36 us       206265 items_per_second=29.7357M/s
node4_full_scan/512                      27.7 us         27.7 us        25112 items_per_second=18.4839M/s
node4_full_scan/4096                      253 us          253 us         2762 items_per_second=16.1748M/s
node4_full_scan/32768                    2819 us         2819 us          248 items_per_second=11.6251M/s
node4_full_scan/65535                    5841 us         5841 us          120 items_per_second=11.2202M/s
node4_random_gets/100                    58.8 us         58.9 us        11890 items_per_second=16.9837k/s
node4_random_gets/512                     309 us          309 us         2264 items_per_second=3.23308k/s
node4_random_gets/4096                   2596 us         2600 us          269 items_per_second=384.661/s
node4_random_gets/32768                 21981 us        21999 us           32 items_per_second=45.4556/s
node4_random_gets/65535                 44036 us        44067 us           16 items_per_second=22.6926/s
full_node4_sequential_delete/100         6.85 us         6.84 us       102188 items_per_second=14.6115M/s
full_node4_sequential_delete/512         35.7 us         35.7 us        19580 items_per_second=14.3293M/s
full_node4_sequential_delete/4096         321 us          321 us         2177 items_per_second=12.7472M/s
full_node4_sequential_delete/32768       2922 us         2922 us          239 items_per_second=11.2143M/s
full_node4_sequential_delete/65535       6194 us         6194 us          113 items_per_second=10.5803M/s
full_node4_random_deletes/100            10.1 us         10.1 us        69366 items_per_second=9.90677M/s
full_node4_random_deletes/512            59.3 us         59.3 us        11801 items_per_second=8.6329M/s
full_node4_random_deletes/4096            585 us          585 us         1196 items_per_second=7.00261M/s
full_node4_random_deletes/32768          6673 us         6673 us          105 items_per_second=4.91046M/s
full_node4_random_deletes/65535         17321 us        17320 us           40 items_per_second=3.78372M/s

 Performance counter stats for './micro_benchmark_node4':

         45,302.99 msec task-clock                #    1.000 CPUs utilized
                95      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           325,188      page-faults               #    0.007 M/sec
   154,270,698,083      cycles                    #    3.405 GHz                      (33.33%)
    48,476,776,768      stalled-cycles-frontend   #   31.42% frontend cycles idle     (44.45%)
    34,150,928,084      stalled-cycles-backend    #   22.14% backend cycles idle      (44.46%)
   248,740,053,345      instructions              #    1.61  insn per cycle
                                                  #    0.19  stalled cycles per insn  (55.57%)
    58,123,840,669      branches                  # 1283.002 M/sec                    (55.57%)
       943,600,307      branch-misses             #    1.62% of all branches          (55.56%)
    66,039,191,356      L1-dcache-loads           # 1457.722 M/sec                    (55.53%)
     1,147,775,936      L1-dcache-load-misses     #    1.74% of all L1-dcache hits    (22.21%)
       286,816,406      LLC-loads                 #    6.331 M/sec                    (22.21%)
   <not supported>      LLC-load-misses

      45.321803994 seconds time elapsed

      40.387146000 seconds user
       4.916382000 seconds sys