### PR TITLE
Use manual loop instead of std::copy_backward for Node4 children arra…

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -682,16 +682,14 @@ class inode_4 final : public basic_inode_4 {
     const auto insert_pos_index =
         static_cast<unsigned>(first_lt + second_lt + third_lt);
 
-    if (insert_pos_index != f.f.children_count) {
-      for (decltype(keys.byte_array)::size_type i = f.f.children_count;
-           i > insert_pos_index; --i)
-        keys.byte_array[i] = keys.byte_array[i - 1];
-      std::copy_backward(children.begin() + insert_pos_index,
-                         children.begin() + f.f.children_count,
-                         children.begin() + f.f.children_count + 1);
+    for (decltype(keys.byte_array)::size_type i = f.f.children_count;
+         i > insert_pos_index; --i) {
+      keys.byte_array[i] = keys.byte_array[i - 1];
+      children[i] = children[i - 1];
     }
     keys.byte_array[insert_pos_index] = static_cast<std::byte>(key_byte);
     children[insert_pos_index] = child.release();
+
     ++f.f.children_count;
 
     assert(std::is_sorted(keys.byte_array.cbegin(),


### PR DESCRIPTION
…y insert

At the same time merge it with the key insert loop and remove the guarding if
statement.

Performance change:

full_node4_sequential_insert/100_pvalue                   0.0020          0.0036      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/100_mean                    -0.0104         -0.0096             9             9             9             9
full_node4_sequential_insert/512_pvalue                   0.1853          0.2164      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/512_mean                    -0.0026         -0.0024            45            45            45            45
full_node4_sequential_insert/4096_pvalue                  0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/4096_mean                   +0.0082         +0.0082           391           395           392           395
full_node4_sequential_insert/32768_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/32768_mean                  -0.0067         -0.0067          4211          4183          4211          4183
full_node4_sequential_insert/65535_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_insert/65535_mean                  -0.0085         -0.0085          9402          9322          9401          9321
full_node4_random_insert/100_pvalue                       0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/100_mean                        -0.0547         -0.0544            13            12            13            12
full_node4_random_insert/512_pvalue                       0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/512_mean                        -0.0594         -0.0593            61            57            61            57
full_node4_random_insert/4096_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/4096_mean                       -0.0563         -0.0564           507           478           507           478
full_node4_random_insert/32768_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_insert/32768_mean                      -0.0349         -0.0349          5099          4921          5099          4921
full_node4_random_insert/65535_pvalue                     0.0062          0.0062      U Test, Repetitions: 9 vs 9
full_node4_random_insert/65535_mean                      -0.0125         -0.0125         11022         10885         11022         10884