### PR TITLE
Implement Node16 shrinking constructor benchmarks

### DIFF
--- a/benchmark/micro_benchmark_node16.cpp
+++ b/benchmark/micro_benchmark_node16.cpp
@@ -52,11 +52,9 @@ void grow_node4_to_node16_sequentially(benchmark::State &state) {
 // randomly-selected value from 0, 2, 4, 6, and 8.
 
 void grow_node4_to_node16_randomly(benchmark::State &state) {
-  unodb::benchmark::grow_node_randomly_benchmark<
-      unodb::db, 4,
-      decltype(unodb::benchmark::make_node4_tree_with_gaps<unodb::db>)>(
-      state, unodb::benchmark::make_node4_tree_with_gaps,
-      unodb::benchmark::generate_random_minimal_node16_over_full_node4_keys);
+  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 4>(
+      state, unodb::benchmark::number_to_full_node4_with_gaps_key,
+      unodb::benchmark::generate_random_keys_over_full_smaller_tree<4>);
 }
 
 // Minimal Node16 tree sequential keys: "base-5" values that vary each byte from
@@ -290,6 +288,17 @@ void full_node16_tree_random_delete(benchmark::State &state) {
   unodb::benchmark::set_size_counter(state, "size", tree_size);
 }
 
+void shrink_node48_to_node16_sequentially(benchmark::State &state) {
+  unodb::benchmark::shrink_node_sequentially_benchmark<
+      unodb::db, 16, unodb::benchmark::full_node16_tree_key_zero_bits>(
+      state, unodb::benchmark::number_to_minimal_leaf_node48_over_node16_key);
+}
+
+void shrink_node48_to_node16_randomly(benchmark::State &state) {
+  unodb::benchmark::shrink_node_randomly_benchmark<unodb::db, 16>(
+      state, unodb::benchmark::number_to_full_node16_with_gaps_key);
+}
+
 }  // namespace
 
 BENCHMARK(grow_node4_to_node16_sequentially)
@@ -318,6 +327,12 @@ BENCHMARK(full_node16_tree_sequential_delete)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node16_tree_random_delete)
+    ->Range(64, 246000)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(shrink_node48_to_node16_sequentially)
+    ->Range(64, 246000)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(shrink_node48_to_node16_randomly)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_node48.cpp
+++ b/benchmark/micro_benchmark_node48.cpp
@@ -32,29 +32,16 @@ namespace {
 // 0x0000000000010010
 // ...
 
-inline constexpr auto full_node16_tree_key_zero_bits = 0xF0F0F0F0'F0F0F0F0ULL;
-
-// Minimal leaf-level Node48 tree keys over full Node16 tree keys: "base-17"
-// values that vary each byte from 0 to 0x10 with the last byte being a constant
-// 0x10.
-inline constexpr auto number_to_minimal_leaf_node48_over_node16_key(
-    std::uint64_t i) noexcept {
-  assert(i / (0x10 * 0x10 * 0x10 * 0x10 * 0x10 * 0x10) < 0x10);
-  return 0x10ULL | unodb::benchmark::to_base_n_value<0x10>(i) << 8;
-}
-
 void grow_node16_to_node48_sequentially(benchmark::State &state) {
   unodb::benchmark::grow_node_sequentially_benchmark<
-      unodb::db, 16, full_node16_tree_key_zero_bits>(
-      state, number_to_minimal_leaf_node48_over_node16_key);
+      unodb::db, 16, unodb::benchmark::full_node16_tree_key_zero_bits>(
+      state, unodb::benchmark::number_to_minimal_leaf_node48_over_node16_key);
 }
 
 void grow_node16_to_node48_randomly(benchmark::State &state) {
-  unodb::benchmark::grow_node_randomly_benchmark<
-      unodb::db, 16,
-      decltype(unodb::benchmark::make_node16_tree_with_gaps<unodb::db>)>(
-      state, unodb::benchmark::make_node16_tree_with_gaps,
-      unodb::benchmark::generate_random_minimal_node48_over_full_node16_keys);
+  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 16>(
+      state, unodb::benchmark::number_to_full_node16_with_gaps_key,
+      unodb::benchmark::generate_random_keys_over_full_smaller_tree<16>);
 }
 
 }  // namespace

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -12,10 +12,13 @@
 #include "art.hpp"
 #include "mutex_art.hpp"
 
-namespace {
+namespace unodb::benchmark {
+
+// Key vectors
 
 template <std::uint8_t NumByteValues>
-auto generate_random_keys_over_full_smaller_tree(unodb::key key_limit) {
+std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
+    unodb::key key_limit) {
   // The last byte at the limit will be randomly-generated and may happen to
   // fall above or below the limit. Reset the limit so that any byte value will
   // pass.
@@ -63,21 +66,12 @@ auto generate_random_keys_over_full_smaller_tree(unodb::key key_limit) {
   }
   cannot_happen();
 }
-}  // namespace
 
-namespace unodb::benchmark {
+template std::vector<unodb::key> generate_random_keys_over_full_smaller_tree<4>(
+    unodb::key);
 
-// Key vectors
-
-std::vector<unodb::key> generate_random_minimal_node16_over_full_node4_keys(
-    unodb::key key_limit) {
-  return generate_random_keys_over_full_smaller_tree<4>(key_limit);
-}
-
-std::vector<unodb::key> generate_random_minimal_node48_over_full_node16_keys(
-    unodb::key key_limit) {
-  return generate_random_keys_over_full_smaller_tree<16>(key_limit);
-}
+template std::vector<unodb::key>
+    generate_random_keys_over_full_smaller_tree<16>(unodb::key);
 
 // PRNG
 
@@ -123,29 +117,6 @@ void assert_mostly_node16_tree(const Db &test_db USED_IN_DEBUG) noexcept {
 }
 
 template void assert_mostly_node16_tree<unodb::db>(const unodb::db &) noexcept;
-
-// Insertion
-
-template <class Db>
-unodb::key make_node4_tree_with_gaps(Db &db, unsigned number_of_keys) {
-  const auto last_inserted_key =
-      insert_n_keys(db, number_of_keys, number_to_full_node4_with_gaps_key);
-  assert_node4_only_tree(db);
-  return last_inserted_key;
-}
-
-template unodb::key make_node4_tree_with_gaps<unodb::db>(unodb::db &, unsigned);
-
-template <class Db>
-unodb::key make_node16_tree_with_gaps(Db &db, unsigned number_of_keys) {
-  const auto last_inserted_key =
-      insert_n_keys(db, number_of_keys, number_to_full_node16_with_gaps_key);
-  assert_mostly_node16_tree(db);
-  return last_inserted_key;
-}
-
-template unodb::key make_node16_tree_with_gaps<unodb::db>(unodb::db &,
-                                                          unsigned);
 
 // Teardown
 


### PR DESCRIPTION
- Refactor unodb::benchmark::grow_node_randomly_benchmark to take number to key
  function instead of a tree-generating function, and remove such functions
  unodb::benchmark::make_node4_tree_with_gaps and
  unodb::benchmark::make_node16_tree_with_gaps.
- Move shrinking_tree_node_stats to micro_benchmark_utils.hpp, unodb::benchmark
  namespace
- Refactor micro_benchmark_node4.cpp:shrink_node16_to_node4_sequentially to
  unodb::benchmark::shrink_node_sequentially_benchmark and
  shrink_node16_to_node4_randomly to
  unodb::benchmark::shrink_node_randomly_benchmark, use them to implement Node48
  -> Node16 shrinking constructor benchmarks
- Move micro_benchmark_node48.cpp:full_node16_tree_key_zero_gits and
  number_to_minimal_leaf_node48_over_node16_key to micro_benchmark_utils.hpp,
  unodb::benchmark namespace
- Remove unodb::benchmark::generate_random_minimal_node16_over_full_node4_keys
  and generate_random_minimal_node48_over_full_node16_keys, move
  generate_random_keys_over_full_smaller_tree to unodb::benchmark namespace and
  use it instead