### PR TITLE
Annotate Node4 insertion subroutines with __restrict__ as applicable

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -436,8 +436,9 @@ class inode {
 
   template <typename KeysType, typename ChildrenType>
   static void insert_into_sorted_key_children_arrays(
-      KeysType &keys, ChildrenType &children, std::uint8_t &children_count,
-      std::byte key_byte, leaf_unique_ptr &&child) {
+      KeysType &__restrict__ keys, ChildrenType &__restrict__ children,
+      std::uint8_t &__restrict__ children_count, std::byte key_byte,
+      leaf_unique_ptr &&__restrict__ child) {
     assert(std::is_sorted(keys.cbegin(), keys.cbegin() + children_count));
 
     const auto insert_pos_index =
@@ -689,7 +690,7 @@ class inode_4 final : public basic_inode_4 {
   inode_4(std::unique_ptr<inode_16> &&source_node,
           std::uint8_t child_to_remove) noexcept;
 
-  void add(leaf_unique_ptr &&child, tree_depth depth) noexcept {
+  void add(leaf_unique_ptr &&__restrict__ child, tree_depth depth) noexcept {
     assert(reinterpret_cast<node_header *>(this)->type() == static_node_type);
 
     const auto key_byte = leaf::key(child.get())[depth];


### PR DESCRIPTION
They are inode_4::add and inode::insert_into_sorted_key_children_arrays

Performance change:

full_node4_sequential_insert/100_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/100_mean                    -0.0295         -0.0295             9             9             9             9
full_node4_sequential_insert/512_pvalue                   0.0006          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/512_mean                    -0.0091         -0.0094            45            45            45            45
full_node4_sequential_insert/4096_pvalue                  0.0036          0.0062      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/4096_mean                   +0.0015         +0.0015           391           391           391           391
full_node4_sequential_insert/32768_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/32768_mean                  -0.0064         -0.0064          4200          4173          4200          4173
full_node4_sequential_insert/65535_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/65535_mean                  -0.0073         -0.0073          9368          9299          9367          9299
full_node4_random_insert/100_pvalue                       0.0521          0.0521      U Test, Repetitions: 9 vs 9
full_node4_random_insert/100_mean                        -0.0206         -0.0197            12            12            12            12
full_node4_random_insert/512_pvalue                       0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/512_mean                        -0.0167         -0.0166            60            59            60            59
full_node4_random_insert/4096_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/4096_mean                       -0.0095         -0.0094           495           490           495           490
full_node4_random_insert/32768_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/32768_mean                      -0.0096         -0.0095          5018          4970          5018          4970
full_node4_random_insert/65535_pvalue                     0.0081          0.0081      U Test, Repetitions: 9 vs 9
full_node4_random_insert/65535_mean                      -0.0071         -0.0071         10932         10853         10931         10853