### PR TITLE
Remove the notion of memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ returned. How long would it remain valid depends on the ART concurrency flavor.
 
 All ART classes implement the same API:
 
-* constructor, with optional memory limit parameter, exceeding which will throw
-  `std::bad_alloc`.
+* constructor.
 * `get(key k)`, returning `get_result`, which is `std::optional<value_view>`.
 * `bool insert(key k, value_view v)`, returning whether insert was
   successful (i.e. the key was not already present).

--- a/art.cpp
+++ b/art.cpp
@@ -1791,21 +1791,6 @@ void db::clear() {
   inode256_count = 0;
 }
 
-DISABLE_GCC_WARNING("-Wsuggest-attribute=cold")
-void db::increase_memory_use(std::size_t delta) {
-  if (memory_limit == 0 || delta == 0) return;
-  assert(current_memory_use <= memory_limit);
-  if (current_memory_use + delta > memory_limit) throw std::bad_alloc{};
-  current_memory_use += delta;
-}
-RESTORE_GCC_WARNINGS()
-
-void db::decrease_memory_use(std::size_t delta) noexcept {
-  if (memory_limit == 0 || delta == 0) return;
-  assert(delta <= current_memory_use);
-  current_memory_use -= delta;
-}
-
 }  // namespace unodb
 
 namespace {
@@ -1835,13 +1820,7 @@ void dump_node(std::ostream &os, const unodb::detail::node_ptr &node) {
 namespace unodb {
 
 void db::dump(std::ostream &os) const {
-  os << "db dump ";
-  if (memory_limit == 0) {
-    os << "(no memory limit):\n";
-  } else {
-    os << "memory limit = " << memory_limit
-       << ", currently used = " << get_current_memory_use() << '\n';
-  }
+  os << "db dump, current memory use = " << get_current_memory_use() << '\n';
   dump_node(os, root);
 }
 

--- a/art.hpp
+++ b/art.hpp
@@ -153,8 +153,7 @@ union node_ptr {
 class db final {
  public:
   // Creation and destruction
-  explicit db(std::size_t memory_limit_ = 0) noexcept
-      : memory_limit{memory_limit_} {}
+  db() noexcept {}
 
   ~db() noexcept;
 
@@ -173,8 +172,7 @@ class db final {
 
   // Stats
 
-  // Return current memory use by tree nodes in bytes, only accounted if memory
-  // limit was specified in the constructor, otherwise always zero.
+  // Return current memory use by tree nodes in bytes.
   [[nodiscard]] auto get_current_memory_use() const noexcept {
     return current_memory_use;
   }
@@ -235,13 +233,18 @@ class db final {
   __attribute__((cold, noinline)) void dump(std::ostream &os) const;
 
  private:
-  void increase_memory_use(std::size_t delta);
-  void decrease_memory_use(std::size_t delta) noexcept;
+  void increase_memory_use(std::size_t delta) noexcept {
+    current_memory_use += delta;
+  }
+
+  void decrease_memory_use(std::size_t delta) noexcept {
+    assert(delta <= current_memory_use);
+    current_memory_use -= delta;
+  }
 
   detail::node_ptr root{nullptr};
 
   std::size_t current_memory_use{0};
-  const std::size_t memory_limit;
 
   std::uint64_t leaf_count{0};
   std::uint64_t inode4_count{0};

--- a/benchmark/micro_benchmark_node4.cpp
+++ b/benchmark/micro_benchmark_node4.cpp
@@ -82,7 +82,7 @@ void node4_sequential_insert(benchmark::State &state,
 
   for (auto _ : state) {
     state.PauseTiming();
-    unodb::db test_db{1000ULL * 1000 * 1000 * 1000};
+    unodb::db test_db;
     benchmark::ClobberMemory();
     state.ResumeTiming();
 

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -13,8 +13,7 @@ namespace unodb {
 class mutex_db final {
  public:
   // Creation and destruction
-  explicit mutex_db(std::size_t memory_limit = 0) noexcept
-      : db_{memory_limit} {}
+  mutex_db() noexcept : db_{} {}
 
   // Querying
   [[nodiscard]] auto get(key k) const noexcept {

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -44,7 +44,7 @@ RESTORE_CLANG_WARNINGS()
 DISABLE_GCC_WARNING("-Wsuggest-override")
 
 TYPED_TEST(ART, SingleNodeTreeEmptyValue) {
-  tree_verifier<TypeParam> verifier{1024};
+  tree_verifier<TypeParam> verifier;
   verifier.check_absent_keys({1});
   verifier.insert(1, {});
   verifier.assert_node_counts(1, 0, 0, 0, 0);
@@ -55,7 +55,7 @@ TYPED_TEST(ART, SingleNodeTreeEmptyValue) {
 }
 
 TYPED_TEST(ART, SingleNodeTreeNonemptyValue) {
-  tree_verifier<TypeParam> verifier{1024};
+  tree_verifier<TypeParam> verifier;
   verifier.insert(1, test_values[2]);
   verifier.assert_node_counts(1, 0, 0, 0, 0);
   verifier.assert_increasing_nodes(0, 0, 0, 0);
@@ -81,7 +81,7 @@ TYPED_TEST(ART, TooLongValue) {
 }
 
 TYPED_TEST(ART, ExpandLeafToNode4) {
-  tree_verifier<TypeParam> verifier{1024};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(0, test_values[1]);
   verifier.assert_node_counts(1, 0, 0, 0, 0);
@@ -96,7 +96,7 @@ TYPED_TEST(ART, ExpandLeafToNode4) {
 }
 
 TYPED_TEST(ART, DuplicateKey) {
-  tree_verifier<TypeParam> verifier{1024};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(0, test_values[0]);
   verifier.assert_node_counts(1, 0, 0, 0, 0);
@@ -111,7 +111,7 @@ TYPED_TEST(ART, DuplicateKey) {
 }
 
 TYPED_TEST(ART, InsertToFullNode4) {
-  tree_verifier<TypeParam> verifier{1024};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 4);
   verifier.assert_node_counts(4, 1, 0, 0, 0);
@@ -122,7 +122,7 @@ TYPED_TEST(ART, InsertToFullNode4) {
 }
 
 TYPED_TEST(ART, TwoNode4) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(1, test_values[0]);
   verifier.insert(3, test_values[2]);
@@ -139,7 +139,7 @@ TYPED_TEST(ART, TwoNode4) {
 }
 
 TYPED_TEST(ART, DbInsertNodeRecursion) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(1, test_values[0]);
   verifier.insert(3, test_values[2]);
@@ -160,7 +160,7 @@ TYPED_TEST(ART, DbInsertNodeRecursion) {
 }
 
 TYPED_TEST(ART, Node16) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 5);
   verifier.assert_node_counts(5, 0, 1, 0, 0);
@@ -171,7 +171,7 @@ TYPED_TEST(ART, Node16) {
 }
 
 TYPED_TEST(ART, FullNode16) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 16);
   verifier.assert_node_counts(16, 0, 1, 0, 0);
@@ -182,7 +182,7 @@ TYPED_TEST(ART, FullNode16) {
 }
 
 TYPED_TEST(ART, Node16KeyPrefixSplit) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(10, 5);
 
@@ -197,7 +197,7 @@ TYPED_TEST(ART, Node16KeyPrefixSplit) {
 }
 
 TYPED_TEST(ART, Node16KeyInsertOrderDescending) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(5, test_values[0]);
   verifier.insert(4, test_values[1]);
@@ -212,7 +212,7 @@ TYPED_TEST(ART, Node16KeyInsertOrderDescending) {
 }
 
 TYPED_TEST(ART, Node48) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 17);
   verifier.assert_node_counts(17, 0, 0, 1, 0);
@@ -223,7 +223,7 @@ TYPED_TEST(ART, Node48) {
 }
 
 TYPED_TEST(ART, FullNode48) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 48);
   verifier.assert_node_counts(48, 0, 0, 1, 0);
@@ -234,7 +234,7 @@ TYPED_TEST(ART, FullNode48) {
 }
 
 TYPED_TEST(ART, Node48KeyPrefixSplit) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(10, 17);
   verifier.assert_node_counts(17, 0, 0, 1, 0);
@@ -252,7 +252,7 @@ TYPED_TEST(ART, Node48KeyPrefixSplit) {
 }
 
 TYPED_TEST(ART, Node256) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 49);
   verifier.assert_node_counts(49, 0, 0, 0, 1);
@@ -263,7 +263,7 @@ TYPED_TEST(ART, Node256) {
 }
 
 TYPED_TEST(ART, FullNode256) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 256);
   verifier.assert_node_counts(256, 0, 0, 0, 1);
@@ -274,7 +274,7 @@ TYPED_TEST(ART, FullNode256) {
 }
 
 TYPED_TEST(ART, Node256KeyPrefixSplit) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(20, 49);
   verifier.assert_node_counts(49, 0, 0, 0, 1);
@@ -292,7 +292,7 @@ TYPED_TEST(ART, Node256KeyPrefixSplit) {
 }
 
 TYPED_TEST(ART, TryDeleteFromEmpty) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.attempt_remove_missing_keys({1});
   verifier.assert_empty();
@@ -300,7 +300,7 @@ TYPED_TEST(ART, TryDeleteFromEmpty) {
 }
 
 TYPED_TEST(ART, SingleNodeTreeDelete) {
-  tree_verifier<TypeParam> verifier{1024};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(1, test_values[0]);
   verifier.remove(1);
@@ -311,7 +311,7 @@ TYPED_TEST(ART, SingleNodeTreeDelete) {
 }
 
 TYPED_TEST(ART, Node4AttemptDeleteAbsent) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 4);
   verifier.attempt_remove_missing_keys({0, 6, 0xFF000001});
@@ -321,7 +321,7 @@ TYPED_TEST(ART, Node4AttemptDeleteAbsent) {
 }
 
 TYPED_TEST(ART, Node4FullDeleteMiddleAndBeginning) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 4);
   // Delete from Node4 middle
@@ -337,7 +337,7 @@ TYPED_TEST(ART, Node4FullDeleteMiddleAndBeginning) {
 }
 
 TYPED_TEST(ART, Node4FullDeleteEndAndMiddle) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 4);
   // Delete from Node4 end
@@ -353,7 +353,7 @@ TYPED_TEST(ART, Node4FullDeleteEndAndMiddle) {
 }
 
 TYPED_TEST(ART, Node4ShrinkToSingleLeaf) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 2);
   verifier.assert_shrinking_nodes(0, 0, 0, 0);
@@ -367,7 +367,7 @@ TYPED_TEST(ART, Node4ShrinkToSingleLeaf) {
 }
 
 TYPED_TEST(ART, Node4DeleteLowerNode) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0, 2);
   // Insert a value that does not share full prefix with the current Node4
@@ -386,7 +386,7 @@ TYPED_TEST(ART, Node4DeleteLowerNode) {
 }
 
 TYPED_TEST(ART, Node4DeleteKeyPrefixMerge) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0x8001, 2);
   // Insert a value that does not share full prefix with the current Node4
@@ -407,7 +407,7 @@ TYPED_TEST(ART, Node4DeleteKeyPrefixMerge) {
 }
 
 TYPED_TEST(ART, Node16DeleteBeginningMiddleEnd) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 16);
   verifier.remove(5);
@@ -421,7 +421,7 @@ TYPED_TEST(ART, Node16DeleteBeginningMiddleEnd) {
 }
 
 TYPED_TEST(ART, Node16ShrinkToNode4DeleteMiddle) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 5);
   verifier.assert_node_counts(5, 0, 1, 0, 0);
@@ -435,7 +435,7 @@ TYPED_TEST(ART, Node16ShrinkToNode4DeleteMiddle) {
 }
 
 TYPED_TEST(ART, Node16ShrinkToNode4DeleteBeginning) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 5);
   verifier.assert_node_counts(5, 0, 1, 0, 0);
@@ -449,7 +449,7 @@ TYPED_TEST(ART, Node16ShrinkToNode4DeleteBeginning) {
 }
 
 TYPED_TEST(ART, Node16ShrinkToNode4DeleteEnd) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 5);
   verifier.assert_node_counts(5, 0, 1, 0, 0);
@@ -463,7 +463,7 @@ TYPED_TEST(ART, Node16ShrinkToNode4DeleteEnd) {
 }
 
 TYPED_TEST(ART, Node16KeyPrefixMerge) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(10, 5);
   // Insert a value that does not share full prefix with the current Node16
@@ -482,7 +482,7 @@ TYPED_TEST(ART, Node16KeyPrefixMerge) {
 }
 
 TYPED_TEST(ART, Node48DeleteBeginningMiddleEnd) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 48);
   verifier.remove(30);
@@ -496,7 +496,7 @@ TYPED_TEST(ART, Node48DeleteBeginningMiddleEnd) {
 }
 
 TYPED_TEST(ART, Node48ShrinkToNode16DeleteMiddle) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(0x80, 17);
   verifier.assert_node_counts(17, 0, 0, 1, 0);
@@ -510,7 +510,7 @@ TYPED_TEST(ART, Node48ShrinkToNode16DeleteMiddle) {
 }
 
 TYPED_TEST(ART, Node48ShrinkToNode16DeleteBeginning) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 17);
   verifier.assert_node_counts(17, 0, 0, 1, 0);
@@ -524,7 +524,7 @@ TYPED_TEST(ART, Node48ShrinkToNode16DeleteBeginning) {
 }
 
 TYPED_TEST(ART, Node48ShrinkToNode16DeleteEnd) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 17);
   verifier.assert_node_counts(17, 0, 0, 1, 0);
@@ -538,7 +538,7 @@ TYPED_TEST(ART, Node48ShrinkToNode16DeleteEnd) {
 }
 
 TYPED_TEST(ART, Node48KeyPrefixMerge) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(10, 17);
   // Insert a value that does not share full prefix with the current Node48
@@ -556,7 +556,7 @@ TYPED_TEST(ART, Node48KeyPrefixMerge) {
 }
 
 TYPED_TEST(ART, Node256DeleteBeginningMiddleEnd) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 256);
   verifier.remove(180);
@@ -569,7 +569,7 @@ TYPED_TEST(ART, Node256DeleteBeginningMiddleEnd) {
 }
 
 TYPED_TEST(ART, Node256ShrinkToNode48DeleteMiddle) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 49);
   verifier.assert_node_counts(49, 0, 0, 0, 1);
@@ -583,7 +583,7 @@ TYPED_TEST(ART, Node256ShrinkToNode48DeleteMiddle) {
 }
 
 TYPED_TEST(ART, Node256ShrinkToNode48DeleteBeginning) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 49);
   verifier.assert_node_counts(49, 0, 0, 0, 1);
@@ -597,7 +597,7 @@ TYPED_TEST(ART, Node256ShrinkToNode48DeleteBeginning) {
 }
 
 TYPED_TEST(ART, Node256ShrinkToNode48DeleteEnd) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(1, 49);
   verifier.assert_node_counts(49, 0, 0, 0, 1);
@@ -611,7 +611,7 @@ TYPED_TEST(ART, Node256ShrinkToNode48DeleteEnd) {
 }
 
 TYPED_TEST(ART, Node256KeyPrefixMerge) {
-  tree_verifier<TypeParam> verifier{20480};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert_key_range(10, 49);
   // Insert a value that does not share full prefix with the current Node256
@@ -629,7 +629,7 @@ TYPED_TEST(ART, Node256KeyPrefixMerge) {
 }
 
 TYPED_TEST(ART, MissingKeyWithPresentPrefix) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(0x010000, test_values[0]);
   verifier.insert(0x000001, test_values[1]);
@@ -639,47 +639,15 @@ TYPED_TEST(ART, MissingKeyWithPresentPrefix) {
 }
 
 TYPED_TEST(ART, MissingKeyMatchingInodePath) {
-  tree_verifier<TypeParam> verifier{10240};
+  tree_verifier<TypeParam> verifier;
 
   verifier.insert(0x0100, test_values[0]);
   verifier.insert(0x0200, test_values[1]);
   verifier.attempt_remove_missing_keys({0x0101, 0x0202});
 }
 
-TYPED_TEST(ART, MemoryLimitBelowMinimum) {
-  tree_verifier<TypeParam> verifier{1};
-  verifier.test_insert_until_memory_limit(0, 0, 0, 0, 0);
-}
-
-TYPED_TEST(ART, MemoryLimitOneLeaf) {
-  tree_verifier<TypeParam> verifier{16};
-  verifier.test_insert_until_memory_limit(1, 0, 0, 0, 0);
-}
-
-TYPED_TEST(ART, MemoryLimitOneNode4) {
-  tree_verifier<TypeParam> verifier{80};
-  verifier.test_insert_until_memory_limit(std::nullopt, 1, 0, 0, 0);
-}
-
-TYPED_TEST(ART, MemoryLimitOneNode16) {
-  tree_verifier<TypeParam> verifier{320};
-  verifier.test_insert_until_memory_limit(std::nullopt, std::nullopt, 1, 0, 0);
-}
-
-TYPED_TEST(ART, MemoryLimitOneNode48) {
-  tree_verifier<TypeParam> verifier{1024};
-  verifier.test_insert_until_memory_limit(std::nullopt, std::nullopt,
-                                          std::nullopt, 1, 0);
-}
-
-TYPED_TEST(ART, MemoryLimitOneNode256) {
-  tree_verifier<TypeParam> verifier{4096};
-  verifier.test_insert_until_memory_limit(std::nullopt, std::nullopt,
-                                          std::nullopt, std::nullopt, 1);
-}
-
 TYPED_TEST(ART, MemoryAccountingDuplicateKeyInsert) {
-  tree_verifier<TypeParam> verifier{2048};
+  tree_verifier<TypeParam> verifier;
   verifier.insert(0, test_values[0]);
   ASSERT_FALSE(verifier.get_db().insert(0, test_values[1]));
   verifier.remove(0);
@@ -687,7 +655,7 @@ TYPED_TEST(ART, MemoryAccountingDuplicateKeyInsert) {
 }
 
 TYPED_TEST(ART, Node48InsertIntoDeletedSlot) {
-  tree_verifier<TypeParam> verifier{4096};
+  tree_verifier<TypeParam> verifier;
   verifier.insert(16865361447928765957ULL, test_values[0]);
   verifier.insert(7551546784238320931ULL, test_values[1]);
   verifier.insert(10913915230368519832ULL, test_values[2]);
@@ -712,55 +680,6 @@ TYPED_TEST(ART, Node48InsertIntoDeletedSlot) {
   verifier.assert_node_counts(18, 0, 0, 1, 0);
 }
 
-TYPED_TEST(ART, MemoryAccountingGrowingNodeException) {
-  tree_verifier<TypeParam> verifier{1024};
-
-  verifier.insert_key_range(0, 4);
-  verifier.assert_node_counts(4, 1, 0, 0, 0);
-
-  std::array<std::byte, 900> large_value;
-  const unodb::value_view large_value_view{large_value};
-
-  // The leaf node will be created first and will take memory use almost to the
-  // limit, then Node16 allocation will go over the limit
-  ASSERT_THROW(verifier.insert(10, large_value_view), std::bad_alloc);
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({10});
-  verifier.assert_node_counts(4, 1, 0, 0, 0);
-}
-
-TYPED_TEST(ART, MemoryAccountingLeafToNode4Exception) {
-  tree_verifier<TypeParam> verifier{50};
-
-  verifier.insert(0, test_values[0]);
-  verifier.assert_node_counts(1, 0, 0, 0, 0);
-
-  ASSERT_THROW(verifier.insert(1, test_values[1]), std::bad_alloc);
-  verifier.assert_node_counts(1, 0, 0, 0, 0);
-  verifier.assert_increasing_nodes(0, 0, 0, 0);
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({1});
-}
-
-TYPED_TEST(ART, MemoryAccountingPrefixSplitException) {
-  tree_verifier<TypeParam> verifier{140};
-
-  verifier.insert(1, test_values[0]);
-  verifier.insert(3, test_values[2]);
-  verifier.assert_node_counts(2, 1, 0, 0, 0);
-
-  // Try to insert a value that does not share full prefix with the current
-  // Node4
-  ASSERT_THROW(verifier.insert(0xFF01, test_values[3]), std::bad_alloc);
-  verifier.assert_node_counts(2, 1, 0, 0, 0);
-  verifier.assert_increasing_nodes(1, 0, 0, 0);
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({0xFF01});
-}
-
 TYPED_TEST(ART, ClearOnEmpty) {
   tree_verifier<TypeParam> verifier;
 
@@ -777,18 +696,6 @@ TYPED_TEST(ART, Clear) {
   verifier.clear();
 
   verifier.check_absent_keys({1});
-  verifier.assert_node_counts(0, 0, 0, 0, 0);
-}
-
-TYPED_TEST(ART, ClearWithMemLimit) {
-  tree_verifier<TypeParam> verifier{13};
-
-  verifier.insert(0, empty_test_value);
-  verifier.assert_node_counts(1, 0, 0, 0, 0);
-
-  verifier.clear();
-
-  verifier.check_absent_keys({0});
   verifier.assert_node_counts(0, 0, 0, 0, 0);
 }
 

--- a/test_art_mutex_concurrency.cpp
+++ b/test_art_mutex_concurrency.cpp
@@ -21,7 +21,7 @@ TEST(ARTMutexConcurrency, ParallelInsertOneTree) {
   constexpr auto num_of_threads = 4;
   constexpr auto total_keys = 1024;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.preinsert_key_range_to_verifier_only(0, total_keys);
   std::array<std::thread, num_of_threads> threads;
   unodb::key i = 0;
@@ -47,7 +47,7 @@ TEST(ARTMutexConcurrency, ParallelTearDownOneTree) {
   constexpr auto num_of_threads = 8;
   constexpr auto total_keys = 2048;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.insert_key_range(0, total_keys);
   unodb::key i = 0;
   std::array<std::thread, num_of_threads> threads;
@@ -85,7 +85,7 @@ TEST(ARTMutexConcurrency, Node4ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 6;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.insert_key_range(0, 3, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -100,7 +100,7 @@ TEST(ARTMutexConcurrency, Node16ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 12;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.insert_key_range(0, 10, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -115,7 +115,7 @@ TEST(ARTMutexConcurrency, Node48ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 32;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.insert_key_range(0, 32, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -130,7 +130,7 @@ TEST(ARTMutexConcurrency, Node256ParallelOps) {
   constexpr auto num_of_threads = 9;
   constexpr auto op_count = 208;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.insert_key_range(0, 152, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {
@@ -167,7 +167,7 @@ TEST(ARTMutexConcurrency, ParallelRandomInsertDeleteGet) {
   constexpr auto initial_keys = 2048;
   constexpr auto ops_per_thread = 10000;
 
-  tree_verifier<unodb::mutex_db> verifier{0, true};
+  tree_verifier<unodb::mutex_db> verifier{true};
   verifier.insert_key_range(0, initial_keys, true);
   std::array<std::thread, num_of_threads> threads;
   for (std::size_t i = 0; i < num_of_threads; ++i) {


### PR DESCRIPTION
It is better handled by the library user anyway. Make get_current_memory_use
account memory always.