### PR TITLE
Node16 random and sequential full and minimal node benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -21,7 +21,7 @@ set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
 add_benchmark_target(micro_benchmark_node4)
 set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
 add_benchmark_target(micro_benchmark_node16)
-set(micro_benchmark_node16_quick_arg "--benchmark_filter='/20|/10|'")
+set(micro_benchmark_node16_quick_arg "--benchmark_filter='/10|/64'")
 add_benchmark_target(micro_benchmark)
 set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 add_benchmark_target(micro_benchmark_mutex)


### PR DESCRIPTION
- Make unodb::benchmark::insert_sequentially work with all tree shapes by moving
  out the Node4-only tree assert to the callers
- Introduce unodb::benchmark::to_base_n_value helper, use it for
  micro_benchmark_node16.cpp:number_to_minimal_node16_key
- For full node benchmarks, factor out existing Node4 ones to
  unodb::benchmark::full_scan_benchmark and
  unodb::benchmark::random_get_benchmark
- Replace micro_benchmark_node4.cp:number_to_node4_key helper with
  to_base_n_value one, drop single node masks
- Introduce unodb::benchmark::print_key debug-only helper, make
  unodb::benchmark::get_existing_key use it in the case of error