### PR TITLE
Node48 growing ctor: split copy loops

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1132,6 +1132,8 @@ inode_48::inode_48(std::unique_ptr<inode_16> &&source_node,
   for (i = 0; i < inode_16::capacity; ++i) {
     const auto existing_key_byte = source_node_ptr->keys.byte_array[i];
     child_indexes[static_cast<std::uint8_t>(existing_key_byte)] = i;
+  }
+  for (i = 0; i < inode_16::capacity; ++i) {
     children[i] = source_node_ptr->children[i];
   }
 


### PR DESCRIPTION
This makes children pointer copy loop to compile to an unrolled VMOVDQ loop.

Performance change:

grow_node16_to_node48_sequentially/8_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/8_mean                     -0.0159         -0.0206             2             2             2             2
grow_node16_to_node48_sequentially/64_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/64_mean                    -0.0394         -0.0418            11            10            11            10
grow_node16_to_node48_sequentially/512_pvalue                  0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/512_mean                   -0.0231         -0.0237            83            81            83            81
grow_node16_to_node48_sequentially/4096_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/4096_mean                  -0.0536         -0.0535           703           665           700           662
grow_node16_to_node48_sequentially/8192_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_sequentially/8192_mean                  -0.0282         -0.0283          1852          1800          1850          1798
grow_node16_to_node48_randomly/8_pvalue                        0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/8_mean                         +0.0132         +0.0146             1             1             1             1
grow_node16_to_node48_randomly/64_pvalue                       0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/64_mean                        -0.0234         -0.0226             3             3             3             3
grow_node16_to_node48_randomly/512_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/512_mean                       -0.0390         -0.0390            20            20            20            19
grow_node16_to_node48_randomly/4096_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/4096_mean                      -0.0314         -0.0317           167           162           167           162
grow_node16_to_node48_randomly/8192_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
grow_node16_to_node48_randomly/8192_mean                      -0.0299         -0.0290           342           332           342           332