### PR TITLE
Introduce Node48 benchmarks and significant benchmark refactoring

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -22,6 +22,8 @@ add_benchmark_target(micro_benchmark_node4)
 set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
 add_benchmark_target(micro_benchmark_node16)
 set(micro_benchmark_node16_quick_arg "--benchmark_filter='/10|/64'")
+add_benchmark_target(micro_benchmark_node48)
+set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64'")
 add_benchmark_target(micro_benchmark)
 set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 add_benchmark_target(micro_benchmark_mutex)
@@ -31,9 +33,11 @@ add_custom_target(benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_key_prefix
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node16
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node48
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex
-  DEPENDS micro_benchmark_key_prefix micro_benchmark_node4 micro_benchmark
+  DEPENDS micro_benchmark_key_prefix micro_benchmark_node4
+  micro_benchmark_node16 micro_benchmark_node48 micro_benchmark
   micro_benchmark_mutex)
 
 add_custom_target(quick_benchmarks
@@ -44,11 +48,13 @@ add_custom_target(quick_benchmarks
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
   DEPENDS micro_benchmark_key_prefix micro_benchmark micro_benchmark_node4
-  micro_benchmark_node16 micro_benchmark_mutex)
+  micro_benchmark_node16 micro_benchmark_node48 micro_benchmark_mutex)
 
 add_custom_target(valgrind_benchmarks
   COMMAND valgrind --error-exitcode=1 --leak-check=full
@@ -58,9 +64,11 @@ add_custom_target(valgrind_benchmarks
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg};
   COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg};
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark ${micro_benchmark_quick_arg};
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg};
   DEPENDS micro_benchmark_key_prefix
-  micro_benchmark_node4 micro_benchmark_node16 micro_benchmark
-  micro_benchmark_mutex)
+  micro_benchmark_node4 micro_benchmark_node16 micro_benchmark_node48
+  micro_benchmark micro_benchmark_mutex)

--- a/benchmark/micro_benchmark_node4.cpp
+++ b/benchmark/micro_benchmark_node4.cpp
@@ -113,7 +113,7 @@ void minimal_node4_random_insert(benchmark::State &state) {
 }
 
 void node4_full_scan(benchmark::State &state) {
-  unodb::benchmark::full_node_scan_benchmark<unodb::db>(
+  unodb::benchmark::full_node_scan_benchmark<unodb::db, 4>(
       state, unodb::benchmark::full_node4_tree_key_zero_bits);
 }
 
@@ -245,8 +245,10 @@ void shrink_node16_to_node4_sequentially(benchmark::State &state) {
     unodb::benchmark::assert_node4_only_tree(test_db);
 
     const auto n4_to_n16_keys_inserted =
-        unodb::benchmark::grow_full_node4_to_minimal_leaf_node16(test_db,
-                                                                 key_limit);
+        unodb::benchmark::grow_full_node_tree_to_minimal_next_size_leaf_level<
+            unodb::db, 4>(
+            test_db, key_limit,
+            unodb::benchmark::number_to_minimal_leaf_node16_over_node4_key);
 
     tree_size = test_db.get_current_memory_use();
     state.ResumeTiming();

--- a/benchmark/micro_benchmark_node48.cpp
+++ b/benchmark/micro_benchmark_node48.cpp
@@ -1,0 +1,69 @@
+// Copyright 2020 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+#include <benchmark/benchmark.h>
+
+#include "art.hpp"
+#include "micro_benchmark_utils.hpp"
+
+namespace {
+
+// Benchmark growing Node16 to Node48: insert to full Node16 tree first:
+// 0x0000000000000000 to ...0000F
+// 0x0000000000000100 to ...0010F
+// ...
+// 0x0000000000000F00 to ...00F0F
+// 0x0000000000010000 to ...1000F
+// ...
+// 0x00000000000F0000 to ...F000F
+// 0x0000000000010100 to ...1010F
+// 0x0000000000010200 to ...1020F
+// ...
+// The insert in the gaps a "base-17" value with the last byte being a constant
+// 10 to get a minimal Node48 tree:
+// 0x0000000000000010
+// 0x0000000000000110
+// ...
+// 0x0000000000000F10
+// 0x0000000000010010
+// ...
+
+inline constexpr auto full_node16_tree_key_zero_bits = 0xF0F0F0F0'F0F0F0F0ULL;
+
+// Minimal leaf-level Node48 tree keys over full Node16 tree keys: "base-17"
+// values that vary each byte from 0 to 0x10 with the last byte being a constant
+// 0x10.
+inline constexpr auto number_to_minimal_leaf_node48_over_node16_key(
+    std::uint64_t i) noexcept {
+  assert(i / (0x10 * 0x10 * 0x10 * 0x10 * 0x10 * 0x10) < 0x10);
+  return 0x10ULL | unodb::benchmark::to_base_n_value<0x10>(i) << 8;
+}
+
+void grow_node16_to_node48_sequentially(benchmark::State &state) {
+  unodb::benchmark::grow_node_sequentially_benchmark<
+      unodb::db, 16, full_node16_tree_key_zero_bits>(
+      state, number_to_minimal_leaf_node48_over_node16_key);
+}
+
+void grow_node16_to_node48_randomly(benchmark::State &state) {
+  unodb::benchmark::grow_node_randomly_benchmark<
+      unodb::db, 16,
+      decltype(unodb::benchmark::make_node16_tree_with_gaps<unodb::db>)>(
+      state, unodb::benchmark::make_node16_tree_with_gaps,
+      unodb::benchmark::generate_random_minimal_node48_over_full_node16_keys);
+}
+
+}  // namespace
+
+BENCHMARK(grow_node16_to_node48_sequentially)
+    ->Range(8, 8192)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(grow_node16_to_node48_randomly)
+    ->Range(8, 8192)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -9,11 +9,15 @@
 #include <random>
 #include <vector>
 
-namespace unodb::benchmark {
+#include "art.hpp"
+#include "mutex_art.hpp"
 
-std::vector<unodb::key> generate_random_minimal_node16_over_full_node4_keys(
-    unodb::key key_limit) noexcept {
-  std::uniform_int_distribution<std::uint8_t> random_04{0, 4ULL};
+namespace {
+
+template <std::uint8_t NumByteValues>
+auto generate_random_keys_over_full_smaller_tree(unodb::key key_limit) {
+  std::uniform_int_distribution<std::uint8_t> prng_byte_values{0,
+                                                               NumByteValues};
 
   std::vector<unodb::key> result;
   union {
@@ -21,27 +25,28 @@ std::vector<unodb::key> generate_random_minimal_node16_over_full_node4_keys(
     std::array<std::uint8_t, 8> as_bytes;  // cppcheck-suppress shadowVariable
   } key;
 
-  for (std::uint8_t i = 0; i < 4; ++i) {
+  for (std::uint8_t i = 0; i < NumByteValues; ++i) {
     key.as_bytes[7] = static_cast<std::uint8_t>(i * 2 + 1);
-    for (std::uint8_t i2 = 0; i2 < 4; ++i2) {
+    for (std::uint8_t i2 = 0; i2 < NumByteValues; ++i2) {
       key.as_bytes[6] = static_cast<std::uint8_t>(i2 * 2 + 1);
-      for (std::uint8_t i3 = 0; i3 < 4; ++i3) {
+      for (std::uint8_t i3 = 0; i3 < NumByteValues; ++i3) {
         key.as_bytes[5] = static_cast<std::uint8_t>(i3 * 2 + 1);
-        for (std::uint8_t i4 = 0; i4 < 4; ++i4) {
+        for (std::uint8_t i4 = 0; i4 < NumByteValues; ++i4) {
           key.as_bytes[4] = static_cast<std::uint8_t>(i4 * 2 + 1);
-          for (std::uint8_t i5 = 0; i5 < 4; ++i5) {
+          for (std::uint8_t i5 = 0; i5 < NumByteValues; ++i5) {
             key.as_bytes[3] = static_cast<std::uint8_t>(i5 * 2 + 1);
-            for (std::uint8_t i6 = 0; i6 < 4; ++i6) {
+            for (std::uint8_t i6 = 0; i6 < NumByteValues; ++i6) {
               key.as_bytes[2] = static_cast<std::uint8_t>(i6 * 2 + 1);
-              for (std::uint8_t i7 = 0; i7 < 4; ++i7) {
+              for (std::uint8_t i7 = 0; i7 < NumByteValues; ++i7) {
                 key.as_bytes[1] = static_cast<std::uint8_t>(i7 * 2 + 1);
-                key.as_bytes[0] =
-                    static_cast<std::uint8_t>(random_04(get_prng()) * 2);
+                key.as_bytes[0] = static_cast<std::uint8_t>(
+                    prng_byte_values(unodb::benchmark::get_prng()) * 2);
 
                 const unodb::key k = key.as_int;
                 if (k > key_limit) {
                   result.shrink_to_fit();
-                  std::shuffle(result.begin(), result.end(), get_prng());
+                  std::shuffle(result.begin(), result.end(),
+                               unodb::benchmark::get_prng());
                   return result;
                 }
                 result.push_back(k);
@@ -54,5 +59,162 @@ std::vector<unodb::key> generate_random_minimal_node16_over_full_node4_keys(
   }
   cannot_happen();
 }
+}  // namespace
+
+namespace unodb::benchmark {
+
+// Key vectors
+
+std::vector<unodb::key> generate_random_minimal_node16_over_full_node4_keys(
+    unodb::key key_limit) {
+  return generate_random_keys_over_full_smaller_tree<4>(key_limit);
+}
+
+std::vector<unodb::key> generate_random_minimal_node48_over_full_node16_keys(
+    unodb::key key_limit) {
+  return generate_random_keys_over_full_smaller_tree<16>(key_limit);
+}
+
+// PRNG
+
+batched_prng::batched_prng(result_type max_value)
+    : random_key_dist{0ULL, max_value} {
+  refill();
+}
+
+void batched_prng::refill() {
+  std::generate(random_keys.begin(), random_keys.end(),
+                [this]() { return random_key_dist(get_prng()); });
+  random_key_ptr = random_keys.cbegin();
+}
+
+// Asserts
+
+template <class Db>
+void assert_node4_only_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+#ifndef NDEBUG
+  if (test_db.get_inode16_count() > 0) {
+    std::cerr << "I16 node found in I4-only tree:\n";
+    test_db.dump(std::cerr);
+    assert(test_db.get_inode16_count() == 0);
+  }
+  assert(test_db.get_inode48_count() == 0);
+  assert(test_db.get_inode256_count() == 0);
+#endif
+}
+
+template void assert_node4_only_tree<unodb::db>(const unodb::db &) noexcept;
+
+template <class Db>
+void assert_mostly_node16_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+#ifndef NDEBUG
+  if (test_db.get_inode4_count() > 8) {
+    std::cerr << "Too many I4 nodes found in mostly-I16 tree:\n";
+    test_db.dump(std::cerr);
+    assert(test_db.get_inode4_count() <= 8);
+  }
+  assert(test_db.get_inode48_count() == 0);
+  assert(test_db.get_inode256_count() == 0);
+#endif
+}
+
+template void assert_mostly_node16_tree<unodb::db>(const unodb::db &) noexcept;
+
+// Insertion
+
+template <class Db>
+unodb::key make_node4_tree_with_gaps(Db &db, unsigned number_of_keys) {
+  const auto last_inserted_key =
+      insert_n_keys(db, number_of_keys, number_to_full_node4_with_gaps_key);
+  assert_node4_only_tree(db);
+  return last_inserted_key;
+}
+
+template unodb::key make_node4_tree_with_gaps<unodb::db>(unodb::db &, unsigned);
+
+template <class Db>
+unodb::key make_node16_tree_with_gaps(Db &db, unsigned number_of_keys) {
+  const auto last_inserted_key =
+      insert_n_keys(db, number_of_keys, number_to_full_node16_with_gaps_key);
+  assert_mostly_node16_tree(db);
+  return last_inserted_key;
+}
+
+template unodb::key make_node16_tree_with_gaps<unodb::db>(unodb::db &,
+                                                          unsigned);
+
+// Teardown
+
+template <class Db>
+void destroy_tree(Db &db, ::benchmark::State &state) noexcept {
+  // Timer must be stopped on entry
+  db.clear();
+  ::benchmark::ClobberMemory();
+  state.ResumeTiming();
+}
+
+template void destroy_tree<unodb::db>(unodb::db &,
+                                      ::benchmark::State &) noexcept;
+template void destroy_tree<unodb::mutex_db>(unodb::mutex_db &,
+                                            ::benchmark::State &) noexcept;
+
+// Benchmarks
+
+template <class Db, unsigned NodeSize>
+void full_node_scan_benchmark(::benchmark::State &state,
+                              std::uint64_t key_zero_bits) {
+  Db test_db;
+  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+
+  insert_sequentially(test_db, number_of_keys, key_zero_bits);
+  assert_node_size_tree<Db, NodeSize>(test_db);
+  const auto tree_size = test_db.get_current_memory_use();
+
+  for (auto _ : state) {
+    unodb::key k = 0;
+    for (std::uint64_t j = 0; j < number_of_keys; ++j) {
+      get_existing_key(test_db, k);
+      k = next_key(k, key_zero_bits);
+    }
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void full_node_scan_benchmark<unodb::db, 4>(::benchmark::State &,
+                                                     std::uint64_t);
+template void full_node_scan_benchmark<unodb::db, 16>(::benchmark::State &,
+                                                      std::uint64_t);
+
+// TODO(laurynas): can derive zero bits from base?
+template <class Db, unsigned Full_Key_Base>
+void full_node_random_get_benchmark(::benchmark::State &state,
+                                    std::uint64_t key_zero_bits) {
+  Db test_db;
+  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+  batched_prng random_key_positions{number_of_keys - 1};
+  insert_sequentially(test_db, number_of_keys, key_zero_bits);
+  const auto tree_size = test_db.get_current_memory_use();
+  // TODO(laurynas): assert desired tree shape here?
+
+  for (auto _ : state) {
+    for (std::uint64_t i = 0; i < number_of_keys; ++i) {
+      const auto key_index = random_key_positions.get(state);
+      const auto key = to_base_n_value<Full_Key_Base>(key_index);
+      get_existing_key(test_db, key);
+    }
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          state.range(0));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void full_node_random_get_benchmark<unodb::db, 4>(::benchmark::State &,
+                                                           std::uint64_t);
+template void full_node_random_get_benchmark<unodb::db, 16>(
+    ::benchmark::State &, std::uint64_t);
 
 }  // namespace unodb::benchmark


### PR DESCRIPTION
- New benchmark micro_benchmark_node48, with Node16->Node48 sequential and
  random node growth benchmarks
- Refactor micro_benchmark_node16.cpp:grow_node4_to_node16_sequentially to
  unodb::benchmark::grow_node_sequentially_benchmark, use it for Node48
- Refactor micro_benchmark_node16.cpp:grow_node4_to_node16_randomly to
  unodb::benchmark::grow_node_randomly_benchmark, use it for Node48
- Refactor unodb::benchmark::grow_full_node4_to_minimal_leaf_node16 to
  grow_full_node_tree_to_minimal_next_size_leaf_level
- Make number_to_full_leaf_over_minimal_node16_key,
  number_to_full_node16_delete_key, and
  number_to_minimal_leaf_node16_over_node4_key use
  unodb::benchmark::to_base_n_value. Also introduce to_scaled_base_n_value
  helper, use it for to_base_n_value and number_to_full_node4_with_gaps_key.
- Factor out and use helpers: unodb::benchmark::insert_n_keys,
  unodb::benchmark::insert_keys_to_limit
- Rename generate_keys_up_to_limit to generate_keys_to_limit
- Introduce node size template argument for
  unodb::benchmark::full_node_scan_benchmark, use it for tree shape asserts
- Use extern templates and explicit template instantiation to move methods and
  functions that do not need inlining from micro_benchmark_utils.hpp to
  micro_benchmark_utils.cpp.
- Refactor generate_random_minimal_node16_over_full_node4_keys to
  generate_random_keys_over_full_smaller_tree, use it for Node48