### PR TITLE
Cleanup benchmark/CMakeLists.txt dependencies

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,48 @@
 # Copyright 2020 Laurynas Biveinis
 
+set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
+set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
+set(micro_benchmark_node16_quick_arg "--benchmark_filter='/64'")
+set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64'")
+set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
+set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
+
+add_custom_target(benchmarks
+  env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_key_prefix
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node16
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node48
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex)
+
+add_custom_target(quick_benchmarks
+  env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark ${micro_benchmark_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg})
+
+add_custom_target(valgrind_benchmarks
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark ${micro_benchmark_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg})
+
 add_library(micro_benchmark_utils STATIC micro_benchmark_utils.cpp
   micro_benchmark_utils.hpp)
 common_target_properties(micro_benchmark_utils)
@@ -14,61 +57,14 @@ function(ADD_BENCHMARK_TARGET TARGET)
   add_executable("${TARGET}" "${TARGET}.cpp")
   common_target_properties("${TARGET}")
   target_link_libraries("${TARGET}" PRIVATE micro_benchmark_utils)
+  add_dependencies(benchmarks "${TARGET}")
+  add_dependencies(quick_benchmarks "${TARGET}")
+  add_dependencies(valgrind_benchmarks "${TARGET}")
 endfunction()
 
 add_benchmark_target(micro_benchmark_key_prefix)
-set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
 add_benchmark_target(micro_benchmark_node4)
-set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
 add_benchmark_target(micro_benchmark_node16)
-set(micro_benchmark_node16_quick_arg "--benchmark_filter='/64'")
 add_benchmark_target(micro_benchmark_node48)
-set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64'")
 add_benchmark_target(micro_benchmark)
-set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 add_benchmark_target(micro_benchmark_mutex)
-set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
-
-add_custom_target(benchmarks
-  env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_key_prefix
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node16
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node48
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex
-  DEPENDS micro_benchmark_key_prefix micro_benchmark_node4
-  micro_benchmark_node16 micro_benchmark_node48 micro_benchmark
-  micro_benchmark_mutex)
-
-add_custom_target(quick_benchmarks
-  env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg}
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark ${micro_benchmark_quick_arg}
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
-  DEPENDS micro_benchmark_key_prefix micro_benchmark micro_benchmark_node4
-  micro_benchmark_node16 micro_benchmark_node48 micro_benchmark_mutex)
-
-add_custom_target(valgrind_benchmarks
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg};
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg};
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg};
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg};
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark ${micro_benchmark_quick_arg};
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg};
-  DEPENDS micro_benchmark_key_prefix
-  micro_benchmark_node4 micro_benchmark_node16 micro_benchmark_node48
-  micro_benchmark micro_benchmark_mutex)


### PR DESCRIPTION
Move the custom target up in the file, remove DEPENDS clauses, and make
add_benchmark_target to add to their dependencies instead.