### PR TITLE
Remove depth arg from inode::get_shared_key_prefix_length

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -58,6 +58,10 @@ struct basic_art_key final {
 
   [[nodiscard]] explicit operator KeyType() const noexcept { return key; }
 
+  void shift_right(const std::size_t num_bytes) noexcept {
+    key >>= (num_bytes * 8);
+  }
+
   KeyType key;
 
   static constexpr auto size = sizeof(KeyType);


### PR DESCRIPTION
By maintaining shifted key at the callers, shifted key maintenance is strength
reduced, one multiplication removed.

Performance, micro_benchmark_key_prefix baseline:

2020-06-15 07:10:40
Running ./micro_benchmark_key_prefix
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.07, 0.30, 0.15
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
unpredictable_get_shared_length      0.870 us        0.871 us       803411 items_per_second=24.1043M/s

With the change:

unpredictable_get_shared_length      0.837 us        0.839 us       834472 items_per_second=25.034M/s

micro_benchmark_node4 baseline:

full_node4_sequential_insert/100         9.10 us         9.10 us        76917 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=10.9943M/s size=12.6289k
full_node4_sequential_insert/512         45.9 us         45.9 us        15270 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=11.1479M/s size=64.5156k
full_node4_sequential_insert/4096         397 us          397 us         1763 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=10.3103M/s size=515.984k
full_node4_sequential_insert/32768       4293 us         4293 us          163 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=7.63306M/s size=4.03127M
full_node4_sequential_insert/65535       9592 us         9592 us           73 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=6.83252M/s size=8.06238M
full_node4_random_insert/100             12.2 us         12.2 us        57287 items_per_second=8.182M/s
full_node4_random_insert/512             60.2 us         60.2 us        11619 items_per_second=8.50145M/s
full_node4_random_insert/4096             508 us          508 us         1377 items_per_second=8.06275M/s
full_node4_random_insert/32768           5168 us         5168 us          135 items_per_second=6.34009M/s
full_node4_random_insert/65535          11400 us        11399 us           62 items_per_second=5.74894M/s
node4_full_scan/100                      3.39 us         3.39 us       206489 items_per_second=29.5039M/s
node4_full_scan/512                      22.3 us         22.3 us        31423 items_per_second=22.9818M/s
node4_full_scan/4096                      217 us          217 us         3229 items_per_second=18.8963M/s
node4_full_scan/32768                    2346 us         2346 us          298 items_per_second=13.965M/s
node4_full_scan/65535                    4899 us         4899 us          143 items_per_second=13.3765M/s
node4_random_gets/100                    58.5 us         58.8 us        11902 items_per_second=17.0043k/s
node4_random_gets/512                     306 us          307 us         2277 items_per_second=3.25289k/s
node4_random_gets/4096                   2537 us         2551 us          274 items_per_second=392.004/s
node4_random_gets/32768                 21528 us        21646 us           32 items_per_second=46.1972/s
node4_random_gets/65535                 43097 us        43336 us           16 items_per_second=23.0755/s
full_node4_sequential_delete/100         6.78 us         6.78 us       103177 items_per_second=14.7487M/s
full_node4_sequential_delete/512         35.2 us         35.2 us        19879 items_per_second=14.5475M/s
full_node4_sequential_delete/4096         322 us          322 us         2176 items_per_second=12.735M/s
full_node4_sequential_delete/32768       3018 us         3018 us          232 items_per_second=10.8582M/s
full_node4_sequential_delete/65535       6356 us         6356 us          110 items_per_second=10.3103M/s
full_node4_random_deletes/100            8.89 us         8.88 us        78782 items_per_second=11.2599M/s
full_node4_random_deletes/512            48.8 us         48.8 us        14332 items_per_second=10.4817M/s
full_node4_random_deletes/4096            482 us          482 us         1453 items_per_second=8.49877M/s
full_node4_random_deletes/32768          5702 us         5702 us          123 items_per_second=5.74697M/s
full_node4_random_deletes/65535         14864 us        14864 us           47 items_per_second=4.40895M/s

With the change:

full_node4_sequential_insert/100         8.57 us         8.59 us        81185 +4=34 16=0 16^=0 256=0 4=34 48=0 48^=0 4^=0 KPfS=9 L=100 items_per_second=11.6404M/s size=12.6289k
full_node4_sequential_insert/512         45.0 us         45.0 us        15588 +4=171 16=0 16^=0 256=0 4=171 48=0 48^=0 4^=0 KPfS=43 L=512 items_per_second=11.3883M/s size=64.5156k
full_node4_sequential_insert/4096         392 us          392 us         1790 +4=1.365k 16=0 16^=0 256=0 4=1.365k 48=0 48^=0 4^=0 KPfS=341 L=4.096k items_per_second=10.4474M/s size=515.984k
full_node4_sequential_insert/32768       4193 us         4193 us          167 +4=10.923k 16=0 16^=0 256=0 4=10.923k 48=0 48^=0 4^=0 KPfS=2.731k L=32.768k items_per_second=7.8155M/s size=4.03127M
full_node4_sequential_insert/65535       9362 us         9362 us           74 +4=21.845k 16=0 16^=0 256=0 4=21.845k 48=0 48^=0 4^=0 KPfS=5.461k L=65.535k items_per_second=7.00014M/s size=8.06238M
full_node4_random_insert/100             11.6 us         11.6 us        60184 items_per_second=8.59905M/s
full_node4_random_insert/512             57.5 us         57.5 us        12182 items_per_second=8.91013M/s
full_node4_random_insert/4096             487 us          487 us         1437 items_per_second=8.40802M/s
full_node4_random_insert/32768           4991 us         4991 us          138 items_per_second=6.56567M/s
full_node4_random_insert/65535          10998 us        10998 us           63 items_per_second=5.95882M/s
node4_full_scan/100                      3.32 us         3.32 us       210690 items_per_second=30.0979M/s
node4_full_scan/512                      21.6 us         21.6 us        32446 items_per_second=23.7304M/s
node4_full_scan/4096                      208 us          208 us         3361 items_per_second=19.6645M/s
node4_full_scan/32768                    2228 us         2228 us          314 items_per_second=14.7052M/s
node4_full_scan/65535                    4666 us         4666 us          150 items_per_second=14.0446M/s
node4_random_gets/100                    57.5 us         57.9 us        12098 items_per_second=17.2822k/s
node4_random_gets/512                     301 us          303 us         2312 items_per_second=3.29989k/s
node4_random_gets/4096                   2503 us         2516 us          278 items_per_second=397.487/s
node4_random_gets/32768                 21217 us        21321 us           33 items_per_second=46.902/s
node4_random_gets/65535                 42479 us        42687 us           16 items_per_second=23.4261/s
full_node4_sequential_delete/100         6.82 us         6.81 us       102400 items_per_second=14.695M/s
full_node4_sequential_delete/512         36.1 us         36.1 us        19378 items_per_second=14.1738M/s
full_node4_sequential_delete/4096         328 us          328 us         2133 items_per_second=12.4827M/s
full_node4_sequential_delete/32768       3023 us         3024 us          231 items_per_second=10.8377M/s
full_node4_sequential_delete/65535       6472 us         6472 us          108 items_per_second=10.1262M/s
full_node4_random_deletes/100            8.62 us         8.61 us        81318 items_per_second=11.6168M/s
full_node4_random_deletes/512            46.8 us         46.8 us        14953 items_per_second=10.9394M/s
full_node4_random_deletes/4096            461 us          461 us         1519 items_per_second=8.88958M/s
full_node4_random_deletes/32768          5462 us         5462 us          128 items_per_second=5.99973M/s
full_node4_random_deletes/65535         14446 us        14446 us           48 items_per_second=4.53645M/s