### PR TITLE
Make key_prefix::get_shared_length branchless

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -56,6 +56,8 @@ struct basic_art_key final {
     return (reinterpret_cast<const std::byte *>(&key))[index];
   }
 
+  [[nodiscard]] explicit operator KeyType() const noexcept { return key; }
+
   KeyType key;
 
   static constexpr auto size = sizeof(KeyType);


### PR DESCRIPTION
Use own inline assembly instead of __builtin_ffs in order to remove redundant
CMOVE out of BSF/CMOVE pair. This will be redundant with GCC 11 and/or on
TZCNT-supporting architectures.

Performance of micro_benchmark_key_prefix: baseline:

2020-06-13 09:38:29
Running ./micro_benchmark_key_prefix
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.00, 0.02, 0.02
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
unpredictable_get_shared_length      0.949 us        0.949 us       737605 items_per_second=22.1218M/s

 Performance counter stats for './micro_benchmark_key_prefix':

          1,538.31 msec task-clock                #    0.988 CPUs utilized
                 2      context-switches          #    0.001 K/sec
                 0      cpu-migrations            #    0.000 K/sec
               150      page-faults               #    0.098 K/sec
     5,237,746,859      cycles                    #    3.405 GHz                      (83.36%)
     2,829,300,464      stalled-cycles-frontend   #   54.02% frontend cycles idle     (83.36%)
     2,090,210,528      stalled-cycles-backend    #   39.91% backend cycles idle      (66.72%)
     3,750,534,408      instructions              #    0.72  insn per cycle
                                                  #    0.75  stalled cycles per insn  (83.36%)
       687,619,152      branches                  #  446.995 M/sec                    (83.36%)
        24,172,616      branch-misses             #    3.52% of all branches          (83.21%)

       1.557020749 seconds time elapsed

       1.057789000 seconds user
       0.480813000 seconds sys

With the change:

unpredictable_get_shared_length      0.849 us        0.850 us       823508 items_per_second=24.7076M/s

 Performance counter stats for './micro_benchmark_key_prefix':

          1,596.06 msec task-clock                #    0.989 CPUs utilized
                 2      context-switches          #    0.001 K/sec
                 0      cpu-migrations            #    0.000 K/sec
               146      page-faults               #    0.091 K/sec
     5,434,776,483      cycles                    #    3.405 GHz                      (83.21%)
     3,055,675,294      stalled-cycles-frontend   #   56.22% frontend cycles idle     (83.21%)
     2,073,259,164      stalled-cycles-backend    #   38.15% backend cycles idle      (66.92%)
     4,194,278,487      instructions              #    0.77  insn per cycle
                                                  #    0.73  stalled cycles per insn  (83.46%)
       689,404,657      branches                  #  431.942 M/sec                    (83.46%)
        16,659,388      branch-misses             #    2.42% of all branches          (83.20%)

       1.614440806 seconds time elapsed

       1.135083000 seconds user
       0.461253000 seconds sys

Cachegrind with branch prediction simulation: baseline:

unpredictable_get_shared_length       14.1 us         14.2 us        49447 items_per_second=1.48367M/s
==833590==
==833590== I   refs:      172,216,844
==833590== I1  misses:          8,228
==833590== LLi misses:          4,039
==833590== I1  miss rate:        0.00%
==833590== LLi miss rate:        0.00%
==833590==
==833590== D   refs:       54,744,658  (38,850,773 rd   + 15,893,885 wr)
==833590== D1  misses:         21,665  (    18,524 rd   +      3,141 wr)
==833590== LLd misses:         11,164  (     9,176 rd   +      1,988 wr)
==833590== D1  miss rate:         0.0% (       0.0%     +        0.0%  )
==833590== LLd miss rate:         0.0% (       0.0%     +        0.0%  )
==833590==
==833590== LL refs:            29,893  (    26,752 rd   +      3,141 wr)
==833590== LL misses:          15,203  (    13,215 rd   +      1,988 wr)
==833590== LL miss rate:          0.0% (       0.0%     +        0.0%  )
==833590==
==833590== Branches:       26,805,998  (26,421,305 cond +    384,693 ind)
==833590== Mispredicts:     1,888,051  ( 1,639,976 cond +    248,075 ind)
==833590== Mispred rate:          7.0% (       6.2%     +       64.5%   )

With the change:

unpredictable_get_shared_length       13.1 us         13.2 us        53058 items_per_second=1.59182M/s
==834387==
==834387== I   refs:      186,766,320
==834387== I1  misses:          7,925
==834387== LLi misses:          3,986
==834387== I1  miss rate:        0.00%
==834387== LLi miss rate:        0.00%
==834387==
==834387== D   refs:       59,994,244  (43,493,204 rd   + 16,501,040 wr)
==834387== D1  misses:         21,664  (    18,525 rd   +      3,139 wr)
==834387== LLd misses:         11,164  (     9,175 rd   +      1,989 wr)
==834387== D1  miss rate:         0.0% (       0.0%     +        0.0%  )
==834387== LLd miss rate:         0.0% (       0.0%     +        0.0%  )
==834387==
==834387== LL refs:            29,589  (    26,450 rd   +      3,139 wr)
==834387== LL misses:          15,150  (    13,161 rd   +      1,989 wr)
==834387== LL miss rate:          0.0% (       0.0%     +        0.0%  )
==834387==
==834387== Branches:       23,195,601  (22,789,254 cond +    406,347 ind)
==834387== Mispredicts:     1,118,359  (   855,970 cond +    262,389 ind)
==834387== Mispred rate:          4.8% (       3.8%     +       64.6%   )

The other benchmarks regress because they all have key prefix lengths of zero,
which get well-predicted through a shorter instruction sequence.

micro_benchmark_node4 baseline:

full_node4_sequential_insert/100         8.89 us         8.91 us        78700 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=11.2293M/s size=12.6289k
full_node4_sequential_insert/512         46.0 us         46.1 us        15209 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=11.1153M/s size=64.5156k
full_node4_sequential_insert/4096         388 us          388 us         1805 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=10.5513M/s size=515.984k
full_node4_sequential_insert/32768       4072 us         4072 us          172 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=8.04753M/s size=4.03127M
full_node4_sequential_insert/65535       9095 us         9095 us           77 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=7.20574M/s size=8.06238M
full_node4_random_insert/100             11.9 us         11.9 us        58877 items_per_second=8.40695M/s
full_node4_random_insert/512             57.2 us         57.2 us        12204 items_per_second=8.94932M/s
full_node4_random_insert/4096             472 us          472 us         1483 items_per_second=8.67693M/s
full_node4_random_insert/32768           4725 us         4725 us          148 items_per_second=6.93473M/s
full_node4_random_insert/65535          10353 us        10353 us           68 items_per_second=6.33032M/s
node4_full_scan/100                      2.76 us         2.76 us       253656 items_per_second=36.2369M/s
node4_full_scan/512                      17.8 us         17.8 us        39329 items_per_second=28.7648M/s
node4_full_scan/4096                      170 us          170 us         4123 items_per_second=24.1233M/s
node4_full_scan/32768                    1787 us         1787 us          392 items_per_second=18.3356M/s
node4_full_scan/65535                    3783 us         3783 us          185 items_per_second=17.3255M/s
node4_random_gets/100                    57.1 us         57.3 us        12232 items_per_second=17.4612k/s
node4_random_gets/512                     298 us          299 us         2344 items_per_second=3.34803k/s
node4_random_gets/4096                   2467 us         2474 us          283 items_per_second=404.156/s
node4_random_gets/32768                 20843 us        20911 us           33 items_per_second=47.8214/s
node4_random_gets/65535                 41769 us        41874 us           17 items_per_second=23.8814/s
full_node4_sequential_delete/100         6.77 us         6.77 us       103114 items_per_second=14.7792M/s
full_node4_sequential_delete/512         34.9 us         34.9 us        20064 items_per_second=14.6842M/s
full_node4_sequential_delete/4096         319 us          319 us         2198 items_per_second=12.8583M/s
full_node4_sequential_delete/32768       2882 us         2881 us          243 items_per_second=11.372M/s
full_node4_sequential_delete/65535       6055 us         6055 us          116 items_per_second=10.8233M/s
full_node4_random_deletes/100            8.66 us         8.65 us        80909 items_per_second=11.5598M/s
full_node4_random_deletes/512            46.3 us         46.3 us        15138 items_per_second=11.0677M/s
full_node4_random_deletes/4096            439 us          439 us         1596 items_per_second=9.33982M/s
full_node4_random_deletes/32768          5098 us         5098 us          137 items_per_second=6.42746M/s
full_node4_random_deletes/65535         13743 us        13743 us           51 items_per_second=4.76845M/s

 Performance counter stats for './micro_benchmark_node4':

         48,909.02 msec task-clock                #    1.000 CPUs utilized
                48      context-switches          #    0.001 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           387,014      page-faults               #    0.008 M/sec
   166,551,872,028      cycles                    #    3.405 GHz                      (83.33%)
    68,129,597,615      stalled-cycles-frontend   #   40.91% frontend cycles idle     (83.33%)
    36,160,081,019      stalled-cycles-backend    #   21.71% backend cycles idle      (66.66%)
   275,159,220,739      instructions              #    1.65  insn per cycle
                                                  #    0.25  stalled cycles per insn  (83.33%)
    57,845,829,581      branches                  # 1182.723 M/sec                    (83.34%)
       396,869,983      branch-misses             #    0.69% of all branches          (83.33%)

      48.927147215 seconds time elapsed

      43.940919000 seconds user
       4.968556000 seconds sys

With the change:

full_node4_sequential_insert/100         8.84 us         8.85 us        78953 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=11.2965M/s size=12.6289k
full_node4_sequential_insert/512         46.4 us         46.4 us        15082 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=11.0243M/s size=64.5156k
full_node4_sequential_insert/4096         406 us          406 us         1724 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=10.087M/s size=515.984k
full_node4_sequential_insert/32768       4382 us         4382 us          160 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=7.47802M/s size=4.03127M
full_node4_sequential_insert/65535       9927 us         9927 us           70 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=6.60164M/s size=8.06238M
full_node4_random_insert/100             11.9 us         11.9 us        58632 items_per_second=8.37749M/s
full_node4_random_insert/512             59.7 us         59.7 us        11715 items_per_second=8.57103M/s
full_node4_random_insert/4096             507 us          507 us         1379 items_per_second=8.07767M/s
full_node4_random_insert/32768           5276 us         5275 us          134 items_per_second=6.21149M/s
full_node4_random_insert/65535          11561 us        11560 us           61 items_per_second=5.66888M/s
node4_full_scan/100                      3.36 us         3.36 us       207990 items_per_second=29.7201M/s
node4_full_scan/512                      21.8 us         21.8 us        32043 items_per_second=23.4388M/s
node4_full_scan/4096                      209 us          209 us         3342 items_per_second=19.5566M/s
node4_full_scan/32768                    2253 us         2253 us          311 items_per_second=14.547M/s
node4_full_scan/65535                    4706 us         4706 us          149 items_per_second=13.9263M/s
node4_random_gets/100                    57.6 us         57.8 us        12118 items_per_second=17.304k/s
node4_random_gets/512                     302 us          303 us         2313 items_per_second=3.30482k/s
node4_random_gets/4096                   2525 us         2534 us          277 items_per_second=394.707/s
node4_random_gets/32768                 21511 us        21587 us           32 items_per_second=46.3249/s
node4_random_gets/65535                 43009 us        43164 us           16 items_per_second=23.1677/s
full_node4_sequential_delete/100         7.06 us         7.06 us        99047 items_per_second=14.1595M/s
full_node4_sequential_delete/512         37.3 us         37.4 us        18736 items_per_second=13.7064M/s
full_node4_sequential_delete/4096         346 us          346 us         2021 items_per_second=11.8308M/s
full_node4_sequential_delete/32768       3196 us         3196 us          219 items_per_second=10.2518M/s
full_node4_sequential_delete/65535       6794 us         6794 us          103 items_per_second=9.64608M/s
full_node4_random_deletes/100            8.80 us         8.79 us        79554 items_per_second=11.371M/s
full_node4_random_deletes/512            48.2 us         48.2 us        14509 items_per_second=10.6168M/s
full_node4_random_deletes/4096            476 us          476 us         1470 items_per_second=8.60192M/s
full_node4_random_deletes/32768          5650 us         5650 us          124 items_per_second=5.79934M/s
full_node4_random_deletes/65535         14877 us        14876 us           47 items_per_second=4.40529M/s

 Performance counter stats for './micro_benchmark_node4':

         47,954.78 msec task-clock                #    1.000 CPUs utilized
               108      context-switches          #    0.002 K/sec
                 2      cpu-migrations            #    0.000 K/sec
           375,302      page-faults               #    0.008 M/sec
   163,267,007,933      cycles                    #    3.405 GHz                      (83.33%)
    70,633,989,291      stalled-cycles-frontend   #   43.26% frontend cycles idle     (83.33%)
    38,387,456,518      stalled-cycles-backend    #   23.51% backend cycles idle      (66.67%)
   263,929,272,273      instructions              #    1.62  insn per cycle
                                                  #    0.27  stalled cycles per insn  (83.33%)
    50,871,078,965      branches                  # 1060.814 M/sec                    (83.33%)
       330,748,698      branch-misses             #    0.65% of all branches          (83.33%)

      47.973920664 seconds time elapsed

      42.895401000 seconds user
       5.059929000 seconds sys

Baseline ./micro_benchmark:

dense_insert_mem_check/100                                8.25 us         8.27 us        84536 items_per_second=12.0862M/s size=13.0508k
dense_insert_mem_check/512                                36.2 us         36.2 us        19317 items_per_second=14.1365M/s size=60.5781k
dense_insert_mem_check/4096                                278 us          278 us         2516 items_per_second=14.7302M/s size=484.406k
dense_insert_mem_check/32768                              3562 us         3562 us          197 items_per_second=9.20035M/s size=3.78517M
dense_insert_mem_check/262144                            32867 us        32866 us           21 items_per_second=7.97606M/s size=30.2735M
dense_insert_mem_check/2097152                          164837 us       164837 us            4 items_per_second=12.7226M/s size=242.189M
dense_insert_mem_check/16777216                        1994372 us      1994331 us            1 items_per_second=8.41245M/s size=1.8921G
dense_insert_mem_check/30000000                        3068481 us      3068470 us            1 items_per_second=9.77686M/s size=3.38333G
dense_insert_no_mem_check/100                             8.72 us         8.73 us        81145 +4=1 16=0 16^=1 256=1 4=0 48=0 48^=1 4^=1 KPfS=0 L=100 items_per_second=11.4545M/s
dense_insert_no_mem_check/512                             36.3 us         36.3 us        19288 +4=3 16=0 16^=2 256=2 4=1 48=0 48^=2 4^=2 KPfS=1 L=512 items_per_second=14.0981M/s
dense_insert_no_mem_check/4096                             286 us          286 us         2445 +4=17 16=1 16^=16 256=16 4=0 48=0 48^=16 4^=17 KPfS=1 L=4.096k items_per_second=14.3081M/s
dense_insert_no_mem_check/32768                           2254 us         2254 us          311 +4=129 16=0 16^=129 256=129 4=0 48=0 48^=129 4^=129 KPfS=1 L=32.768k items_per_second=14.5369M/s
dense_insert_no_mem_check/262144                         18514 us        18514 us           38 +4=1029 16=0 16^=1028 256=1028 4=1 48=0 48^=1028 4^=1028 KPfS=5 L=262.144k items_per_second=14.1594M/s
dense_insert_no_mem_check/2097152                       148392 us       148391 us            5 +4=8.225k 16=0 16^=8.225k 256=8.224k 4=0 48=1 48^=8.224k 4^=8.225k KPfS=33 L=2.09715M items_per_second=14.1326M/s
dense_insert_no_mem_check/16777216                     1180809 us      1180781 us            1 +4=65.793k 16=0 16^=65.793k 256=65.793k 4=0 48=0 48^=65.793k 4^=65.793k KPfS=257 L=16.7772M items_per_second=14.2086M/s
dense_insert_no_mem_check/30000000                     2612583 us      2612559 us            1 +4=117.649k 16=0 16^=117.648k 256=117.648k 4=1 48=0 48^=117.648k 4^=117.648k KPfS=461 L=30M items_per_second=11.483M/s
sparse_insert_mem_check_dups_allowed/100                  65.2 us         65.5 us        10696 items_per_second=1.52766M/s size=13.8477k
sparse_insert_mem_check_dups_allowed/512                   325 us          327 us         2141 items_per_second=1.56574M/s size=66.8281k
sparse_insert_mem_check_dups_allowed/4096                 2632 us         2645 us          265 items_per_second=1.54865M/s size=546.078k
sparse_insert_mem_check_dups_allowed/32768               20847 us        20942 us           33 items_per_second=1.56468M/s size=4.31255M
sparse_insert_mem_check_dups_allowed/262144             180438 us       181827 us            4 items_per_second=1.44172M/s size=34.1208M
sparse_insert_mem_check_dups_allowed/2097152           1601246 us      1612184 us            1 items_per_second=1.30081M/s size=272.991M
sparse_insert_mem_check_dups_allowed/10000000          7857562 us      7912942 us            1 items_per_second=1.26375M/s size=1.27014G
sparse_insert_no_mem_check_dups_allowed/100               67.6 us         68.0 us        10292 +4=14 16=0 16^=1 256=1 4=13 48=0 48^=1 4^=1 KPfS=0 L=100 items_per_second=1.47084M/s
sparse_insert_no_mem_check_dups_allowed/512                334 us          336 us         2083 +4=151 16=15 16^=1 256=1 4=135 48=0 48^=1 4^=16 KPfS=0 L=512 items_per_second=1.52264M/s
sparse_insert_no_mem_check_dups_allowed/4096              2701 us         2718 us          258 +4=373 16=160 16^=97 256=1 4=116 48=96 48^=1 4^=257 KPfS=1 L=4.096k items_per_second=1.50693M/s
sparse_insert_no_mem_check_dups_allowed/32768            21563 us        21687 us           32 +4=6.202k 16=7 16^=257 256=257 4=5.938k 48=0 48^=257 4^=264 KPfS=3 L=32.768k items_per_second=1.51094M/s
sparse_insert_no_mem_check_dups_allowed/262144          184445 us       186091 us            4 +4=61.752k 16=23.969k 16^=257 256=257 4=37.526k 48=0 48^=257 4^=24.226k KPfS=179 L=262.144k items_per_second=1.40869M/s
sparse_insert_no_mem_check_dups_allowed/2097152        1638899 us      1650572 us            1 +4=187.452k 16=160 16^=65.637k 256=287 4=121.655k 48=65.35k 48^=287 4^=65.797k KPfS=276 L=2.09715M items_per_second=1.27056M/s
sparse_insert_no_mem_check_dups_allowed/10000000       8079626 us      8141781 us            1 +4=2.09185M 16=6.137k 16^=65.793k 256=65.793k 4=2.01992M 48=0 48^=65.793k 4^=71.93k KPfS=1.746k L=10M items_per_second=1.22823M/s
dense_full_scan/100                                       73.5 us         73.5 us         9523 items_per_second=68.0231M/s size=13.0508k
dense_full_scan/512                                        421 us          422 us         1661 items_per_second=60.7351M/s size=60.5781k
dense_full_scan/4096                                      3386 us         3386 us          207 items_per_second=60.4835M/s size=484.406k
dense_full_scan/32768                                    26534 us        26534 us           26 items_per_second=61.7473M/s size=3.78517M
dense_full_scan/262144                                  281862 us       281860 us            2 items_per_second=46.5025M/s size=30.2735M
dense_full_scan/2097152                                2099415 us      2099413 us            1 items_per_second=49.9462M/s size=242.189M
dense_full_scan/16777216                              16752669 us     16752729 us            1 items_per_second=50.0731M/s size=1.8921G
dense_full_scan/20000000                              22728313 us     22728293 us            1 items_per_second=43.998M/s size=2.25556G
dense_tree_sparse_deletes/1000/deletes:800                 485 us          487 us         1437 end L=438 end size=56.4434k items_per_second=1.64234M/s start L=1000 start size=118.461k
dense_tree_sparse_deletes/1000/deletes:1000                597 us          600 us         1167 end L=358 end size=47.6152k items_per_second=1.66689M/s start L=1000 start size=118.461k
dense_tree_sparse_deletes/8000/deletes:800                 692 us          694 us         1008 end L=7.243k end size=864.417k items_per_second=1.15199M/s start L=8k start size=947.953k
dense_tree_sparse_deletes/8000/deletes:8000               4813 us         4839 us          145 end L=3.001k end size=394.931k items_per_second=1.65332M/s start L=8k start size=947.953k
dense_tree_sparse_deletes/64000/deletes:800               2724 us         2726 us          257 end L=63.204k end size=7.30526M items_per_second=293.476k/s start L=64k start size=7.39104M
dense_tree_sparse_deletes/64000/deletes:64000            41617 us        41821 us           17 end L=23.583k end size=3.03549M items_per_second=1.53032M/s start L=64k start size=7.39104M
dense_tree_sparse_deletes/512000/deletes:800             19165 us        19168 us           37 end L=511.201k end size=59.0423M items_per_second=41.7367k/s start L=512k start size=59.1284M
dense_tree_sparse_deletes/512000/deletes:512000         411753 us       413406 us            2 end L=188.473k end size=24.2635M items_per_second=1.23849M/s start L=512k start size=59.1284M
dense_tree_sparse_deletes/4096000/deletes:800           148126 us       148126 us            5 end L=4.0952M end size=472.94M items_per_second=5.4008k/s start L=4.096M start size=473.026M
dense_tree_sparse_deletes/4096000/deletes:4096000      3629629 us      3642870 us            1 end L=1.50751M end size=194.078M items_per_second=1.12439M/s start L=4.096M start size=473.026M
dense_tree_increasing_keys/100                             106 ms          106 ms            7 items_per_second=18.8776M/s
dense_tree_increasing_keys/512                             112 ms          112 ms            6 items_per_second=17.8165M/s
dense_tree_increasing_keys/4096                            111 ms          111 ms            6 items_per_second=17.9807M/s
dense_tree_increasing_keys/32768                           114 ms          114 ms            6 items_per_second=17.5767M/s
dense_tree_increasing_keys/262144                          121 ms          121 ms            6 items_per_second=16.5903M/s
dense_tree_increasing_keys/2097152                         117 ms          117 ms            6 items_per_second=17.0411M/s
dense_tree_increasing_keys/16777216                        126 ms          126 ms            6 items_per_second=15.894M/s
dense_tree_increasing_keys/30000000                        126 ms          126 ms            6 items_per_second=15.9336M/s
dense_insert_value_lengths/100/value len log10:0          7.29 us         7.30 us        96051 items_per_second=13.6959M/s size=3.38281k
dense_insert_value_lengths/100/value len log10:1          7.23 us         7.25 us        96391 items_per_second=13.7951M/s size=4.26172k
dense_insert_value_lengths/100/value len log10:2          8.62 us         8.64 us        80905 items_per_second=11.5803M/s size=13.0508k
dense_insert_value_lengths/100/value len log10:3          14.1 us         14.1 us        49604 items_per_second=7.07694M/s size=100.941k
dense_insert_value_lengths/100/value len log10:4          53.0 us         53.2 us        13163 items_per_second=1.88059M/s size=979.848k
dense_insert_value_lengths/800/value len log10:0          45.0 us         45.0 us        15629 items_per_second=17.7882M/s size=17.6719k
dense_insert_value_lengths/800/value len log10:1          45.4 us         45.4 us        15406 items_per_second=17.6103M/s size=24.7031k
dense_insert_value_lengths/800/value len log10:2          57.3 us         57.3 us        12203 items_per_second=13.955M/s size=95.0156k
dense_insert_value_lengths/800/value len log10:3           118 us          118 us         5929 items_per_second=6.77493M/s size=798.141k
dense_insert_value_lengths/800/value len log10:4           650 us          651 us         1075 items_per_second=1.22812M/s size=7.64589M
dense_insert_value_lengths/6400/value len log10:0          354 us          354 us         1971 items_per_second=18.0932M/s size=138.531k
dense_insert_value_lengths/6400/value len log10:1          358 us          358 us         1956 items_per_second=17.8889M/s size=194.781k
dense_insert_value_lengths/6400/value len log10:2          452 us          453 us         1547 items_per_second=14.1433M/s size=757.281k
dense_insert_value_lengths/6400/value len log10:3         1019 us         1020 us          687 items_per_second=6.27579M/s size=6.2327M
dense_insert_value_lengths/6400/value len log10:4         7718 us         7720 us           91 items_per_second=829.053k/s size=61.1643M
dense_insert_value_lengths/51200/value len log10:0        2787 us         2787 us          251 items_per_second=18.3711M/s size=1105.14k
dense_insert_value_lengths/51200/value len log10:1        2808 us         2808 us          249 items_per_second=18.233M/s size=1.51869M
dense_insert_value_lengths/51200/value len log10:2        3585 us         3585 us          195 items_per_second=14.2832M/s size=5.91322M
dense_insert_value_lengths/51200/value len log10:3       10121 us        10122 us           69 items_per_second=5.0583M/s size=49.8585M
dense_insert_value_lengths/51200/value len log10:4       61685 us        61687 us           11 items_per_second=829.99k/s size=489.312M
dense_insert_value_lengths/409600/value len log10:0      23800 us        23800 us           29 items_per_second=17.2104M/s size=8.6321M
dense_insert_value_lengths/409600/value len log10:1      24377 us        24377 us           29 items_per_second=16.8027M/s size=12.1477M
dense_insert_value_lengths/409600/value len log10:2      30075 us        30075 us           23 items_per_second=13.6191M/s size=47.304M
dense_insert_value_lengths/409600/value len log10:3      81507 us        81505 us            9 items_per_second=5.02546M/s size=398.866M
dense_insert_value_lengths/409600/value len log10:4     766550 us       766561 us            1 items_per_second=534.335k/s size=3.82275G
dense_insert_dup_attempts/100                             2.31 us         2.29 us       305597 items_per_second=43.673M/s
dense_insert_dup_attempts/512                             8.68 us         8.63 us        81096 items_per_second=59.3547M/s
dense_insert_dup_attempts/4096                            63.2 us         63.0 us        11116 items_per_second=65.0536M/s
dense_insert_dup_attempts/32768                            481 us          481 us         1455 items_per_second=68.1398M/s
dense_insert_dup_attempts/262144                          5634 us         5632 us          124 items_per_second=46.5436M/s
dense_insert_dup_attempts/2097152                        41571 us        41570 us           17 items_per_second=50.4485M/s
dense_insert_dup_attempts/16777216                      326041 us       326044 us            2 items_per_second=51.4569M/s
dense_insert_dup_attempts/30000000                      725170 us       725179 us            1 items_per_second=41.3691M/s

 Performance counter stats for './micro_benchmark':

        293,223.54 msec task-clock                #    1.000 CPUs utilized
               396      context-switches          #    0.001 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         4,987,572      page-faults               #    0.017 M/sec
   997,611,456,647      cycles                    #    3.402 GHz                      (83.33%)
   388,024,102,384      stalled-cycles-frontend   #   38.90% frontend cycles idle     (83.33%)
   245,426,075,637      stalled-cycles-backend    #   24.60% backend cycles idle      (66.67%)
 1,776,902,065,112      instructions              #    1.78  insn per cycle
                                                  #    0.22  stalled cycles per insn  (83.33%)
   404,657,121,385      branches                  # 1380.029 M/sec                    (83.33%)
       926,003,162      branch-misses             #    0.23% of all branches          (83.33%)

     293.242926489 seconds time elapsed

     258.299770000 seconds user
      34.924509000 seconds sys

With the change:

dense_insert_mem_check/100                                8.44 us         8.45 us        82741 items_per_second=11.8319M/s size=13.0508k
dense_insert_mem_check/512                                34.5 us         34.5 us        20291 items_per_second=14.8426M/s size=60.5781k
dense_insert_mem_check/4096                                280 us          280 us         2496 items_per_second=14.6078M/s size=484.406k
dense_insert_mem_check/32768                              3354 us         3354 us          209 items_per_second=9.77103M/s size=3.78517M
dense_insert_mem_check/262144                            30941 us        30941 us           23 items_per_second=8.47233M/s size=30.2735M
dense_insert_mem_check/2097152                          170046 us       170046 us            3 items_per_second=12.3328M/s size=242.189M
dense_insert_mem_check/16777216                        1932270 us      1932268 us            1 items_per_second=8.68266M/s size=1.8921G
dense_insert_mem_check/30000000                        3055271 us      3055248 us            1 items_per_second=9.81917M/s size=3.38333G
dense_insert_no_mem_check/100                             8.58 us         8.59 us        82465 +4=1 16=0 16^=1 256=1 4=0 48=0 48^=1 4^=1 KPfS=0 L=100 items_per_second=11.6441M/s
dense_insert_no_mem_check/512                             35.4 us         35.4 us        19710 +4=3 16=0 16^=2 256=2 4=1 48=0 48^=2 4^=2 KPfS=1 L=512 items_per_second=14.4493M/s
dense_insert_no_mem_check/4096                             282 us          282 us         2481 +4=17 16=1 16^=16 256=16 4=0 48=0 48^=16 4^=17 KPfS=1 L=4.096k items_per_second=14.5081M/s
dense_insert_no_mem_check/32768                           2199 us         2199 us          318 +4=129 16=0 16^=129 256=129 4=0 48=0 48^=129 4^=129 KPfS=1 L=32.768k items_per_second=14.9006M/s
dense_insert_no_mem_check/262144                         19224 us        19224 us           36 +4=1029 16=0 16^=1028 256=1028 4=1 48=0 48^=1028 4^=1028 KPfS=5 L=262.144k items_per_second=13.6361M/s
dense_insert_no_mem_check/2097152                       153806 us       153807 us            5 +4=8.225k 16=0 16^=8.225k 256=8.224k 4=0 48=1 48^=8.224k 4^=8.225k KPfS=33 L=2.09715M items_per_second=13.6349M/s
dense_insert_no_mem_check/16777216                     1218684 us      1218646 us            1 +4=65.793k 16=0 16^=65.793k 256=65.793k 4=0 48=0 48^=65.793k 4^=65.793k KPfS=257 L=16.7772M items_per_second=13.7671M/s
dense_insert_no_mem_check/30000000                     2665556 us      2665574 us            1 +4=117.649k 16=0 16^=117.648k 256=117.648k 4=1 48=0 48^=117.648k 4^=117.648k KPfS=461 L=30M items_per_second=11.2546M/s
sparse_insert_mem_check_dups_allowed/100                  65.0 us         65.5 us        10694 items_per_second=1.52761M/s size=13.707k
sparse_insert_mem_check_dups_allowed/512                   325 us          328 us         2135 items_per_second=1.562M/s size=67.1719k
sparse_insert_mem_check_dups_allowed/4096                 2652 us         2672 us          262 items_per_second=1.53288M/s size=548.359k
sparse_insert_mem_check_dups_allowed/32768               20933 us        21080 us           33 items_per_second=1.55444M/s size=4.30818M
sparse_insert_mem_check_dups_allowed/262144             182217 us       184053 us            4 items_per_second=1.42428M/s size=34.1297M
sparse_insert_mem_check_dups_allowed/2097152           1650158 us      1663987 us            1 items_per_second=1.26032M/s size=272.993M
sparse_insert_mem_check_dups_allowed/10000000          8249674 us      8324881 us            1 items_per_second=1.20122M/s size=1.2702G
sparse_insert_no_mem_check_dups_allowed/100               64.8 us         65.2 us        10723 +4=17 16=0 16^=1 256=1 4=16 48=0 48^=1 4^=1 KPfS=0 L=100 items_per_second=1.53356M/s
sparse_insert_no_mem_check_dups_allowed/512                324 us          326 us         2146 +4=150 16=17 16^=1 256=1 4=132 48=0 48^=1 4^=18 KPfS=0 L=512 items_per_second=1.57001M/s
sparse_insert_no_mem_check_dups_allowed/4096              2637 us         2656 us          264 +4=381 16=155 16^=102 256=1 4=124 48=101 48^=1 4^=257 KPfS=1 L=4.096k items_per_second=1.54212M/s
sparse_insert_no_mem_check_dups_allowed/32768            20882 us        21013 us           33 +4=6.237k 16=15 16^=257 256=257 4=5.965k 48=0 48^=257 4^=272 KPfS=6 L=32.768k items_per_second=1.55941M/s
sparse_insert_no_mem_check_dups_allowed/262144          181721 us       183521 us            4 +4=61.857k 16=23.878k 16^=257 256=257 4=37.722k 48=0 48^=257 4^=24.135k KPfS=184 L=262.144k items_per_second=1.42842M/s
sparse_insert_no_mem_check_dups_allowed/2097152        1649870 us      1663513 us            1 +4=186.417k 16=142 16^=65.655k 256=276 4=120.62k 48=65.379k 48^=276 4^=65.797k KPfS=278 L=2.09715M items_per_second=1.26068M/s
sparse_insert_no_mem_check_dups_allowed/10000000       8308787 us      8376680 us            1 +4=2.09407M 16=6.253k 16^=65.793k 256=65.793k 4=2.02202M 48=0 48^=65.793k 4^=72.046k KPfS=1.723k L=10M items_per_second=1.19379M/s
dense_full_scan/100                                       67.6 us         67.6 us        10352 items_per_second=73.95M/s size=13.0508k
dense_full_scan/512                                        414 us          414 us         1690 items_per_second=61.8029M/s size=60.5781k
dense_full_scan/4096                                      3261 us         3261 us          215 items_per_second=62.8103M/s size=484.406k
dense_full_scan/32768                                    25019 us        25019 us           28 items_per_second=65.4864M/s size=3.78517M
dense_full_scan/262144                                  357869 us       357865 us            2 items_per_second=36.6261M/s size=30.2735M
dense_full_scan/2097152                                2540177 us      2540172 us            1 items_per_second=41.2797M/s size=242.189M
dense_full_scan/16777216                              20548626 us     20548592 us            1 items_per_second=40.8233M/s size=1.8921G
dense_full_scan/20000000                              31833874 us     31833918 us            1 items_per_second=31.413M/s size=2.25556G
dense_tree_sparse_deletes/1000/deletes:800                 486 us          488 us         1434 end L=446 end size=57.3262k items_per_second=1.63866M/s start L=1000 start size=118.461k
dense_tree_sparse_deletes/1000/deletes:1000                599 us          601 us         1165 end L=375 end size=49.4912k items_per_second=1.66377M/s start L=1000 start size=118.461k
dense_tree_sparse_deletes/8000/deletes:800                 702 us          704 us          994 end L=7.239k end size=863.976k items_per_second=1.13642M/s start L=8k start size=947.953k
dense_tree_sparse_deletes/8000/deletes:8000               4846 us         4866 us          144 end L=2.9k end size=383.785k items_per_second=1.64412M/s start L=8k start size=947.953k
dense_tree_sparse_deletes/64000/deletes:800               2779 us         2781 us          252 end L=63.202k end size=7.30504M items_per_second=287.657k/s start L=64k start size=7.39104M
dense_tree_sparse_deletes/64000/deletes:64000            41805 us        41920 us           17 end L=23.569k end size=3.03398M items_per_second=1.52672M/s start L=64k start size=7.39104M
dense_tree_sparse_deletes/512000/deletes:800             19668 us        19671 us           36 end L=511.201k end size=59.0423M items_per_second=40.6681k/s start L=512k start size=59.1284M
dense_tree_sparse_deletes/512000/deletes:512000         418071 us       419422 us            2 end L=188.504k end size=24.2668M items_per_second=1.22073M/s start L=512k start size=59.1284M
dense_tree_sparse_deletes/4096000/deletes:800           152018 us       152018 us            5 end L=4.0952M end size=472.94M items_per_second=5.26254k/s start L=4.096M start size=473.026M
dense_tree_sparse_deletes/4096000/deletes:4096000      3751451 us      3762212 us            1 end L=1.50801M end size=194.131M items_per_second=1088.72k/s start L=4.096M start size=473.026M
dense_tree_increasing_keys/100                            91.4 ms         91.4 ms            8 items_per_second=21.8816M/s
dense_tree_increasing_keys/512                            97.6 ms         97.6 ms            7 items_per_second=20.4972M/s
dense_tree_increasing_keys/4096                           97.5 ms         97.5 ms            7 items_per_second=20.505M/s
dense_tree_increasing_keys/32768                           102 ms          102 ms            7 items_per_second=19.6026M/s
dense_tree_increasing_keys/262144                          111 ms          111 ms            6 items_per_second=18.0931M/s
dense_tree_increasing_keys/2097152                         108 ms          108 ms            6 items_per_second=18.4902M/s
dense_tree_increasing_keys/16777216                        126 ms          126 ms            6 items_per_second=15.8273M/s
dense_tree_increasing_keys/30000000                        125 ms          125 ms            6 items_per_second=15.9919M/s
dense_insert_value_lengths/100/value len log10:0          6.94 us         6.94 us       101359 items_per_second=14.4021M/s size=3.38281k
dense_insert_value_lengths/100/value len log10:1          6.94 us         6.94 us       100951 items_per_second=14.4062M/s size=4.26172k
dense_insert_value_lengths/100/value len log10:2          8.11 us         8.12 us        86110 items_per_second=12.3188M/s size=13.0508k
dense_insert_value_lengths/100/value len log10:3          13.8 us         13.8 us        50528 items_per_second=7.22876M/s size=100.941k
dense_insert_value_lengths/100/value len log10:4          52.9 us         53.1 us        13192 items_per_second=1.88388M/s size=979.848k
dense_insert_value_lengths/800/value len log10:0          43.8 us         43.8 us        15986 items_per_second=18.267M/s size=17.6719k
dense_insert_value_lengths/800/value len log10:1          44.4 us         44.4 us        15765 items_per_second=18.0232M/s size=24.7031k
dense_insert_value_lengths/800/value len log10:2          52.6 us         52.7 us        13293 items_per_second=15.1944M/s size=95.0156k
dense_insert_value_lengths/800/value len log10:3           110 us          110 us         6371 items_per_second=7.28338M/s size=798.141k
dense_insert_value_lengths/800/value len log10:4           600 us          601 us         1165 items_per_second=1.33119M/s size=7.64589M
dense_insert_value_lengths/6400/value len log10:0          343 us          343 us         2034 items_per_second=18.6793M/s size=138.531k
dense_insert_value_lengths/6400/value len log10:1          350 us          350 us         2002 items_per_second=18.3087M/s size=194.781k
dense_insert_value_lengths/6400/value len log10:2          415 us          415 us         1685 items_per_second=15.4135M/s size=757.281k
dense_insert_value_lengths/6400/value len log10:3          933 us          934 us          750 items_per_second=6.85241M/s size=6.2327M
dense_insert_value_lengths/6400/value len log10:4         7685 us         7687 us           91 items_per_second=832.581k/s size=61.1643M
dense_insert_value_lengths/51200/value len log10:0        2738 us         2739 us          256 items_per_second=18.6958M/s size=1105.14k
dense_insert_value_lengths/51200/value len log10:1        2776 us         2776 us          252 items_per_second=18.4443M/s size=1.51869M
dense_insert_value_lengths/51200/value len log10:2        3319 us         3319 us          211 items_per_second=15.426M/s size=5.91322M
dense_insert_value_lengths/51200/value len log10:3        9742 us         9744 us           72 items_per_second=5.25464M/s size=49.8585M
dense_insert_value_lengths/51200/value len log10:4       61319 us        61318 us           11 items_per_second=834.996k/s size=489.312M
dense_insert_value_lengths/409600/value len log10:0      24618 us        24618 us           28 items_per_second=16.6381M/s size=8.6321M
dense_insert_value_lengths/409600/value len log10:1      25291 us        25288 us           28 items_per_second=16.1972M/s size=12.1477M
dense_insert_value_lengths/409600/value len log10:2      28874 us        28872 us           24 items_per_second=14.187M/s size=47.304M
dense_insert_value_lengths/409600/value len log10:3      79500 us        79502 us            9 items_per_second=5.15208M/s size=398.866M
dense_insert_value_lengths/409600/value len log10:4     757310 us       757307 us            1 items_per_second=540.864k/s size=3.82275G
dense_insert_dup_attempts/100                             1.82 us         1.81 us       386474 items_per_second=55.2125M/s
dense_insert_dup_attempts/512                             8.07 us         8.03 us        87155 items_per_second=63.7729M/s
dense_insert_dup_attempts/4096                            56.8 us         56.6 us        12365 items_per_second=72.3123M/s
dense_insert_dup_attempts/32768                            419 us          419 us         1671 items_per_second=78.2085M/s
dense_insert_dup_attempts/262144                          6514 us         6512 us          107 items_per_second=40.2551M/s
dense_insert_dup_attempts/2097152                        47663 us        47662 us           15 items_per_second=44.0004M/s
dense_insert_dup_attempts/16777216                      364373 us       364353 us            2 items_per_second=46.0466M/s
dense_insert_dup_attempts/30000000                      931981 us       931964 us            1 items_per_second=32.1901M/s

 Performance counter stats for './micro_benchmark':

        310,570.00 msec task-clock                #    1.000 CPUs utilized
               382      context-switches          #    0.001 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         4,973,154      page-faults               #    0.016 M/sec
 1,056,611,705,712      cycles                    #    3.402 GHz                      (83.33%)
   438,190,990,690      stalled-cycles-frontend   #   41.47% frontend cycles idle     (83.33%)
   280,993,020,577      stalled-cycles-backend    #   26.59% backend cycles idle      (66.67%)
 1,789,212,543,852      instructions              #    1.69  insn per cycle
                                                  #    0.24  stalled cycles per insn  (83.33%)
   373,224,854,356      branches                  # 1201.741 M/sec                    (83.33%)
       897,739,472      branch-misses             #    0.24% of all branches          (83.33%)

     310.589044084 seconds time elapsed

     275.065751000 seconds user
      35.504226000 seconds sys