### PR TITLE
inode_4::remove: replace std::copy on key bytes and children with one…

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -434,27 +434,6 @@ class inode {
   }
   RESTORE_GCC_WARNINGS()
 
-  template <typename KeysType, typename ChildrenType>
-  static void remove_from_sorted_key_children_arrays(
-      KeysType &keys, ChildrenType &children, std::uint8_t &children_count,
-      std::uint8_t child_to_remove) noexcept {
-    assert(child_to_remove < children_count);
-    assert(std::is_sorted(keys.cbegin(), keys.cbegin() + children_count));
-
-    std::copy(keys.cbegin() + child_to_remove + 1,
-              keys.cbegin() + children_count, keys.begin() + child_to_remove);
-
-    delete_node_ptr_at_scope_exit delete_on_scope_exit{
-        children[child_to_remove]};
-
-    std::copy(children.begin() + child_to_remove + 1,
-              children.begin() + children_count,
-              children.begin() + child_to_remove);
-    --children_count;
-
-    assert(std::is_sorted(keys.cbegin(), keys.cbegin() + children_count));
-  }
-
  private:
   static constexpr auto key_bytes_mask = 0xFFFFFFFF'FFFFFF00ULL;
 
@@ -707,9 +686,22 @@ class inode_4 final : public basic_inode_4 {
 
   void remove(std::uint8_t child_index) noexcept {
     assert(reinterpret_cast<node_header *>(this)->type() == static_node_type);
+    assert(child_index < f.f.children_count);
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + f.f.children_count));
 
-    remove_from_sorted_key_children_arrays(keys.byte_array, children,
-                                           f.f.children_count, child_index);
+    delete_node_ptr_at_scope_exit delete_on_scope_exit{children[child_index]};
+
+    for (decltype(keys.byte_array)::size_type i = child_index;
+         i < static_cast<unsigned>(f.f.children_count - 1); ++i) {
+      keys.byte_array[i] = keys.byte_array[i + 1];
+      children[i] = children[i + 1];
+    }
+
+    --f.f.children_count;
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + f.f.children_count));
   }
 
   auto leave_last_child(std::uint8_t child_to_delete) noexcept {
@@ -865,8 +857,7 @@ class inode_16 final : public basic_inode_16 {
   void remove(std::uint8_t child_index) noexcept {
     assert(reinterpret_cast<node_header *>(this)->type() == static_node_type);
 
-    remove_from_sorted_key_children_arrays(keys.byte_array, children,
-                                           f.f.children_count, child_index);
+    remove_from_sorted_key_children_arrays(child_index);
   }
 
   [[nodiscard]] find_result_type find_child(std::byte key_byte) noexcept;
@@ -895,6 +886,28 @@ class inode_16 final : public basic_inode_16 {
     keys.byte_array[insert_pos_index] = key_byte;
     children[insert_pos_index] = child.release();
     ++f.f.children_count;
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + f.f.children_count));
+  }
+
+  void remove_from_sorted_key_children_arrays(
+      std::uint8_t child_to_remove) noexcept {
+    assert(child_to_remove < f.f.children_count);
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + f.f.children_count));
+
+    std::copy(keys.byte_array.cbegin() + child_to_remove + 1,
+              keys.byte_array.cbegin() + f.f.children_count,
+              keys.byte_array.begin() + child_to_remove);
+
+    delete_node_ptr_at_scope_exit delete_on_scope_exit{
+        children[child_to_remove]};
+
+    std::copy(children.begin() + child_to_remove + 1,
+              children.begin() + f.f.children_count,
+              children.begin() + child_to_remove);
+    --f.f.children_count;
 
     assert(std::is_sorted(keys.byte_array.cbegin(),
                           keys.byte_array.cbegin() + f.f.children_count));


### PR DESCRIPTION
… manual loop

This makes inode::remove_from_sorted_key_children_arrays an inode16-specific
method, so move it there.

Performance: baseline:

2020-06-27 17:01:40
Running ./micro_benchmark_node4
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.37, 0.22, 0.08
---------------------------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------
full_node4_sequential_delete/100         6.67 us         6.67 us       104778 items_per_second=15.0029M/s
full_node4_sequential_delete/512         35.0 us         35.0 us        20023 items_per_second=14.6462M/s
full_node4_sequential_delete/4096         320 us          320 us         2190 items_per_second=12.813M/s
full_node4_sequential_delete/32768       3011 us         3011 us          232 items_per_second=10.8826M/s
full_node4_sequential_delete/65535       6560 us         6560 us          107 items_per_second=9.99071M/s
full_node4_random_deletes/100            8.69 us         8.68 us        80621 items_per_second=11.5189M/s
full_node4_random_deletes/512            47.5 us         47.5 us        14749 items_per_second=10.7877M/s
full_node4_random_deletes/4096            458 us          458 us         1528 items_per_second=8.94025M/s
full_node4_random_deletes/32768          5467 us         5467 us          128 items_per_second=5.99398M/s
full_node4_random_deletes/65535         14420 us        14420 us           48 items_per_second=4.54461M/s

With the change:

full_node4_sequential_delete/100         6.57 us         6.57 us       106379 items_per_second=15.2283M/s
full_node4_sequential_delete/512         34.7 us         34.7 us        20154 items_per_second=14.7439M/s
full_node4_sequential_delete/4096         316 us          316 us         2213 items_per_second=12.961M/s
full_node4_sequential_delete/32768       2981 us         2982 us          235 items_per_second=10.9903M/s
full_node4_sequential_delete/65535       6514 us         6514 us          108 items_per_second=10.0605M/s
full_node4_random_deletes/100            8.46 us         8.45 us        82783 items_per_second=11.8275M/s
full_node4_random_deletes/512            45.8 us         45.8 us        15272 items_per_second=11.1706M/s
full_node4_random_deletes/4096            447 us          447 us         1565 items_per_second=9.15489M/s
full_node4_random_deletes/32768          5353 us         5353 us          130 items_per_second=6.12092M/s
full_node4_random_deletes/65535         14201 us        14201 us           49 items_per_second=4.6147M/s

U-test:

full_node4_sequential_delete/100_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_delete/100_mean                    -0.0158         -0.0140             7             7             7             7
full_node4_sequential_delete/512_pvalue                   0.0521          0.0521      U Test, Repetitions: 9 vs 9
full_node4_sequential_delete/512_mean                    -0.0064         -0.0063            35            35            35            35
full_node4_sequential_delete/4096_pvalue                  0.0217          0.0217      U Test, Repetitions: 9 vs 9
full_node4_sequential_delete/4096_mean                   +0.0010         +0.0010           317           317           317           317
full_node4_sequential_delete/32768_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_delete/32768_mean                  -0.0105         -0.0105          3014          2983          3014          2983
full_node4_sequential_delete/65535_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_sequential_delete/65535_mean                  -0.0062         -0.0062          6538          6498          6538          6498
full_node4_random_deletes/100_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_deletes/100_mean                       -0.0247         -0.0251             9             8             9             8
full_node4_random_deletes/512_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_deletes/512_mean                       -0.0333         -0.0333            48            46            48            46
full_node4_random_deletes/4096_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_deletes/4096_mean                      -0.0090         -0.0090           457           453           457           453
full_node4_random_deletes/32768_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node4_random_deletes/32768_mean                     -0.0055         -0.0055          5388          5359          5388          5359
full_node4_random_deletes/65535_pvalue                    0.0171          0.0171      U Test, Repetitions: 9 vs 9
full_node4_random_deletes/65535_mean                     +0.0027         +0.0027         14371         14410         14370         14410