### PR TITLE
Implement benchmark for Node16 shrinking to Node4 randomly

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,12 +1,22 @@
 # Copyright 2020 Laurynas Biveinis
 
+add_library(micro_benchmark_utils STATIC micro_benchmark_utils.cpp
+  micro_benchmark_utils.hpp)
+common_target_properties(micro_benchmark_utils)
+target_include_directories(micro_benchmark_utils PUBLIC ".")
+target_link_libraries(micro_benchmark_utils PUBLIC unodb)
+target_link_libraries(micro_benchmark_utils PUBLIC benchmark::benchmark)
+target_include_directories(micro_benchmark_utils SYSTEM PUBLIC
+  ${benchmark_include_dirs})
+if(DO_CLANG_TIDY)
+   set_target_properties(micro_benchmark_utils PROPERTIES CXX_CLANG_TIDY
+     "${DO_CLANG_TIDY}")
+endif()
+
 function(ADD_BENCHMARK_TARGET TARGET)
-  add_executable("${TARGET}" "${TARGET}.cpp" micro_benchmark.hpp)
+  add_executable("${TARGET}" "${TARGET}.cpp")
   common_target_properties("${TARGET}")
-  target_include_directories("${TARGET}" SYSTEM PRIVATE
-    ${benchmark_include_dirs})
-  target_link_libraries("${TARGET}" PRIVATE benchmark::benchmark)
-  target_link_libraries("${TARGET}" PRIVATE unodb)
+  target_link_libraries("${TARGET}" PRIVATE micro_benchmark_utils)
 endfunction()
 
 add_benchmark_target(micro_benchmark_key_prefix)

--- a/benchmark/micro_benchmark.cpp
+++ b/benchmark/micro_benchmark.cpp
@@ -7,7 +7,7 @@
 #include <benchmark/benchmark.h>
 
 #include "art.hpp"
-#include "micro_benchmark.hpp"
+#include "micro_benchmark_utils.hpp"
 
 namespace {
 

--- a/benchmark/micro_benchmark_key_prefix.cpp
+++ b/benchmark/micro_benchmark_key_prefix.cpp
@@ -10,7 +10,7 @@
 
 #include "art.hpp"
 #include "art_common.hpp"
-#include "micro_benchmark.hpp"
+#include "micro_benchmark_utils.hpp"
 
 namespace {
 

--- a/benchmark/micro_benchmark_mutex.cpp
+++ b/benchmark/micro_benchmark_mutex.cpp
@@ -7,7 +7,7 @@
 #include <benchmark/benchmark.h>
 
 #include "art.hpp"
-#include "micro_benchmark.hpp"
+#include "micro_benchmark_utils.hpp"
 #include "mutex_art.hpp"
 
 namespace {

--- a/benchmark/micro_benchmark_node16.cpp
+++ b/benchmark/micro_benchmark_node16.cpp
@@ -3,12 +3,11 @@
 #include "global.hpp"
 
 #include <cstdint>
-#include <random>
 
 #include <benchmark/benchmark.h>
 
 #include "art.hpp"
-#include "micro_benchmark.hpp"
+#include "micro_benchmark_utils.hpp"
 
 namespace {
 
@@ -74,97 +73,22 @@ void grow_node4_to_node16_sequentially(benchmark::State &state) {
 // 0, 2, 4, 6, and 8, and leading bytes enumerating through 1, 3, 5, 7, and one
 // randomly-selected value from 0, 2, 4, 6, and 8.
 
-inline constexpr auto number_to_dense_node4_with_holes_key(
-    std::uint64_t i) noexcept {
-  assert(i / (4 * 4 * 4 * 4 * 4 * 4 * 4) < 4);
-  return (i % 4 * 2 + 1) | ((i / 4 % 4 * 2 + 1) << 8) |
-         ((i / (4 * 4) % 4 * 2 + 1) << 16) |
-         ((i / (4 * 4 * 4) % 4 * 2 + 1) << 24) |
-         ((i / (4 * 4 * 4 * 4) % 4 * 2 + 1) << 32) |
-         ((i / (4 * 4 * 4 * 4 * 4) % 4 * 2 + 1) << 40) |
-         ((i / (4 * 4 * 4 * 4 * 4 * 4) % 4 * 2 + 1) << 48) |
-         ((i / (4 * 4 * 4 * 4 * 4 * 4 * 4) % 4 * 2 + 1) << 56);
-}
-
-std::random_device rd;
-std::mt19937 gen{rd()};
-
-inline auto rnd_even_0_8() {
-  static std::uniform_int_distribution<std::uint8_t> random_key_dist{0, 4ULL};
-
-  const auto result = static_cast<std::uint8_t>(random_key_dist(gen) * 2);
-  assert(result <= 8);
-  return result;
-}
-
-inline std::uint8_t min_node16_over_dense_node4_lead_key_byte(std::uint8_t i) {
-  assert(i < 5);
-  return (i < 4) ? static_cast<std::uint8_t>(i * 2 + 1) : rnd_even_0_8();
-}
-
-std::vector<unodb::key> generate_random_minimal_node16_over_dense_node4_keys(
-    unodb::key key_limit) noexcept {
-  std::vector<unodb::key> result;
-  union {
-    std::uint64_t as_int;
-    std::array<std::uint8_t, 8> as_bytes;
-  } key;
-
-  for (std::uint8_t i = 0; i < 5; ++i) {
-    key.as_bytes[7] = min_node16_over_dense_node4_lead_key_byte(i);
-    for (std::uint8_t i2 = 0; i2 < 5; ++i2) {
-      key.as_bytes[6] = min_node16_over_dense_node4_lead_key_byte(i2);
-      for (std::uint8_t i3 = 0; i3 < 5; ++i3) {
-        key.as_bytes[5] = min_node16_over_dense_node4_lead_key_byte(i3);
-        for (std::uint8_t i4 = 0; i4 < 5; ++i4) {
-          key.as_bytes[4] = min_node16_over_dense_node4_lead_key_byte(i4);
-          for (std::uint8_t i5 = 0; i5 < 5; ++i5) {
-            key.as_bytes[3] = min_node16_over_dense_node4_lead_key_byte(i5);
-            for (std::uint8_t i6 = 0; i6 < 5; ++i6) {
-              key.as_bytes[2] = min_node16_over_dense_node4_lead_key_byte(i6);
-              for (std::uint8_t i7 = 0; i7 < 5; ++i7) {
-                key.as_bytes[1] = min_node16_over_dense_node4_lead_key_byte(i7);
-                key.as_bytes[0] = rnd_even_0_8();
-                const unodb::key k = key.as_int;
-                if (k > key_limit) {
-                  std::shuffle(result.begin(), result.end(), gen);
-                  return result;
-                }
-                result.push_back(k);
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  cannot_happen();
-}
-
 void grow_node4_to_node16_randomly(benchmark::State &state) {
   std::size_t tree_size = 0;
-  const auto node4_node_count = static_cast<std::uint64_t>(state.range(0));
+  const auto node4_node_count = static_cast<unsigned>(state.range(0));
 
   for (auto _ : state) {
     state.PauseTiming();
     unodb::db test_db;
-    unodb::key key_limit = 0;
-    for (std::uint64_t i = 0; i < node4_node_count * 4; ++i) {
-      const unodb::key insert_key = number_to_dense_node4_with_holes_key(i);
-      unodb::benchmark::insert_key(
-          test_db, insert_key, unodb::value_view{unodb::benchmark::value100});
-      key_limit = insert_key;
-    }
-    unodb::benchmark::assert_node4_only_tree(test_db);
+    const auto key_limit = unodb::benchmark::make_node4_tree_with_gaps(
+        test_db, node4_node_count * 4);
 
     const auto node16_keys =
-        generate_random_minimal_node16_over_dense_node4_keys(key_limit);
+        unodb::benchmark::generate_random_minimal_node16_over_dense_node4_keys(
+            key_limit);
     state.ResumeTiming();
 
-    for (const auto k : node16_keys) {
-      unodb::benchmark::insert_key(
-          test_db, k, unodb::value_view{unodb::benchmark::value100});
-    }
+    unodb::benchmark::insert_keys(test_db, node16_keys);
 
     state.PauseTiming();
     unodb::benchmark::assert_mostly_node16_tree(test_db);

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -1,0 +1,76 @@
+// Copyright 2020 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "micro_benchmark_utils.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+namespace {
+
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects,cert-err58-cpp)
+std::random_device rd;
+// NOLINTNEXTLINE(fuchsia-statically-constructed-objects,cert-err58-cpp)
+std::mt19937 gen{rd()};
+
+inline auto rnd_even_0_8() {
+  static std::uniform_int_distribution<std::uint8_t> random_key_dist{0, 4ULL};
+
+  const auto result = static_cast<std::uint8_t>(random_key_dist(gen) * 2);
+  assert(result <= 8);
+  return result;
+}
+
+inline auto min_node16_over_dense_node4_lead_key_byte(std::uint8_t i) {
+  assert(i < 5);
+  return (i < 4) ? static_cast<std::uint8_t>(i * 2 + 1) : rnd_even_0_8();
+}
+
+}  // namespace
+
+namespace unodb::benchmark {
+
+std::vector<unodb::key> generate_random_minimal_node16_over_dense_node4_keys(
+    unodb::key key_limit) noexcept {
+  std::vector<unodb::key> result;
+  union {
+    std::uint64_t as_int;                  // cppcheck-suppress shadowVariable
+    std::array<std::uint8_t, 8> as_bytes;  // cppcheck-suppress shadowVariable
+  } key;
+
+  for (std::uint8_t i = 0; i < 5; ++i) {
+    key.as_bytes[7] = min_node16_over_dense_node4_lead_key_byte(i);
+    for (std::uint8_t i2 = 0; i2 < 5; ++i2) {
+      key.as_bytes[6] = min_node16_over_dense_node4_lead_key_byte(i2);
+      for (std::uint8_t i3 = 0; i3 < 5; ++i3) {
+        key.as_bytes[5] = min_node16_over_dense_node4_lead_key_byte(i3);
+        for (std::uint8_t i4 = 0; i4 < 5; ++i4) {
+          key.as_bytes[4] = min_node16_over_dense_node4_lead_key_byte(i4);
+          for (std::uint8_t i5 = 0; i5 < 5; ++i5) {
+            key.as_bytes[3] = min_node16_over_dense_node4_lead_key_byte(i5);
+            for (std::uint8_t i6 = 0; i6 < 5; ++i6) {
+              key.as_bytes[2] = min_node16_over_dense_node4_lead_key_byte(i6);
+              for (std::uint8_t i7 = 0; i7 < 5; ++i7) {
+                key.as_bytes[1] = min_node16_over_dense_node4_lead_key_byte(i7);
+                key.as_bytes[0] = rnd_even_0_8();
+                const unodb::key k = key.as_int;
+                if (k > key_limit) {
+                  result.shrink_to_fit();
+                  std::shuffle(result.begin(), result.end(), gen);
+                  return result;
+                }
+                result.push_back(k);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  cannot_happen();
+}
+
+}  // namespace unodb::benchmark


### PR DESCRIPTION
Move the necessary machinery from Node16 benchmarks to the helper header.

Introduce a helper library micro_benchmark_utils.

Other assorted cleanups.

This concludes Node4 benchmarks for now.