### PR TITLE
Use unsigned instead of std::uint8_t in Node16 shrinking constructor

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1100,7 +1100,7 @@ inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
   source_node->child_indexes[child_to_remove] = inode_48::empty_child;
 
   // TODO(laurynas): consider AVX512 gather?
-  std::uint8_t next_child = 0;
+  unsigned next_child = 0;
   for (unsigned i = 0; i < 256; i++) {
     const auto source_child_i = source_node->child_indexes[i];
     if (source_child_i != inode_48::empty_child) {


### PR DESCRIPTION
Performance change:

shrink_node48_to_node16_sequentially/64_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/64_mean                      -0.0300         -0.0364             1             1             1             1
shrink_node48_to_node16_sequentially/512_pvalue                    0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/512_mean                     -0.0168         -0.0179             4             4             4             4
shrink_node48_to_node16_sequentially/4096_pvalue                   0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/4096_mean                    +0.0263         +0.0260            29            30            29            29
shrink_node48_to_node16_sequentially/32768_pvalue                  0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/32768_mean                   -0.0194         -0.0200           259           254           258           253
shrink_node48_to_node16_sequentially/246000_pvalue                 0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/246000_mean                  -0.0113         -0.0113          2805          2773          2803          2771
shrink_node48_to_node16_randomly/64_pvalue                         0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/64_mean                          -0.0096         -0.0215             1             1             1             1
shrink_node48_to_node16_randomly/512_pvalue                        0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/512_mean                         +0.0083         +0.0040             5             5             5             5
shrink_node48_to_node16_randomly/4096_pvalue                       0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/4096_mean                        +0.0085         +0.0078            30            31            30            30
shrink_node48_to_node16_randomly/32768_pvalue                      0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/32768_mean                       -0.0044         -0.0044           275           274           274           273
shrink_node48_to_node16_randomly/246000_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/246000_mean                      -0.0200         -0.0200          3491          3421          3489          3419