### PR TITLE
Node48 add: use infinite loop to find an empty children slot

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1041,13 +1041,14 @@ class inode_48 final : public basic_inode_48 {
 
     const auto key_byte = static_cast<uint8_t>(leaf::key(child.get())[depth]);
     assert(child_indexes[key_byte] == empty_child);
-    std::uint8_t i;
+    std::uint8_t i{0};
     node_ptr child_ptr;
-    for (i = 0; i < capacity; ++i) {
+    while (true) {
       child_ptr = children[i];
       if (child_ptr == nullptr) break;
+      assert(i < 255);
+      ++i;
     }
-    assert(child_ptr == nullptr);
     child_indexes[key_byte] = i;
     children[i] = child.release();
     ++f.f.children_count;


### PR DESCRIPTION
Performance change:

node48_sequential_add/2_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_sequential_add/2_mean                     -0.1133         -0.1143             7             7             7             7
node48_sequential_add/8_pvalue                    0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_sequential_add/8_mean                     -0.1318         -0.1320            27            23            27            23
node48_sequential_add/64_pvalue                   0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_sequential_add/64_mean                    -0.1081         -0.1081           288           257           288           257
node48_sequential_add/512_pvalue                  0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_sequential_add/512_mean                   -0.0892         -0.0892          2577          2347          2576          2347
node48_sequential_add/4096_pvalue                 0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_sequential_add/4096_mean                  -0.0886         -0.0887         21455         19553         21454         19551
node48_random_add/2_pvalue                        0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_random_add/2_mean                         -0.0182         -0.0184             6             6             6             6
node48_random_add/8_pvalue                        0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_random_add/8_mean                         -0.0191         -0.0190            22            21            22            21
node48_random_add/64_pvalue                       0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_random_add/64_mean                        +0.1275         +0.1272           185           209           185           208
node48_random_add/512_pvalue                      0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_random_add/512_mean                       +0.3250         +0.3252          1748          2316          1748          2316
node48_random_add/4096_pvalue                     0.0004          0.0004      U Test, Repetitions: 9 vs 9
node48_random_add/4096_mean                      -0.0234         -0.0234         23600         23047         23598         23046

perf stat:

before:

2020-10-26T06:04:05+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.02, 0.07, 0.19
-------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------
node48_sequential_add/2          7.54 us         7.54 us        92857 items_per_second=8.22505M/s size=12.1895k
node48_sequential_add/8          27.1 us         27.1 us        25877 items_per_second=9.15973M/s size=48.6953k
node48_sequential_add/64          292 us          292 us         2395 items_per_second=7.11603M/s size=402.013k
node48_sequential_add/512        2658 us         2658 us          264 items_per_second=6.3211M/s size=3.16333M
node48_sequential_add/4096      21809 us        21808 us           32 items_per_second=6.16373M/s size=25.3126M
node48_random_add/2              6.19 us         6.18 us       113241 items_per_second=10.0298M/s size=12.1895k
node48_random_add/8              21.7 us         21.6 us        32434 items_per_second=11.4716M/s size=48.6953k
node48_random_add/64              234 us          234 us         2982 items_per_second=8.88758M/s size=402.013k
node48_random_add/512            2509 us         2509 us          278 items_per_second=6.69689M/s size=3.16333M
node48_random_add/4096          24222 us        24221 us           29 items_per_second=5.54948M/s size=25.3126M

 Performance counter stats for './micro_benchmark_node48 --benchmark_filter=add':

         18,688.75 msec task-clock                #    0.999 CPUs utilized
                40      context-switches          #    0.002 K/sec
                 0      cpu-migrations            #    0.000 K/sec
         1,564,878      page-faults               #    0.084 M/sec
    71,030,856,782      cycles                    #    3.801 GHz                      (83.33%)
    24,704,409,246      stalled-cycles-frontend   #   34.78% frontend cycles idle     (83.33%)
    12,681,732,977      stalled-cycles-backend    #   17.85% backend cycles idle      (66.67%)
   129,975,515,371      instructions              #    1.83  insn per cycle
                                                  #    0.19  stalled cycles per insn  (83.34%)
    25,696,011,400      branches                  # 1374.945 M/sec                    (83.35%)
       267,780,939      branch-misses             #    1.04% of all branches          (83.33%)

      18.707068674 seconds time elapsed

      16.772637000 seconds user
       1.916529000 seconds sys

after:

2020-10-26T05:51:27+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.01, 0.37, 0.36
-------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------
node48_sequential_add/2          6.56 us         6.56 us       106760 items_per_second=9.45774M/s size=12.1895k
node48_sequential_add/8          23.3 us         23.2 us        30108 items_per_second=10.6738M/s size=48.6953k
node48_sequential_add/64          258 us          258 us         2699 items_per_second=8.05614M/s size=402.013k
node48_sequential_add/512        2361 us         2361 us          296 items_per_second=7.11618M/s size=3.16333M
node48_sequential_add/4096      19654 us        19653 us           36 items_per_second=6.83942M/s size=25.3126M
node48_random_add/2              6.11 us         6.11 us       114703 items_per_second=10.1508M/s size=12.1895k
node48_random_add/8              21.3 us         21.3 us        32898 items_per_second=11.6502M/s size=48.6953k
node48_random_add/64              208 us          208 us         3374 items_per_second=10.0028M/s size=402.013k
node48_random_add/512            2332 us         2331 us          300 items_per_second=7.20653M/s size=3.16333M
node48_random_add/4096          23306 us        23305 us           30 items_per_second=5.76767M/s size=25.3126M

 Performance counter stats for './micro_benchmark_node48 --benchmark_filter=add':

         18,844.19 msec task-clock                #    0.999 CPUs utilized
                19      context-switches          #    0.001 K/sec
                 0      cpu-migrations            #    0.000 K/sec
         1,674,491      page-faults               #    0.089 M/sec
    71,678,946,784      cycles                    #    3.804 GHz                      (83.34%)
    23,300,241,884      stalled-cycles-frontend   #   32.51% frontend cycles idle     (83.34%)
    12,252,042,146      stalled-cycles-backend    #   17.09% backend cycles idle      (66.67%)
   133,807,608,637      instructions              #    1.87  insn per cycle
                                                  #    0.17  stalled cycles per insn  (83.34%)
    24,873,846,935      branches                  # 1319.974 M/sec                    (83.34%)
       147,084,407      branch-misses             #    0.59% of all branches          (83.31%)

      18.862661117 seconds time elapsed

      16.847731000 seconds user
       1.996442000 seconds sys