### PR TITLE
Node16 remove: replace two std::copy calls with a single loop

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -909,16 +909,14 @@ class inode_16 final : public basic_inode_16 {
     assert(std::is_sorted(keys.byte_array.cbegin(),
                           keys.byte_array.cbegin() + f.f.children_count));
 
-    std::copy(keys.byte_array.cbegin() + child_to_remove + 1,
-              keys.byte_array.cbegin() + f.f.children_count,
-              keys.byte_array.begin() + child_to_remove);
-
     delete_node_ptr_at_scope_exit delete_on_scope_exit{
         children[child_to_remove]};
 
-    std::copy(children.begin() + child_to_remove + 1,
-              children.begin() + f.f.children_count,
-              children.begin() + child_to_remove);
+    for (unsigned i = child_to_remove + 1; i < f.f.children_count; ++i) {
+      keys.byte_array[i - 1] = keys.byte_array[i];
+      children[i - 1] = children[i];
+    }
+
     --f.f.children_count;
 
     assert(std::is_sorted(keys.byte_array.cbegin(),


### PR DESCRIPTION
Performance change:

full_node16_tree_sequential_delete/64_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_sequential_delete/64_mean                      -0.0156         -0.0136             4             4             4             4
full_node16_tree_sequential_delete/512_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_sequential_delete/512_mean                     -0.0406         -0.0381             8             8             8             8
full_node16_tree_sequential_delete/4096_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_sequential_delete/4096_mean                    -0.0121         -0.0119            19            19            19            19
full_node16_tree_sequential_delete/32768_pvalue                  0.0008          0.0008      U Test, Repetitions: 9 vs 9
full_node16_tree_sequential_delete/32768_mean                   -0.0078         -0.0073           102           101           102           101
full_node16_tree_sequential_delete/246000_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_sequential_delete/246000_mean                  -0.0377         -0.0378           529           509           527           507

full_node16_tree_random_delete/64_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_random_delete/64_mean                      -0.0231         -0.0209             3             3             3             3
full_node16_tree_random_delete/512_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_random_delete/512_mean                     -0.0454         -0.0446             8             8             8             8
full_node16_tree_random_delete/4096_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_random_delete/4096_mean                    -0.0256         -0.0254            19            19            19            18
full_node16_tree_random_delete/32768_pvalue                  0.0004          0.0004      U Test, Repetitions: 9 vs 9
full_node16_tree_random_delete/32768_mean                   -0.0245         -0.0205           108           106           107           105
full_node16_tree_random_delete/246000_pvalue                 0.0011          0.0011      U Test, Repetitions: 9 vs 9
full_node16_tree_random_delete/246000_mean                  +0.0171         +0.0171           952           968           949           965