### PR TITLE
Node16 add: implement SIMD search for insert position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ else()
       "-misc-non-private-member-variables-in-classes,"
       "-modernize-use-equals-default," # Until foo() noexcept = default is accepted by clang
       "-modernize-use-trailing-return-type,"
+      "-portability-simd-intrinsics,"
       "-readability-braces-around-statements,"
       "-readability-named-parameter,"
       "-readability-magic-numbers")


### PR DESCRIPTION
Performance:

Baseline:

2020-09-13T09:33:01+02:00
Running ./micro_benchmark_node16
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.50, 0.44, 0.18
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
node16_sequential_add/10          9.76 us         9.76 us        71756 +4=13 16=12 16^=0 256=0 4=1 48=0 48^=0 4^=12 KPfS=3 L=150 items_per_second=10.1454M/s size=18.4746k
node16_sequential_add/64          66.6 us         66.5 us        10513 +4=81 16=78 16^=0 256=0 4=3 48=0 48^=0 4^=78 KPfS=17 L=1014 items_per_second=10.4167M/s size=124.225k
node16_sequential_add/512          784 us          784 us          891 +4=641 16=639 16^=0 256=0 4=2 48=0 48^=0 4^=639 KPfS=129 L=8.182k items_per_second=7.16758M/s size=1002.83k
node16_sequential_add/4096        7481 us         7481 us           94 +4=5.122k 16=5.118k 16^=0 256=0 4=4 48=0 48^=0 4^=5.118k KPfS=1026 L=65.526k items_per_second=6.02146M/s size=7.84255M
node16_sequential_add/16383      31863 us        31860 us           22 +4=20.482k 16=20.477k 16^=0 256=0 4=5 48=0 48^=0 4^=20.477k KPfS=4.099k L=262.118k items_per_second=5.65599M/s size=31.372M
node16_random_add/10              10.5 us         10.5 us        66648 +4=13 16=12 16^=0 256=0 4=1 48=0 48^=0 4^=12 KPfS=3 L=150 items_per_second=9.51743M/s size=18.4746k
node16_random_add/64              71.9 us         71.9 us         9745 +4=81 16=78 16^=0 256=0 4=3 48=0 48^=0 4^=78 KPfS=17 L=1014 items_per_second=9.65471M/s size=124.225k
node16_random_add/512              620 us          620 us         1128 +4=641 16=639 16^=0 256=0 4=2 48=0 48^=0 4^=639 KPfS=129 L=8.182k items_per_second=9.06503M/s size=1002.83k
node16_random_add/4096            6886 us         6885 us          103 +4=5.122k 16=5.118k 16^=0 256=0 4=4 48=0 48^=0 4^=5.118k KPfS=1026 L=65.526k items_per_second=6.54256M/s size=7.84255M
node16_random_add/16383          34108 us        34105 us           21 +4=20.482k 16=20.477k 16^=0 256=0 4=5 48=0 48^=0 4^=20.477k KPfS=4.099k L=262.118k items_per_second=5.28374M/s size=31.372M

 Performance counter stats for './micro_benchmark_node16 --benchmark_filter=add':

         17,573.88 msec task-clock                #    0.999 CPUs utilized
                29      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           635,037      page-faults               #    0.036 M/sec
    59,834,302,352      cycles                    #    3.405 GHz                      (83.33%)
    21,354,768,298      stalled-cycles-frontend   #   35.69% frontend cycles idle     (83.32%)
    11,198,638,088      stalled-cycles-backend    #   18.72% backend cycles idle      (66.68%)
   110,756,841,666      instructions              #    1.85  insn per cycle
                                                  #    0.19  stalled cycles per insn  (83.34%)
    20,247,435,525      branches                  # 1152.132 M/sec                    (83.34%)
       142,177,446      branch-misses             #    0.70% of all branches          (83.33%)

      17.592403149 seconds time elapsed

      16.658108000 seconds user
       0.916115000 seconds sys

With the change:

2020-09-13T09:33:25+02:00
Running ./micro_benchmark_node16
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.56, 0.46, 0.19
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
node16_sequential_add/10          9.35 us         9.35 us        74895 +4=13 16=12 16^=0 256=0 4=1 48=0 48^=0 4^=12 KPfS=3 L=150 items_per_second=10.5911M/s size=18.4746k
node16_sequential_add/64          64.5 us         64.5 us        10845 +4=81 16=78 16^=0 256=0 4=3 48=0 48^=0 4^=78 KPfS=17 L=1014 items_per_second=10.7445M/s size=124.225k
node16_sequential_add/512          767 us          767 us          913 +4=641 16=639 16^=0 256=0 4=2 48=0 48^=0 4^=639 KPfS=129 L=8.182k items_per_second=7.33285M/s size=1002.83k
node16_sequential_add/4096        7343 us         7343 us           95 +4=5.122k 16=5.118k 16^=0 256=0 4=4 48=0 48^=0 4^=5.118k KPfS=1026 L=65.526k items_per_second=6.13475M/s size=7.84255M
node16_sequential_add/16383      31370 us        31367 us           22 +4=20.482k 16=20.477k 16^=0 256=0 4=5 48=0 48^=0 4^=20.477k KPfS=4.099k L=262.118k items_per_second=5.74494M/s size=31.372M
node16_random_add/10              9.77 us         9.76 us        71673 +4=13 16=12 16^=0 256=0 4=1 48=0 48^=0 4^=12 KPfS=3 L=150 items_per_second=10.2409M/s size=18.4746k
node16_random_add/64              66.2 us         66.1 us        10574 +4=81 16=78 16^=0 256=0 4=3 48=0 48^=0 4^=78 KPfS=17 L=1014 items_per_second=10.4935M/s size=124.225k
node16_random_add/512              586 us          586 us         1195 +4=641 16=639 16^=0 256=0 4=2 48=0 48^=0 4^=639 KPfS=129 L=8.182k items_per_second=9.59912M/s size=1002.83k
node16_random_add/4096            6578 us         6577 us          100 +4=5.122k 16=5.118k 16^=0 256=0 4=4 48=0 48^=0 4^=5.118k KPfS=1026 L=65.526k items_per_second=6.84881M/s size=7.84255M
node16_random_add/16383          35258 us        35256 us           21 +4=20.482k 16=20.477k 16^=0 256=0 4=5 48=0 48^=0 4^=20.477k KPfS=4.099k L=262.118k items_per_second=5.11126M/s size=31.372M

 Performance counter stats for './micro_benchmark_node16 --benchmark_filter=add':

         17,746.83 msec task-clock                #    0.999 CPUs utilized
                44      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
           668,424      page-faults               #    0.038 M/sec
    60,424,637,263      cycles                    #    3.405 GHz                      (83.33%)
    21,425,864,749      stalled-cycles-frontend   #   35.46% frontend cycles idle     (83.32%)
    11,091,139,962      stalled-cycles-backend    #   18.36% backend cycles idle      (66.66%)
   112,076,299,340      instructions              #    1.85  insn per cycle
                                                  #    0.19  stalled cycles per insn  (83.34%)
    20,353,003,299      branches                  # 1146.853 M/sec                    (83.34%)
       119,498,667      branch-misses             #    0.59% of all branches          (83.34%)

      17.765352181 seconds time elapsed

      16.787038000 seconds user
       0.960173000 seconds sys