### PR TITLE
Node16 shrinking constructor: do not reset the deleted Node48 child p…

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1095,8 +1095,6 @@ inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
                    std::uint8_t child_to_remove) noexcept
     : basic_inode_16{*source_node} {
   source_node->remove_child_pointer(child_to_remove);
-  // This assignment is redundant but results in benchmark regression, go figure
-  source_node->children[source_node->child_indexes[child_to_remove]] = nullptr;
   source_node->child_indexes[child_to_remove] = inode_48::empty_child;
 
   // TODO(laurynas): consider AVX512 gather?


### PR DESCRIPTION
…ointer

OK to leave it as-is, as it won't be accessed again.

Performance change

shrink_node48_to_node16_sequentially/64_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/64_mean                      -0.0059         -0.0055             1             1             1             1
shrink_node48_to_node16_sequentially/512_pvalue                    0.0023          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/512_mean                     -0.0038         -0.0053             4             4             4             4
shrink_node48_to_node16_sequentially/4096_pvalue                   0.0130          0.0075      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/4096_mean                    +0.0020         +0.0023            28            29            28            28
shrink_node48_to_node16_sequentially/32768_pvalue                  0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/32768_mean                   -0.0111         -0.0130           258           256           258           255
shrink_node48_to_node16_sequentially/246000_pvalue                 0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_sequentially/246000_mean                  -0.0044         -0.0044          2750          2738          2748          2736
shrink_node48_to_node16_randomly/64_pvalue                         0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/64_mean                          -0.0111         -0.0187             1             1             1             1
shrink_node48_to_node16_randomly/512_pvalue                        0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/512_mean                         -0.0253         -0.0244             5             5             5             5
shrink_node48_to_node16_randomly/4096_pvalue                       0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/4096_mean                        -0.0288         -0.0292            31            30            30            29
shrink_node48_to_node16_randomly/32768_pvalue                      0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/32768_mean                       -0.0128         -0.0141           271           267           270           266
shrink_node48_to_node16_randomly/246000_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node48_to_node16_randomly/246000_mean                      +0.0042         +0.0043          3368          3382          3365          3380