### PR TITLE
Add key_prefix::get_shared_length benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ else()
   message(STATUS
     "cppcheck found: ${CPPCHECK_EXE}, --version: ${CPPCHECK_VERSION_OUTPUT}")
   set(DO_CPPCHECK "${CPPCHECK_EXE}" "--enable=warning,style,performance,portability"
-    "--error-exitcode=2" "-D__x86_64")
+    "--error-exitcode=2" "-D__x86_64" "--inline-suppr")
   list(APPEND DO_CPPCHECK "${CPPCHECK_CHECKS}")
 endif()
 
@@ -577,37 +577,46 @@ function(ADD_BENCHMARK_TARGET TARGET)
   target_link_libraries("${TARGET}" PRIVATE unodb)
 endfunction()
 
-add_benchmark_target(micro_benchmark)
-set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
+add_benchmark_target(micro_benchmark_key_prefix)
+set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
 add_benchmark_target(micro_benchmark_node4)
 set(micro_benchmark_node4_quick_arg "--benchmark_filter='/100'")
+add_benchmark_target(micro_benchmark)
+set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 add_benchmark_target(micro_benchmark_mutex)
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
 
 add_custom_target(benchmarks
-  env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
+  env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_key_prefix
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex
-  DEPENDS micro_benchmark micro_benchmark_node4 micro_benchmark_mutex)
+  DEPENDS micro_benchmark_key_prefix micro_benchmark_node4 micro_benchmark
+  micro_benchmark_mutex)
 
 add_custom_target(quick_benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark ${micro_benchmark_quick_arg}
+  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark ${micro_benchmark_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
-  DEPENDS micro_benchmark micro_benchmark_node4 micro_benchmark_mutex)
+  DEPENDS micro_benchmark_key_prefix micro_benchmark micro_benchmark_node4
+  micro_benchmark_mutex)
 
 add_custom_target(valgrind
-  valgrind --error-exitcode=1 --leak-check=full ./test_art;
+  COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_art;
   COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./test_art_mutex_concurrency;
+  ./test_art_mutex_concurrency
   COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark ${micro_benchmark_quick_arg};
+  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg};
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg};
   COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark ${micro_benchmark_quick_arg};
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg};
-  DEPENDS test_art test_art_mutex_concurrency micro_benchmark
-  micro_benchmark_mutex)
+  DEPENDS test_art test_art_mutex_concurrency micro_benchmark_key_prefix
+  micro_benchmark_node4 micro_benchmark micro_benchmark_mutex)

--- a/micro_benchmark.hpp
+++ b/micro_benchmark.hpp
@@ -147,6 +147,11 @@ void get_existing_key(const Db &db, unodb::key k) {
 }
 
 template <class Db>
+void get_key(const Db &db, unodb::key k) {
+  static_cast<void>(db.get(k));
+}
+
+template <class Db>
 void delete_key(Db &db, unodb::key k) {
   const auto result USED_IN_DEBUG = db.remove(k);
   assert(result);

--- a/micro_benchmark_key_prefix.cpp
+++ b/micro_benchmark_key_prefix.cpp
@@ -1,0 +1,102 @@
+// Copyright 2020 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+
+#include <benchmark/benchmark.h>
+
+#include "art.hpp"
+#include "art_common.hpp"
+#include "micro_benchmark.hpp"
+
+/*
+
+Make get_shared_length too hard for the CPU branch predictor:
+
+I16 root keys:
+0x0
+ I4 0x0 0x0 0x0 0x0 0x0 - prefix, keys:
+                        0x0
+                          L 0x0
+                        0x1
+                          L 0x0
+0x1
+ I4 0x0 0x0 0x0 0x0 - prefix, keys:
+                    0x0
+                      L 0x0 0x0
+                    0x1
+                      L 0x0 0x0
+...
+0x4
+ I4 0x0 - prefix, keys:
+        0x0
+          L 0x0 0x0 0x0 0x0 0x0
+        0x1
+          L 0x0 0x0 0x0 0x0 0x0
+0x5
+I4 keys:
+    0x0
+      L 0x0 0x0 0x0 0x0 0x0 0x0
+    0x1
+      L 0x0 0x0 0x0 0x0 0x0 0x0
+
+Keys to be inserted:    Additional key prefix mismatch keys:
+0x0000000000000000      0x0000000000100000
+0x0000000000000100      0x0001000000000000
+0x0100000000000000      0x0100000010000000
+0x0100000000010000      0x0101000000000000
+...
+0x0400000000000000      0x0401000000000000
+0x0400010000000000
+0x0500000000000000
+0x0501000000000000
+ */
+
+namespace {
+
+// cppcheck-suppress constParameter
+void unpredictable_get_shared_length(benchmark::State &state) {
+  std::vector<unodb::key> search_keys{};
+  search_keys.reserve(7 * 2 + 7 * 2 - 3);
+  unodb::db db;
+  for (std::uint8_t top_byte = 0x00; top_byte <= 0x05; ++top_byte) {
+    const std::uint64_t first_key = static_cast<std::uint64_t>(top_byte) << 56;
+    const std::uint64_t second_key = first_key | (1ULL << ((top_byte + 1) * 8));
+    unodb::benchmark::insert_key(db, first_key,
+                                 unodb::value_view{unodb::benchmark::value100});
+    unodb::benchmark::insert_key(db, second_key,
+                                 unodb::value_view{unodb::benchmark::value100});
+    search_keys.push_back(first_key);
+    search_keys.push_back(second_key);
+    if (top_byte > 4) continue;
+    const std::uint64_t first_not_found_key =
+        first_key | (1ULL << ((top_byte + 2) * 8));
+    search_keys.push_back(first_not_found_key);
+
+    if (top_byte > 3) continue;
+    const std::uint64_t second_not_found_key = first_key | (1ULL << 48);
+    search_keys.push_back(second_not_found_key);
+  }
+
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+  std::shuffle(search_keys.begin(), search_keys.end(), gen);
+
+  for (auto _ : state) {
+    for (const auto k : search_keys) {
+      unodb::benchmark::get_key(db, k);
+    }
+  }
+
+  state.SetItemsProcessed(
+      static_cast<std::int64_t>(state.iterations() * search_keys.size()));
+}
+
+}  // namespace
+
+BENCHMARK(unpredictable_get_shared_length)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
In other benchmarks, due to tree shape, the key prefix is usually zero- or
one-length, too easy for the CPU branch predictor to predict. Add one benchmark
where key_prefix::get_shared_length loop has an unpredictable number of
iterations.