### PR TITLE
Minor fixes from running benchmarks in debug builds

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -398,7 +398,6 @@ class inode {
         tree_depth depth) noexcept
       : f{type, k1, k2, depth, children_count} {
     assert(type != node_type::LEAF);
-    assert(k1 != k2);
   }
 
   inode(node_type type, unsigned children_count, unsigned key_prefix_len,

--- a/benchmark/micro_benchmark_node4.cpp
+++ b/benchmark/micro_benchmark_node4.cpp
@@ -22,7 +22,9 @@ constexpr auto sparse_node4_key_zero_bits = 0xFEFEFEFE'FEFEFEFEULL;
 // constexpr auto sparse_single_node4_mask = 0x1;
 constexpr auto dense_single_node4_mask = 0x3;
 
-inline auto next_node4_key(unodb::key k, std::uint64_t key_zero_bits) {
+constexpr inline auto next_node4_key(unodb::key k,
+                                     std::uint64_t key_zero_bits) noexcept {
+  assert((k & key_zero_bits) == 0);
   const auto result = ((k | key_zero_bits) + 1) & ~key_zero_bits;
   assert(result > k);
   return result;


### PR DESCRIPTION
Remove a spurious assert which compared full key and shifted right key.

At the same time add an assert to next_node4_key and mark it as a constexpr
noexcept.