### PR TITLE
Replace tree operation recursion with looping

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -153,15 +153,15 @@ class db final {
   ~db() noexcept;
 
   // Querying
-  [[nodiscard]] get_result get(key k) const noexcept;
+  [[nodiscard]] get_result get(key search_key) const noexcept;
 
   [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
 
   // Modifying
   // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
-  [[nodiscard]] bool insert(key k, value_view v);
+  [[nodiscard]] bool insert(key insert_key, value_view v);
 
-  [[nodiscard]] bool remove(key k);
+  [[nodiscard]] bool remove(key remove_key);
 
   void clear();
 
@@ -229,18 +229,6 @@ class db final {
   __attribute__((cold, noinline)) void dump(std::ostream &os) const;
 
  private:
-  [[nodiscard]] static get_result get_from_subtree(
-      detail::node_ptr node, detail::art_key k,
-      detail::tree_depth depth) noexcept;
-
-  [[nodiscard]] bool insert_to_subtree(detail::art_key k,
-                                       detail::node_ptr &node, value_view v,
-                                       detail::tree_depth depth);
-
-  [[nodiscard]] bool remove_from_subtree(detail::art_key k,
-                                         detail::tree_depth depth,
-                                         detail::node_ptr &node);
-
   void increase_memory_use(std::size_t delta);
   void decrease_memory_use(std::size_t delta) noexcept;
 


### PR DESCRIPTION
It compiles to a much more straightforward code.

Performance before:

2020-06-06 16:45:54
Running ./micro_benchmark_node4
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.08, 0.23, 0.12
---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_insert/100         9.18 us         9.20 us        76138 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=10.873M/s size=12.6289k
full_node4_sequential_insert/512         47.4 us         47.4 us        14782 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=10.7993M/s size=64.5156k
full_node4_sequential_insert/4096         414 us          414 us         1694 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=9.90083M/s size=515.984k
full_node4_sequential_insert/32768       4427 us         4427 us          158 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=7.40254M/s size=4.03127M
full_node4_sequential_insert/65535       9877 us         9877 us           71 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=6.63524M/s size=8.06238M
full_node4_random_insert/100             12.3 us         12.3 us        56997 items_per_second=8.14271M/s
full_node4_random_insert/512             61.1 us         61.1 us        11457 items_per_second=8.38299M/s
full_node4_random_insert/4096             515 us          515 us         1358 items_per_second=7.94814M/s
full_node4_random_insert/32768           5236 us         5236 us          133 items_per_second=6.25867M/s
full_node4_random_insert/65535          11402 us        11401 us           62 items_per_second=5.74808M/s
node4_full_scan/100                      3.60 us         3.60 us       194613 items_per_second=27.78M/s
node4_full_scan/512                      20.9 us         20.9 us        33436 items_per_second=24.4566M/s
node4_full_scan/4096                      199 us          199 us         3522 items_per_second=20.6068M/s
node4_full_scan/32768                    1982 us         1982 us          353 items_per_second=16.5298M/s
node4_full_scan/65535                    4197 us         4197 us          167 items_per_second=15.6136M/s
node4_random_gets/100                    57.0 us         57.3 us        12225 items_per_second=17.4651k/s
node4_random_gets/512                     298 us          298 us         2349 items_per_second=3.35395k/s
node4_random_gets/4096                   2470 us         2480 us          282 items_per_second=403.248/s
node4_random_gets/32768                 20863 us        20930 us           33 items_per_second=47.7793/s
node4_random_gets/65535                 41789 us        41904 us           17 items_per_second=23.8642/s
full_node4_sequential_delete/100         7.06 us         7.06 us        98829 items_per_second=14.172M/s
full_node4_sequential_delete/512         36.5 us         36.5 us        19175 items_per_second=14.0347M/s
full_node4_sequential_delete/4096         337 us          337 us         2076 items_per_second=12.1475M/s
full_node4_sequential_delete/32768       3133 us         3133 us          223 items_per_second=10.46M/s
full_node4_sequential_delete/65535       6583 us         6583 us          106 items_per_second=9.95571M/s
full_node4_random_deletes/100            9.01 us         9.00 us        77741 items_per_second=11.1069M/s
full_node4_random_deletes/512            49.5 us         49.5 us        14148 items_per_second=10.341M/s
full_node4_random_deletes/4096            478 us          478 us         1464 items_per_second=8.56583M/s
full_node4_random_deletes/32768          5682 us         5682 us          123 items_per_second=5.76707M/s
full_node4_random_deletes/65535         15208 us        15207 us           46 items_per_second=4.30958M/s

 Performance counter stats for './micro_benchmark_node4':

         48,127.68 msec task-clock                #    1.000 CPUs utilized
                78      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           398,254      page-faults               #    0.008 M/sec
   163,893,739,425      cycles                    #    3.405 GHz                      (33.33%)
    58,998,734,715      stalled-cycles-frontend   #   36.00% frontend cycles idle     (44.44%)
    30,351,524,752      stalled-cycles-backend    #   18.52% backend cycles idle      (44.44%)
   296,346,204,942      instructions              #    1.81  insn per cycle
                                                  #    0.20  stalled cycles per insn  (55.55%)
    60,017,273,157      branches                  # 1247.043 M/sec                    (55.56%)
       340,722,655      branch-misses             #    0.57% of all branches          (55.56%)
    75,498,948,038      L1-dcache-loads           # 1568.722 M/sec                    (55.54%)
     1,362,465,206      L1-dcache-load-misses     #    1.80% of all L1-dcache hits    (22.22%)
       338,384,812      LLC-loads                 #    7.031 M/sec                    (22.21%)
   <not supported>      LLC-load-misses

      48.146022012 seconds time elapsed

      43.067671000 seconds user
       5.060431000 seconds sys

After:

2020-06-07 07:21:37
Running ./micro_benchmark_node4
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.66, 0.47, 0.18
---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_insert/100         8.68 us         8.70 us        79781 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=11.4879M/s size=12.6289k
full_node4_sequential_insert/512         43.3 us         43.3 us        16100 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=11.8279M/s size=64.5156k
full_node4_sequential_insert/4096         371 us          371 us         1890 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=11.0515M/s size=515.984k
full_node4_sequential_insert/32768       3995 us         3994 us          176 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=8.20344M/s size=4.03127M
full_node4_sequential_insert/65535       9005 us         9004 us           78 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=7.2786M/s size=8.06238M
full_node4_random_insert/100             11.2 us         11.2 us        62202 items_per_second=8.89216M/s
full_node4_random_insert/512             54.6 us         54.6 us        12802 items_per_second=9.37551M/s
full_node4_random_insert/4096             457 us          457 us         1526 items_per_second=8.95304M/s
full_node4_random_insert/32768           4651 us         4651 us          150 items_per_second=7.04577M/s
full_node4_random_insert/65535          10466 us        10465 us           68 items_per_second=6.26218M/s
node4_full_scan/100                      2.77 us         2.77 us       252654 items_per_second=36.0932M/s
node4_full_scan/512                      17.7 us         17.7 us        39524 items_per_second=28.9126M/s
node4_full_scan/4096                      169 us          169 us         4133 items_per_second=24.1917M/s
node4_full_scan/32768                    1787 us         1787 us          325 items_per_second=18.3371M/s
node4_full_scan/65535                    4080 us         4080 us          158 items_per_second=16.0643M/s
node4_random_gets/100                    57.4 us         57.5 us        12168 items_per_second=17.387k/s
node4_random_gets/512                     299 us          300 us         2332 items_per_second=3.33649k/s
node4_random_gets/4096                   2483 us         2486 us          282 items_per_second=402.281/s
node4_random_gets/32768                 20958 us        20980 us           33 items_per_second=47.6647/s
node4_random_gets/65535                 41943 us        41976 us           17 items_per_second=23.823/s
full_node4_sequential_delete/100         6.81 us         6.81 us       102918 items_per_second=14.6907M/s
full_node4_sequential_delete/512         35.3 us         35.3 us        19776 items_per_second=14.4838M/s
full_node4_sequential_delete/4096         322 us          322 us         2177 items_per_second=12.7374M/s
full_node4_sequential_delete/32768       2911 us         2911 us          240 items_per_second=11.2558M/s
full_node4_sequential_delete/65535       6183 us         6184 us          113 items_per_second=10.5981M/s
full_node4_random_deletes/100            8.46 us         8.46 us        82694 items_per_second=11.8143M/s
full_node4_random_deletes/512            45.4 us         45.4 us        15435 items_per_second=11.2827M/s
full_node4_random_deletes/4096            431 us          431 us         1624 items_per_second=9.50855M/s
full_node4_random_deletes/32768          5008 us         5008 us          140 items_per_second=6.54293M/s
full_node4_random_deletes/65535         13574 us        13574 us           51 items_per_second=4.82784M/s

 Performance counter stats for './micro_benchmark_node4':

         48,913.56 msec task-clock                #    1.000 CPUs utilized
               193      context-switches          #    0.004 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           502,117      page-faults               #    0.010 M/sec
   166,571,887,353      cycles                    #    3.405 GHz                      (33.32%)
    66,569,852,221      stalled-cycles-frontend   #   39.96% frontend cycles idle     (44.44%)
    35,466,479,375      stalled-cycles-backend    #   21.29% backend cycles idle      (44.45%)
   278,017,209,530      instructions              #    1.67  insn per cycle
                                                  #    0.24  stalled cycles per insn  (55.56%)
    58,400,732,738      branches                  # 1193.958 M/sec                    (55.57%)
       428,433,689      branch-misses             #    0.73% of all branches          (55.57%)
    67,333,835,214      L1-dcache-loads           # 1376.588 M/sec                    (55.54%)
     1,557,377,458      L1-dcache-load-misses     #    2.31% of all L1-dcache hits    (22.22%)
       410,607,892      LLC-loads                 #    8.395 M/sec                    (22.21%)
   <not supported>      LLC-load-misses

      48.933183728 seconds time elapsed

      43.626075000 seconds user
       5.288251000 seconds sys