### PR TITLE
Implement Node4 delete-from-node benchmarks

### DIFF
--- a/benchmark/micro_benchmark_node16.cpp
+++ b/benchmark/micro_benchmark_node16.cpp
@@ -42,7 +42,7 @@ void grow_node4_to_node16_sequentially(benchmark::State &state) {
     unodb::db test_db;
     unodb::key key_limit = unodb::benchmark::insert_sequentially(
         test_db, node4_node_count * 4,
-        unodb::benchmark::dense_node4_key_zero_bits);
+        unodb::benchmark::full_node4_tree_key_zero_bits);
     unodb::benchmark::assert_node4_only_tree(test_db);
     benchmark::ClobberMemory();
     state.ResumeTiming();

--- a/benchmark/micro_benchmark_node4.cpp
+++ b/benchmark/micro_benchmark_node4.cpp
@@ -16,19 +16,33 @@
 
 namespace {
 
-constexpr auto sparse_node4_key_zero_bits = 0xFEFEFEFE'FEFEFEFEULL;
+constexpr auto minimal_node4_key_zero_bits = 0xFEFEFEFE'FEFEFEFEULL;
 
-std::vector<unodb::key> make_key_sequence(std::size_t count,
-                                          std::uint64_t key_zero_bits) {
+std::vector<unodb::key> make_n_key_sequence(std::size_t n,
+                                            std::uint64_t key_zero_bits) {
   std::vector<unodb::key> result;
-  result.reserve(count);
+  result.reserve(n);
 
   unodb::key insert_key = 0;
-  for (decltype(count) i = 0; i < count; ++i) {
+  for (decltype(n) i = 0; i < n; ++i) {
     result.push_back(insert_key);
     insert_key = unodb::benchmark::next_key(insert_key, key_zero_bits);
   }
 
+  return result;
+}
+
+std::vector<unodb::key> make_limited_key_sequence(unodb::key limit,
+                                                  std::uint64_t key_zero_bits) {
+  std::vector<unodb::key> result;
+
+  unodb::key insert_key = 0;
+  while (insert_key < limit) {
+    result.push_back(insert_key);
+    insert_key = unodb::benchmark::next_key(insert_key, key_zero_bits);
+  }
+
+  result.shrink_to_fit();
   return result;
 }
 
@@ -60,16 +74,17 @@ void node4_sequential_insert(benchmark::State &state,
 }
 
 void full_node4_sequential_insert(benchmark::State &state) {
-  node4_sequential_insert(state, unodb::benchmark::dense_node4_key_zero_bits);
+  node4_sequential_insert(state,
+                          unodb::benchmark::full_node4_tree_key_zero_bits);
 }
 
-void sparse_node4_sequential_insert(benchmark::State &state) {
-  node4_sequential_insert(state, sparse_node4_key_zero_bits);
+void minimal_node4_sequential_insert(benchmark::State &state) {
+  node4_sequential_insert(state, minimal_node4_key_zero_bits);
 }
 
 void node4_random_insert(benchmark::State &state, std::uint64_t key_zero_bits) {
-  auto keys = make_key_sequence(static_cast<std::size_t>(state.range(0)),
-                                key_zero_bits);
+  auto keys = make_n_key_sequence(static_cast<std::size_t>(state.range(0)),
+                                  key_zero_bits);
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -90,69 +105,104 @@ void node4_random_insert(benchmark::State &state, std::uint64_t key_zero_bits) {
 }
 
 void full_node4_random_insert(benchmark::State &state) {
-  node4_random_insert(state, unodb::benchmark::dense_node4_key_zero_bits);
+  node4_random_insert(state, unodb::benchmark::full_node4_tree_key_zero_bits);
 }
 
 void sparse_node4_random_insert(benchmark::State &state) {
-  node4_random_insert(state, sparse_node4_key_zero_bits);
+  node4_random_insert(state, minimal_node4_key_zero_bits);
 }
 
 void node4_full_scan(benchmark::State &state) {
   unodb::benchmark::full_node_scan_benchmark<unodb::db>(
-      state, unodb::benchmark::dense_node4_key_zero_bits);
+      state, unodb::benchmark::full_node4_tree_key_zero_bits);
 }
 
 void node4_random_gets(benchmark::State &state) {
   unodb::benchmark::full_node_random_get_benchmark<unodb::db, 4>(
-      state, unodb::benchmark::dense_node4_key_zero_bits);
+      state, unodb::benchmark::full_node4_tree_key_zero_bits);
 }
 
-void full_node4_sequential_delete(benchmark::State &state) {
+void node4_sequential_delete_benchmark(benchmark::State &state,
+                                       std::uint64_t insert_key_zero_bits,
+                                       std::uint64_t delete_key_zero_bits) {
   const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+  int keys_deleted{0};
+  std::size_t tree_size{0};
 
   for (auto _ : state) {
     state.PauseTiming();
     unodb::db test_db;
-    unodb::benchmark::insert_sequentially(
-        test_db, number_of_keys, unodb::benchmark::dense_node4_key_zero_bits);
+    const auto key_limit = unodb::benchmark::insert_sequentially(
+        test_db, number_of_keys, insert_key_zero_bits);
+    tree_size = test_db.get_current_memory_use();
     unodb::benchmark::assert_node4_only_tree(test_db);
     state.ResumeTiming();
 
     unodb::key k = 0;
-    for (std::uint64_t j = 0; j < number_of_keys; ++j) {
+    keys_deleted = 0;
+    while (k < key_limit) {
       unodb::benchmark::delete_key(test_db, k);
-      k = unodb::benchmark::next_key(
-          k, unodb::benchmark::dense_node4_key_zero_bits);
+      ++keys_deleted;
+      k = unodb::benchmark::next_key(k, delete_key_zero_bits);
     }
-
-    assert(test_db.empty());
   }
 
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          state.range(0));
+                          keys_deleted);
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
 }
 
-void full_node4_random_deletes(benchmark::State &state) {
+void full_node4_sequential_delete(benchmark::State &state) {
+  node4_sequential_delete_benchmark(
+      state, unodb::benchmark::full_node4_tree_key_zero_bits,
+      unodb::benchmark::full_node4_tree_key_zero_bits);
+}
+
+void node4_random_delete_benchmark(benchmark::State &state,
+                                   std::uint64_t insert_key_zero_bits,
+                                   std::uint64_t delete_key_zero_bits) {
   const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
-  auto keys = make_key_sequence(number_of_keys,
-                                unodb::benchmark::dense_node4_key_zero_bits);
+  std::size_t tree_size{0};
 
   for (auto _ : state) {
     state.PauseTiming();
-    std::shuffle(keys.begin(), keys.end(), unodb::benchmark::get_prng());
     unodb::db test_db;
-    unodb::benchmark::insert_sequentially(
-        test_db, number_of_keys, unodb::benchmark::dense_node4_key_zero_bits);
+    const auto key_limit = unodb::benchmark::insert_sequentially(
+        test_db, number_of_keys, insert_key_zero_bits);
+    tree_size = test_db.get_current_memory_use();
     unodb::benchmark::assert_node4_only_tree(test_db);
+
+    auto keys = make_limited_key_sequence(key_limit, delete_key_zero_bits);
+    std::shuffle(keys.begin(), keys.end(), unodb::benchmark::get_prng());
     state.ResumeTiming();
 
     unodb::benchmark::delete_keys(test_db, keys);
-
-    assert(test_db.empty());
   }
 
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           state.range(0));
+  unodb::benchmark::set_size_counter(state, "size", tree_size);
+}
+
+void full_node4_random_deletes(benchmark::State &state) {
+  node4_random_delete_benchmark(
+      state, unodb::benchmark::full_node4_tree_key_zero_bits,
+      unodb::benchmark::full_node4_tree_key_zero_bits);
+}
+
+constexpr auto minimal_node4_tree_full_leaf_level_key_zero_bits =
+    0xFCFCFCFC'FCFCFCFEULL;
+
+void full_node4_to_minimal_sequential_delete(benchmark::State &state) {
+  node4_sequential_delete_benchmark(
+      state, unodb::benchmark::full_node4_tree_key_zero_bits,
+      minimal_node4_tree_full_leaf_level_key_zero_bits);
+}
+
+void full_node4_to_minimal_random_delete(benchmark::State &state) {
+  node4_random_delete_benchmark(
+      state, unodb::benchmark::full_node4_tree_key_zero_bits,
+      minimal_node4_tree_full_leaf_level_key_zero_bits);
 }
 
 // Benchmark shrinking Node16 to Node4: insert to minimal Node16 first:
@@ -160,8 +210,8 @@ void full_node4_random_deletes(benchmark::State &state) {
 // 0x0000000000000100 to ...104
 // 0x0000000000000200 to ...204
 // 0x0000000000000300 to ...304
-// 0x0000000000000404 (note that no 0x0400..0x403, these would create sparse but
-// not minimal Node16 tree).
+// 0x0000000000000404 (note that no 0x0400..0x403, these would create sparse
+// but not minimal Node16 tree).
 //
 // Then remove the minimal Node16 over dense Node4 key subset, see
 // number_to_minimal_node16_over_node4_key.
@@ -192,7 +242,7 @@ void shrink_node16_to_node4_sequentially(benchmark::State &state) {
     unodb::db test_db;
     unodb::key key_limit = unodb::benchmark::insert_sequentially(
         test_db, node4_insert_count,
-        unodb::benchmark::dense_node4_key_zero_bits);
+        unodb::benchmark::full_node4_tree_key_zero_bits);
     unodb::benchmark::assert_node4_only_tree(test_db);
 
     const auto n4_to_n16_keys_inserted =
@@ -276,7 +326,7 @@ BENCHMARK(full_node4_sequential_insert)
 BENCHMARK(full_node4_random_insert)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK(sparse_node4_sequential_insert)
+BENCHMARK(minimal_node4_sequential_insert)
     ->Range(16, 255)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(sparse_node4_random_insert)
@@ -289,6 +339,12 @@ BENCHMARK(full_node4_sequential_delete)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node4_random_deletes)
     ->Range(100, 65535)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node4_to_minimal_sequential_delete)
+    ->Range(100, 65533)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node4_to_minimal_random_delete)
+    ->Range(100, 65533)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(shrink_node16_to_node4_sequentially)
     ->Range(100, 65535)

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -37,7 +37,7 @@ inline constexpr std::array<unodb::value_view, 5> values = {
 
 // Key manipulation
 
-inline constexpr auto dense_node4_key_zero_bits = 0xFCFCFCFC'FCFCFCFCULL;
+inline constexpr auto full_node4_tree_key_zero_bits = 0xFCFCFCFC'FCFCFCFCULL;
 
 inline constexpr auto next_key(unodb::key k,
                                std::uint64_t key_zero_bits) noexcept {
@@ -342,6 +342,15 @@ void get_key(const Db &db, unodb::key k) {
 template <class Db>
 void delete_key(Db &db, unodb::key k) {
   const auto result USED_IN_DEBUG = db.remove(k);
+#ifndef NDEBUG
+  if (!result) {
+    std::cerr << "Failed to delete existing key ";
+    print_key(std::cerr, k);
+    std::cerr << "\nTree:";
+    db.dump(std::cerr);
+    assert(result);
+  }
+#endif
   assert(result);
   ::benchmark::ClobberMemory();
 }


### PR DESCRIPTION
At the same time do some renames throughout the benchmark code: "dense" to
"full", "sparse" to "minimal".

Factor out helpers for benchmarking Node4 deletes -
node4_sequential_delete_benchmark and node4_random_delete_benchmark, use them
for the existing benchmarks that fully empty the tree and the new ones that do
not change the tree structure.

Dump tree on unodb::benchmark::delete_key failure.