### PR TITLE
Node16 shrinking constructor: iterate over byte values in an infinite…

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1101,7 +1101,8 @@ inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
 
   // TODO(laurynas): consider AVX512 gather?
   unsigned next_child = 0;
-  for (unsigned i = 0; i < 256; i++) {
+  unsigned i = 0;
+  while (true) {
     const auto source_child_i = source_node->child_indexes[i];
     if (source_child_i != inode_48::empty_child) {
       keys.byte_array[next_child] = gsl::narrow_cast<std::byte>(i);
@@ -1111,6 +1112,8 @@ inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
       ++next_child;
       if (next_child == capacity) break;
     }
+    assert(i < 255);
+    ++i;
   }
 
   assert(std::is_sorted(keys.byte_array.cbegin(),


### PR DESCRIPTION
… loop

The loop will exit after filling 16 values anyway, making the byte value exit
condition redundant.

Performance change:

shrink_node48_to_node16_sequentially/64_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/64_mean                      -0.0539         -0.0542             1             1             1             1
shrink_node48_to_node16_sequentially/512_pvalue                    0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/512_mean                     -0.1407         -0.1411             5             4             5             4
shrink_node48_to_node16_sequentially/4096_pvalue                   0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/4096_mean                    -0.1735         -0.1735            34            29            34            28
shrink_node48_to_node16_sequentially/32768_pvalue                  0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/32768_mean                   -0.2368         -0.2379           335           255           334           255
shrink_node48_to_node16_sequentially/246000_pvalue                 0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/246000_mean                  -0.1721         -0.1721          3308          2739          3306          2737
shrink_node48_to_node16_randomly/64_pvalue                         0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/64_mean                          -0.0472         -0.0446             1             1             1             1
shrink_node48_to_node16_randomly/512_pvalue                        0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/512_mean                         -0.1088         -0.1104             5             5             5             5
shrink_node48_to_node16_randomly/4096_pvalue                       0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/4096_mean                        -0.1766         -0.1769            37            30            36            30
shrink_node48_to_node16_randomly/32768_pvalue                      0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/32768_mean                       -0.2308         -0.2323           351           270           350           268
shrink_node48_to_node16_randomly/246000_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/246000_mean                      -0.1587         -0.1588          3989          3356          3987          3354