### PR TITLE
Restrict inode_48 growing ctor args

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1123,20 +1123,22 @@ inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
 inode_48::inode_48(std::unique_ptr<inode_16> &&source_node,
                    leaf_unique_ptr &&child, tree_depth depth) noexcept
     : basic_inode_48{*source_node} {
+  auto *const __restrict__ source_node_ptr = source_node.get();
+  auto *const __restrict__ child_ptr = child.release();
+
   std::memset(&child_indexes[0], empty_child,
               child_indexes.size() * sizeof(child_indexes[0]));
   std::uint8_t i;
   for (i = 0; i < inode_16::capacity; ++i) {
-    const auto existing_key_byte = source_node->keys.byte_array[i];
+    const auto existing_key_byte = source_node_ptr->keys.byte_array[i];
     child_indexes[static_cast<std::uint8_t>(existing_key_byte)] = i;
-    children[i] = source_node->children[i];
+    children[i] = source_node_ptr->children[i];
   }
 
-  const auto key_byte =
-      static_cast<std::uint8_t>(leaf::key(child.get())[depth]);
+  const auto key_byte = static_cast<std::uint8_t>(leaf::key(child_ptr)[depth]);
   assert(child_indexes[key_byte] == empty_child);
   child_indexes[key_byte] = i;
-  children[i] = child.release();
+  children[i] = child_ptr;
   for (i = f.f.children_count; i < capacity; i++) {
     children[i] = nullptr;
   }


### PR DESCRIPTION
The goal for this was to allow pipelining in the copying loop. That did not
happen, yet performance did improve:

grow_node16_to_node48_sequentially/8_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/8_mean                     -0.0203         -0.0190             2             2             2             2
grow_node16_to_node48_sequentially/64_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/64_mean                    -0.0176         -0.0165            11            11            11            11
grow_node16_to_node48_sequentially/512_pvalue                  0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/512_mean                   -0.0170         -0.0163            86            84            86            84
grow_node16_to_node48_sequentially/4096_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/4096_mean                  -0.0149         -0.0148           702           692           699           689
grow_node16_to_node48_sequentially/8192_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/8192_mean                  -0.0029         -0.0027          1859          1854          1857          1852
grow_node16_to_node48_randomly/8_pvalue                        0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/8_mean                         -0.0434         -0.0430             1             1             1             1
grow_node16_to_node48_randomly/64_pvalue                       0.0004          0.0006      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/64_mean                        -0.0031         -0.0026             3             3             3             3
grow_node16_to_node48_randomly/512_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/512_mean                       -0.0074         -0.0081            20            20            20            20
grow_node16_to_node48_randomly/4096_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/4096_mean                      -0.0046         -0.0047           168           167           167           166
grow_node16_to_node48_randomly/8192_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/8192_mean                      -0.0096         -0.0101           346           343           346           342

Perf stats:

Baseline:

         94,325.00 msec task-clock                #    1.000 CPUs utilized
               179      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
         1,176,139      page-faults               #    0.012 M/sec
   358,522,850,376      cycles                    #    3.801 GHz                      (83.33%)
    89,915,233,931      stalled-cycles-frontend   #   25.08% frontend cycles idle     (83.33%)
    49,539,255,546      stalled-cycles-backend    #   13.82% backend cycles idle      (66.67%)
   754,637,981,419      instructions              #    2.10  insn per cycle
                                                  #    0.12  stalled cycles per insn  (83.33%)
   149,807,061,606      branches                  # 1588.201 M/sec                    (83.33%)
     1,433,186,580      branch-misses             #    0.96% of all branches          (83.33%)

      94.344302014 seconds time elapsed

      91.417811000 seconds user
       2.908057000 seconds sys

With the patch:

 Performance counter stats for './micro_benchmark_node48':

         86,824.07 msec task-clock                #    1.000 CPUs utilized
               169      context-switches          #    0.002 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         1,178,565      page-faults               #    0.014 M/sec
   330,062,571,595      cycles                    #    3.802 GHz                      (83.33%)
    79,881,345,918      stalled-cycles-frontend   #   24.20% frontend cycles idle     (83.33%)
    38,302,436,715      stalled-cycles-backend    #   11.60% backend cycles idle      (66.67%)
   755,997,125,359      instructions              #    2.29  insn per cycle
                                                  #    0.11  stalled cycles per insn  (83.34%)
   150,052,558,702      branches                  # 1728.237 M/sec                    (83.34%)
       292,511,343      branch-misses             #    0.19% of all branches          (83.33%)

      86.843265359 seconds time elapsed

      83.932678000 seconds user
       2.892161000 seconds sys

I don't understand what's going on, but I'll take it.