### PR TITLE
Node16 shrinking constructor: remove the child-to-be-removed before t…

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1094,25 +1094,20 @@ class inode_48 final : public basic_inode_48 {
 inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
                    std::uint8_t child_to_remove) noexcept
     : basic_inode_16{*source_node} {
+  source_node->remove_child_pointer(child_to_remove);
+  source_node->children[source_node->child_indexes[child_to_remove]] = nullptr;
+  source_node->child_indexes[child_to_remove] = inode_48::empty_child;
+
   std::uint8_t next_child = 0;
   for (unsigned i = 0; i < 256; i++) {
     const auto source_child_i = source_node->child_indexes[i];
-    if (i == child_to_remove) {
-      source_node->direct_remove_child_pointer(source_child_i);
-      continue;
-    }
     if (source_child_i != inode_48::empty_child) {
       keys.byte_array[next_child] = gsl::narrow_cast<std::byte>(i);
       const auto source_child_ptr = source_node->children[source_child_i];
       assert(source_child_ptr != nullptr);
       children[next_child] = source_child_ptr;
       ++next_child;
-      if (next_child == f.f.children_count) {
-        if (i < child_to_remove) {
-          source_node->remove_child_pointer(child_to_remove);
-        }
-        break;
-      }
+      if (next_child == f.f.children_count) break;
     }
   }
 


### PR DESCRIPTION
…he loop

This enables to remove branching from the children copying loop.

Performance change:

Baseline:

2020-10-23T17:40:50+02:00
Running ./micro_benchmark_node16
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.52, 0.64, 0.36
------------------------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------
shrink_node48_to_node16_sequentially/64           1.46 us         1.45 us       483389 16v=0 48v=4 items_per_second=2.76005M/s size=10.1133k
shrink_node48_to_node16_sequentially/512          4.76 us         4.71 us       148749 16v=0 48v=32 items_per_second=6.80012M/s size=80.8906k
shrink_node48_to_node16_sequentially/4096         30.9 us         30.7 us        22810 16v=0 48v=256 items_per_second=8.33098M/s size=646.906k
shrink_node48_to_node16_sequentially/32768         275 us          275 us         2546 16v=0 48v=2.048k items_per_second=7.45313M/s size=5.05411M
shrink_node48_to_node16_sequentially/246000       2814 us         2812 us          249 16v=0 48v=15.375k items_per_second=5.46731M/s size=37.9423M
shrink_node48_to_node16_randomly/64               1.51 us         1.50 us       467407 16v=0 48v=4 items_per_second=2.67227M/s size=10.1133k
shrink_node48_to_node16_randomly/512              5.63 us         5.58 us       125658 16v=0 48v=32 items_per_second=5.7399M/s size=80.8906k
shrink_node48_to_node16_randomly/4096             37.4 us         37.2 us        18850 16v=0 48v=256 items_per_second=6.88878M/s size=646.906k
shrink_node48_to_node16_randomly/32768             325 us          324 us         2160 16v=0 48v=2.048k items_per_second=6.31905M/s size=5.05411M
shrink_node48_to_node16_randomly/246000           3906 us         3904 us          179 16v=0 48v=15.375k items_per_second=3.93871M/s size=37.9423M

 Performance counter stats for './micro_benchmark_node16 --benchmark_filter=shrink':

        114,755.68 msec task-clock                #    1.000 CPUs utilized
               285      context-switches          #    0.002 K/sec
                 2      cpu-migrations            #    0.000 K/sec
           410,832      page-faults               #    0.004 M/sec
   436,322,937,441      cycles                    #    3.802 GHz                      (83.33%)
   100,791,970,474      stalled-cycles-frontend   #   23.10% frontend cycles idle     (83.33%)
    47,182,089,437      stalled-cycles-backend    #   10.81% backend cycles idle      (66.67%)
 1,018,965,625,307      instructions              #    2.34  insn per cycle
                                                  #    0.10  stalled cycles per insn  (83.34%)
   201,289,311,953      branches                  # 1754.068 M/sec                    (83.33%)
       369,493,700      branch-misses             #    0.18% of all branches          (83.33%)

     114.775863765 seconds time elapsed

     112.384650000 seconds user
       2.372013000 seconds sys

With the patch:

shrink_node48_to_node16_sequentially/64           1.37 us         1.35 us       517481 16v=0 48v=4 items_per_second=2.95663M/s size=10.1133k
shrink_node48_to_node16_sequentially/512          4.44 us         4.38 us       159584 16v=0 48v=32 items_per_second=7.3026M/s size=80.8906k
shrink_node48_to_node16_sequentially/4096         28.9 us         28.7 us        24386 16v=0 48v=256 items_per_second=8.92085M/s size=646.906k
shrink_node48_to_node16_sequentially/32768         260 us          259 us         2690 16v=0 48v=2.048k items_per_second=7.8991M/s size=5.05411M
shrink_node48_to_node16_sequentially/246000       2832 us         2831 us          248 16v=0 48v=15.375k items_per_second=5.43155M/s size=37.9423M
shrink_node48_to_node16_randomly/64               1.45 us         1.44 us       488545 16v=0 48v=4 items_per_second=2.78467M/s size=10.1133k
shrink_node48_to_node16_randomly/512              4.78 us         4.73 us       147866 16v=0 48v=32 items_per_second=6.76105M/s size=80.8906k
shrink_node48_to_node16_randomly/4096             30.9 us         30.7 us        22830 16v=0 48v=256 items_per_second=8.3458M/s size=646.906k
shrink_node48_to_node16_randomly/32768             279 us          278 us         2513 16v=0 48v=2.048k items_per_second=7.37376M/s size=5.05411M
shrink_node48_to_node16_randomly/246000           3596 us         3595 us          195 16v=0 48v=15.375k items_per_second=4.27735M/s size=37.9423M

 Performance counter stats for './micro_benchmark_node16 --benchmark_filter=shrink':

        126,994.73 msec task-clock                #    1.000 CPUs utilized
               220      context-switches          #    0.002 K/sec
                 3      cpu-migrations            #    0.000 K/sec
           422,683      page-faults               #    0.003 M/sec
   482,838,461,381      cycles                    #    3.802 GHz                      (83.33%)
   108,329,038,347      stalled-cycles-frontend   #   22.44% frontend cycles idle     (83.33%)
    49,892,144,251      stalled-cycles-backend    #   10.33% backend cycles idle      (66.67%)
 1,138,294,759,661      instructions              #    2.36  insn per cycle
                                                  #    0.10  stalled cycles per insn  (83.33%)
   224,050,930,296      branches                  # 1764.254 M/sec                    (83.33%)
       336,823,617      branch-misses             #    0.15% of all branches          (83.33%)

     127.013898790 seconds time elapsed

     124.607620000 seconds user
       2.388069000 seconds sys