### PR TITLE
Implement branchless inode::cut_key_prefix

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -324,8 +324,15 @@ class inode {
     assert(cut_len > 0);
     assert(cut_len <= key_prefix_length());
 
-    std::copy(f.f.key_prefix_data.cbegin() + cut_len,
-              f.f.key_prefix_data.cend(), f.f.key_prefix_data.begin());
+    const auto type = static_cast<std::uint8_t>(f.f.header.type());
+    const auto prefix_word =
+        static_cast<std::uint64_t>(f.words[1]) << 32U | f.words[0];
+    const auto cut_prefix_word =
+        ((prefix_word >> (cut_len * 8)) & 0xFFFFFFFFFFFFFF00ULL) | type;
+    f.words[0] =
+        gsl::narrow_cast<std::uint32_t>(cut_prefix_word & 0xFFFFFFFFULL);
+    f.words[1] = gsl::narrow_cast<std::uint32_t>(cut_prefix_word >> 32U);
+
     f.f.key_prefix_length =
         gsl::narrow_cast<key_prefix_size_type>(key_prefix_length() - cut_len);
   }


### PR DESCRIPTION
Performance change: baseline:

2020-06-24 16:07:10
Running ./micro_benchmark_key_prefix
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.46, 0.39, 0.16
---------------------------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------
unpredictable_cut_key_prefix       26.1 us         26.1 us        26845 items_per_second=9.6721M/s

With the change:

unpredictable_cut_key_prefix       24.1 us         24.1 us        29054 items_per_second=10.4606M/s

U test:

Benchmark                                             Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------
unpredictable_cut_key_prefix                       -0.1035         -0.1040            27            24            27            24
unpredictable_cut_key_prefix                       -0.1041         -0.1047            27            24            27            24
unpredictable_cut_key_prefix                       -0.1037         -0.1043            27            24            27            24
unpredictable_cut_key_prefix                       -0.1073         -0.1078            27            24            27            24
unpredictable_cut_key_prefix                       -0.1026         -0.1032            27            24            27            24
unpredictable_cut_key_prefix                       -0.1006         -0.1012            27            24            27            24
unpredictable_cut_key_prefix                       -0.1005         -0.1011            27            24            27            24
unpredictable_cut_key_prefix                       -0.1002         -0.1008            27            24            27            24
unpredictable_cut_key_prefix                       -0.1003         -0.1008            27            24            27            24
unpredictable_cut_key_prefix_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
unpredictable_cut_key_prefix_mean                  -0.1025         -0.1031            27            24            27            24
unpredictable_cut_key_prefix_median                -0.1018         -0.1023            27            24            27            24
unpredictable_cut_key_prefix_stddev                +0.1603         +0.1969             0             0             0             0