### PR TITLE
Implement Node48 add benchmarks

### DIFF
--- a/benchmark/micro_benchmark_node48.cpp
+++ b/benchmark/micro_benchmark_node48.cpp
@@ -44,6 +44,28 @@ void grow_node16_to_node48_randomly(benchmark::State &state) {
       unodb::benchmark::generate_random_keys_over_full_smaller_tree<16>);
 }
 
+inline constexpr auto number_to_minimal_node48_key(std::uint64_t i) noexcept {
+  return unodb::benchmark::to_base_n_value<17>(i);
+}
+
+inline constexpr auto number_to_full_leaf_over_minimal_node48_key(
+    std::uint64_t i) noexcept {
+  assert(i / (31 * 17 * 17 * 17 * 17 * 17 * 17) < 17);
+  return ((i % 31) + 17) | unodb::benchmark::to_base_n_value<17>(i / 31) << 8;
+}
+
+void node48_sequential_add(benchmark::State &state) {
+  unodb::benchmark::sequential_add_benchmark<unodb::db, 48>(
+      state, number_to_minimal_node48_key,
+      number_to_full_leaf_over_minimal_node48_key);
+}
+
+void node48_random_add(benchmark::State &state) {
+  unodb::benchmark::random_add_benchmark<unodb::db, 48>(
+      state, number_to_minimal_node48_key,
+      number_to_full_leaf_over_minimal_node48_key);
+}
+
 }  // namespace
 
 BENCHMARK(grow_node16_to_node48_sequentially)
@@ -52,5 +74,7 @@ BENCHMARK(grow_node16_to_node48_sequentially)
 BENCHMARK(grow_node16_to_node48_randomly)
     ->Range(2, 2048)
     ->Unit(benchmark::kMicrosecond);
+BENCHMARK(node48_sequential_add)->Range(2, 4096)->Unit(benchmark::kMicrosecond);
+BENCHMARK(node48_random_add)->Range(2, 4096)->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -117,6 +117,20 @@ void assert_mostly_node16_tree(const Db &test_db USED_IN_DEBUG) noexcept {
 
 template void assert_mostly_node16_tree<unodb::db>(const unodb::db &) noexcept;
 
+template <class Db>
+void assert_mostly_node48_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+#ifndef NDEBUG
+  if (test_db.get_inode4_count() + test_db.get_inode16_count() > 8) {
+    std::cerr << "Too many I4/I16 nodes found in mostly-I48 tree:\n";
+    test_db.dump(std::cerr);
+    assert(test_db.get_inode4_count() + test_db.get_inode16_count() <= 8);
+  }
+  assert(test_db.get_inode256_count() == 0);
+#endif
+}
+
+template void assert_mostly_node48_tree<unodb::db>(const unodb::db &) noexcept;
+
 // Teardown
 
 template <class Db>


### PR DESCRIPTION
- Refactor Node16 add benchmarks: move number_to_minimal_node16_key,
  number_to_full_leaf_over_minimal_node16_key, generate_keys_to_limit to
  unodb::benchmark::namespace, introduce
  unodb::benchmark::sequential_add_benchmark and
  unodb::benchmark::random_add_benchmark, make Node16 add benchmarks use them.
- New helpers in unodb::benchmark: assert_mostly_node48_tree,
  node_capacity_to_minimum_size, make_base_tree_for_add.