### PR TITLE
Implement unpredictable_leaf_key_prefix_split micro benchmark

### DIFF
--- a/micro_benchmark_key_prefix.cpp
+++ b/micro_benchmark_key_prefix.cpp
@@ -12,6 +12,8 @@
 #include "art_common.hpp"
 #include "micro_benchmark.hpp"
 
+namespace {
+
 /*
 
 Make get_shared_length too hard for the CPU branch predictor:
@@ -55,29 +57,25 @@ Keys to be inserted:    Additional key prefix mismatch keys:
 0x0501000000000000
  */
 
-namespace {
-
-// cppcheck-suppress constParameter
 void unpredictable_get_shared_length(benchmark::State &state) {
   std::vector<unodb::key> search_keys{};
   search_keys.reserve(7 * 2 + 7 * 2 - 3);
-  unodb::db db;
+  unodb::db test_db;
   for (std::uint8_t top_byte = 0x00; top_byte <= 0x05; ++top_byte) {
-    const std::uint64_t first_key = static_cast<std::uint64_t>(top_byte) << 56;
-    const std::uint64_t second_key = first_key | (1ULL << ((top_byte + 1) * 8));
-    unodb::benchmark::insert_key(db, first_key,
+    const auto first_key = static_cast<std::uint64_t>(top_byte) << 56;
+    const auto second_key = first_key | (1ULL << ((top_byte + 1) * 8));
+    unodb::benchmark::insert_key(test_db, first_key,
                                  unodb::value_view{unodb::benchmark::value100});
-    unodb::benchmark::insert_key(db, second_key,
+    unodb::benchmark::insert_key(test_db, second_key,
                                  unodb::value_view{unodb::benchmark::value100});
     search_keys.push_back(first_key);
     search_keys.push_back(second_key);
     if (top_byte > 4) continue;
-    const std::uint64_t first_not_found_key =
-        first_key | (1ULL << ((top_byte + 2) * 8));
+    const auto first_not_found_key = first_key | (1ULL << ((top_byte + 2) * 8));
     search_keys.push_back(first_not_found_key);
 
     if (top_byte > 3) continue;
-    const std::uint64_t second_not_found_key = first_key | (1ULL << 48);
+    const auto second_not_found_key = first_key | (1ULL << 48);
     search_keys.push_back(second_not_found_key);
   }
 
@@ -89,7 +87,7 @@ void unpredictable_get_shared_length(benchmark::State &state) {
     std::shuffle(search_keys.begin(), search_keys.end(), gen);
     state.ResumeTiming();
     for (const auto k : search_keys) {
-      unodb::benchmark::get_key(db, k);
+      unodb::benchmark::get_key(test_db, k);
     }
   }
 
@@ -97,8 +95,128 @@ void unpredictable_get_shared_length(benchmark::State &state) {
       static_cast<std::int64_t>(state.iterations() * search_keys.size()));
 }
 
+/*
+
+Make inode_4 two-key constructor too hard for the CPU branch predictor by
+inserting every second key in the above tree, and benchmarking inserting of the
+rest:
+
+before:
+
+I256 root keys:
+0x00
+  L  0x0 0x0 0x0 0x0 0x0 0x0 0x0
+...
+0xFC
+  L  0x0 0x0 0x0 0x0 0x0 0x0 0x0
+
+after:
+
+I256 root keys:
+0x0
+ I4 0x0 0x0 0x0 0x0 0x0 0x0 - prefix, keys:
+                            0x0
+                          L 0x0
+                            0x1
+                          L 0x1
+0x1
+ I4 0x0 0x0 0x0 0x0 0x0 - prefix, keys:
+                        0x0
+                          L 0x0
+                        0x1
+                          L 0x0
+0x2
+ I4 0x0 0x0 0x0 0x0 - prefix, keys:
+                    0x0
+                      L 0x0 0x0
+                    0x1
+                      L 0x0 0x0
+...
+0x6
+I4 keys:
+    0x0
+      L 0x0 0x0 0x0 0x0 0x0 0x0
+    0x1
+      L 0x0 0x0 0x0 0x0 0x0 0x0
+0x7 to 0xFC: the above repeated
+
+Keys to be inserted in preparation:
+0x0000000000000000
+0x0100000000000000
+...
+0x0600000000000000
+
+In benchmark:
+0x0000000000000001
+0x0100000000000100
+...
+0x0601000000000000
+... and repeated
+
+*/
+
+void insert_keys(unodb::db &test_db, const std::vector<unodb::key> &keys) {
+  for (const auto k : keys) {
+    unodb::benchmark::insert_key(test_db, k,
+                                 unodb::value_view{unodb::benchmark::value100});
+  }
+}
+
+void unpredictable_leaf_key_prefix_split(benchmark::State &state) {
+  static constexpr auto stride_len = 7;
+  static constexpr auto num_strides = 36;
+  static constexpr auto num_top_bytes = stride_len * num_strides;
+  static_assert(num_top_bytes < 256);
+
+  std::vector<unodb::key> prepare_insert_keys{};
+  prepare_insert_keys.reserve(num_top_bytes);
+  std::vector<unodb::key> benchmark_insert_keys{};
+  benchmark_insert_keys.reserve(num_top_bytes);
+  for (std::uint8_t top_byte = 0x00; top_byte < num_top_bytes; ++top_byte) {
+    const auto first_key = static_cast<std::uint64_t>(top_byte) << 56U;
+
+    // Quadratic but debug build only
+    assert(std::find(prepare_insert_keys.cbegin(), prepare_insert_keys.cend(),
+                     first_key) == prepare_insert_keys.cend());
+    assert(std::find(benchmark_insert_keys.cbegin(),
+                     benchmark_insert_keys.cend(),
+                     first_key) == benchmark_insert_keys.cend());
+    prepare_insert_keys.push_back(first_key);
+
+    const auto second_key = first_key | (1ULL << (top_byte % 7 * 8));
+    // Quadratic but debug build only
+    assert(std::find(prepare_insert_keys.cbegin(), prepare_insert_keys.cend(),
+                     second_key) == prepare_insert_keys.cend());
+    assert(std::find(benchmark_insert_keys.cbegin(),
+                     benchmark_insert_keys.cend(),
+                     second_key) == benchmark_insert_keys.cend());
+    benchmark_insert_keys.push_back(second_key);
+  }
+
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    unodb::db test_db;
+    insert_keys(test_db, prepare_insert_keys);
+    std::shuffle(benchmark_insert_keys.begin(), benchmark_insert_keys.end(),
+                 gen);
+    state.ResumeTiming();
+
+    insert_keys(test_db, benchmark_insert_keys);
+
+    state.PauseTiming();
+    unodb::benchmark::destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(
+      state.iterations() * benchmark_insert_keys.size()));
+}
+
 }  // namespace
 
 BENCHMARK(unpredictable_get_shared_length)->Unit(benchmark::kMicrosecond);
+BENCHMARK(unpredictable_leaf_key_prefix_split)->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
At the same time cleanup unpredictable_get_shared_length a bit.