### PR TITLE
Node48 add: make it SIMD, fully rolled for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
     "-Warray-bounds=2" "-Wredundant-tags")
 endif()
 
-list(APPEND CXX_FLAGS "${CXX_WARNING_FLAGS}" "-g")
+list(APPEND CXX_FLAGS "${CXX_WARNING_FLAGS}" "-g" "-msse4.1")
 
 option(COVERAGE "Enable code coverage reporting")
 if(COVERAGE)
@@ -294,6 +294,8 @@ else()
     string(CONCAT CLANG_TIDY_DISABLED
       "-fuchsia-default-arguments,"
       "-clang-diagnostic-error,"
+      # Duplicated by modernize-avoid-c-arrays
+      "-cppcoreguidelines-avoid-c-arrays,"
       "-cppcoreguidelines-avoid-magic-numbers,"
       "-cppcoreguidelines-init-variables,"
       "-cppcoreguidelines-macro-usage," # Until it respects __LINE__ in macro definition
@@ -314,6 +316,8 @@ else()
       "-fuchsia-overloaded-operator,"
       "-google-readability-braces-around-statements,"
       "-google-runtime-references,"
+      # Duplicated by modernize-avoid-c-arrays
+      "-hicpp-avoid-c-arrays,"
       "-hicpp-braces-around-statements,"
       "-hicpp-member-init,"
       "-hicpp-no-array-decay,"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Status](https://travis-ci.org/laurynas-biveinis/unodb.svg?branch=master)](https:
 Unodb is a adaptive radix tree implementation, done as my playground for various
 C++ tools and ideas.
 
+## Requirements
+
+The code uses SSE4.1 intrinsics (Nehalem and higher). This is in contrast to the
+original ART paper needing SSE2 only.
+
 ## Usage
 
 All the declarations live in the `unodb` namespace, which is omitted in the

--- a/art.cpp
+++ b/art.cpp
@@ -7,15 +7,17 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#ifdef __x86_64
-#include <emmintrin.h>
-#endif
 #include <exception>
 #include <iomanip>
 #include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <utility>
+
+#ifdef __x86_64
+#include <emmintrin.h>
+#include <smmintrin.h>
+#endif
 
 #include <gsl/gsl_util>
 
@@ -1045,16 +1047,32 @@ class inode_48 final : public basic_inode_48 {
 
     const auto key_byte = static_cast<uint8_t>(leaf::key(child.get())[depth]);
     assert(child_indexes[key_byte] == empty_child);
-    std::uint8_t i{0};
+    unsigned i{0};
+#ifdef __x86_64
+    const auto nullptr_vector = _mm_setzero_si128();
+    while (true) {
+      const auto pointer_vector = _mm_load_si128(&children.pointer_vector[i]);
+      const auto vec_cmp = _mm_cmpeq_epi64(pointer_vector, nullptr_vector);
+      const auto cmp_mask =
+          static_cast<std::uint64_t>(_mm_movemask_epi8(vec_cmp));
+      if (cmp_mask != 0) {
+        i = (i << 1U) + (ffs_nonzero(cmp_mask) >> 3U);
+        break;
+      }
+      ++i;
+    }
+#else
     node_ptr child_ptr;
     while (true) {
-      child_ptr = children[i];
+      child_ptr = children.pointer_array[i];
       if (child_ptr == nullptr) break;
       assert(i < 255);
       ++i;
     }
-    child_indexes[key_byte] = i;
-    children[i] = child.release();
+#endif
+    assert(children.pointer_array[i] == nullptr);
+    child_indexes[key_byte] = gsl::narrow_cast<std::uint8_t>(i);
+    children.pointer_array[i] = child.release();
     ++f.f.children_count;
   }
 
@@ -1062,7 +1080,7 @@ class inode_48 final : public basic_inode_48 {
     assert(reinterpret_cast<node_header *>(this)->type() == static_node_type);
 
     remove_child_pointer(child_index);
-    children[child_indexes[child_index]] = nullptr;
+    children.pointer_array[child_indexes[child_index]] = nullptr;
     child_indexes[child_index] = empty_child;
     --f.f.children_count;
   }
@@ -1079,7 +1097,7 @@ class inode_48 final : public basic_inode_48 {
   }
 
   void direct_remove_child_pointer(std::uint8_t children_i) noexcept {
-    const auto child_ptr = children[children_i];
+    const auto child_ptr = children.pointer_array[children_i];
 
     assert(children_i != empty_child);
     assert(child_ptr != nullptr);
@@ -1088,7 +1106,17 @@ class inode_48 final : public basic_inode_48 {
   }
 
   std::array<std::uint8_t, 256> child_indexes;
-  std::array<node_ptr, capacity> children;
+
+  union children_union {
+    std::array<node_ptr, capacity> pointer_array;
+#ifdef __x86_64
+    static_assert(capacity % 16 == 0);
+    // No std::array below because it would ignore the alignment attribute
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    __m128i pointer_vector[capacity / 16];  // NOLINT(runtime/arrays)
+#endif
+    children_union() {}
+  } children;
 
   static constexpr std::uint8_t empty_child = 0xFF;
 
@@ -1111,7 +1139,8 @@ inode_16::inode_16(std::unique_ptr<inode_48> &&source_node,
     const auto source_child_i = source_node->child_indexes[i];
     if (source_child_i != inode_48::empty_child) {
       keys.byte_array[next_child] = gsl::narrow_cast<std::byte>(i);
-      const auto source_child_ptr = source_node->children[source_child_i];
+      const auto source_child_ptr =
+          source_node->children.pointer_array[source_child_i];
       assert(source_child_ptr != nullptr);
       children[next_child] = source_child_ptr;
       ++next_child;
@@ -1140,15 +1169,15 @@ inode_48::inode_48(std::unique_ptr<inode_16> &&source_node,
     child_indexes[static_cast<std::uint8_t>(existing_key_byte)] = i;
   }
   for (i = 0; i < inode_16::capacity; ++i) {
-    children[i] = source_node_ptr->children[i];
+    children.pointer_array[i] = source_node_ptr->children[i];
   }
 
   const auto key_byte = static_cast<std::uint8_t>(leaf::key(child_ptr)[depth]);
   assert(child_indexes[key_byte] == empty_child);
   child_indexes[key_byte] = i;
-  children[i] = child_ptr;
+  children.pointer_array[i] = child_ptr;
   for (i = f.f.children_count; i < capacity; i++) {
-    children[i] = nullptr;
+    children.pointer_array[i] = nullptr;
   }
 }
 
@@ -1158,9 +1187,9 @@ __attribute__((pure)) inode::find_result_type inode_48::find_child(
 
   if (child_indexes[static_cast<std::uint8_t>(key_byte)] != empty_child) {
     const auto child_i = child_indexes[static_cast<std::uint8_t>(key_byte)];
-    assert(children[child_i] != nullptr);
+    assert(children.pointer_array[child_i] != nullptr);
     return std::make_pair(static_cast<std::uint8_t>(key_byte),
-                          &children[child_i]);
+                          &children.pointer_array[child_i]);
   }
   return std::make_pair(0xFF, nullptr);
 }
@@ -1168,7 +1197,7 @@ __attribute__((pure)) inode::find_result_type inode_48::find_child(
 void inode_48::delete_subtree() noexcept {
   unsigned actual_children_count = 0;
   for (unsigned i = 0; i < capacity; ++i) {
-    const auto child = children[i];
+    const auto child = children.pointer_array[i];
     if (child != nullptr) {
       ++actual_children_count;
       ::delete_subtree(child);
@@ -1188,8 +1217,8 @@ void inode_48::dump(std::ostream &os) const {
       dump_byte(os, gsl::narrow_cast<std::byte>(i));
       os << ", child index = " << static_cast<unsigned>(child_indexes[i])
          << ": ";
-      assert(children[child_indexes[i]] != nullptr);
-      dump_node(os, children[child_indexes[i]]);
+      assert(children.pointer_array[child_indexes[i]] != nullptr);
+      dump_node(os, children.pointer_array[child_indexes[i]]);
       assert(actual_children_count <= f.f.children_count);
     }
 
@@ -1266,7 +1295,7 @@ inode_48::inode_48(std::unique_ptr<inode_256> &&source_node,
     }
     assert(child_ptr != nullptr);
     child_indexes[child_i] = next_child;
-    children[next_child] = source_node->children[child_i];
+    children.pointer_array[next_child] = source_node->children[child_i];
     ++next_child;
     if (next_child == f.f.children_count) {
       if (child_i < child_to_remove) {
@@ -1289,7 +1318,7 @@ inode_256::inode_256(std::unique_ptr<inode_48> &&source_node,
     const auto children_i = source_node->child_indexes[i];
     children[i] = children_i == inode_48::empty_child
                       ? nullptr
-                      : source_node->children[children_i];
+                      : source_node->children.pointer_array[children_i];
   }
 
   const auto key_byte = static_cast<uint8_t>(leaf::key(child.get())[depth]);


### PR DESCRIPTION
This introduces SSE4.1 intrinsics over the previous SSE2 ones, add a note and a
compilation flag.

Baseline performance:

$ ./micro_benchmark_node48 --benchmark_filter=add
2020-10-29T05:35:22+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.22, 0.09, 0.02
-------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------
node48_sequential_add/2          6.55 us         6.54 us       107032 items_per_second=9.47406M/s size=12.1895k
node48_sequential_add/8          23.3 us         23.3 us        30011 items_per_second=10.6661M/s size=48.6953k
node48_sequential_add/64          255 us          255 us         2743 items_per_second=8.14183M/s size=402.013k
node48_sequential_add/512        2341 us         2341 us          299 items_per_second=7.17849M/s size=3.16333M
node48_sequential_add/4096      19537 us        19535 us           36 items_per_second=6.88069M/s size=25.3126M
node48_random_add/2              6.05 us         6.04 us       115634 items_per_second=10.266M/s size=12.1895k
node48_random_add/8              21.3 us         21.3 us        32915 items_per_second=11.6685M/s size=48.6953k
node48_random_add/64              206 us          206 us         3388 items_per_second=10.0689M/s size=402.013k
node48_random_add/512            2318 us         2318 us          302 items_per_second=7.24918M/s size=3.16333M
node48_random_add/4096          22993 us        22991 us           30 items_per_second=5.84648M/s size=25.3126M

With the patch:

$ ./micro_benchmark_node48 --benchmark_filter=add
2020-10-29T05:58:18+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.94, 0.32, 0.11
-------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------
node48_sequential_add/2          5.87 us         5.87 us       118794 items_per_second=10.569M/s size=12.1895k
node48_sequential_add/8          20.6 us         20.6 us        33935 items_per_second=12.03M/s size=48.6953k
node48_sequential_add/64          239 us          239 us         2939 items_per_second=8.69739M/s size=402.013k
node48_sequential_add/512        2205 us         2205 us          317 items_per_second=7.61996M/s size=3.16333M
node48_sequential_add/4096      18455 us        18453 us           38 items_per_second=7.28409M/s size=25.3126M
node48_random_add/2              5.18 us         5.18 us       135261 items_per_second=11.9739M/s size=12.1895k
node48_random_add/8              18.2 us         18.2 us        38529 items_per_second=13.6471M/s size=48.6953k
node48_random_add/64              191 us          190 us         3662 items_per_second=10.9103M/s size=402.013k
node48_random_add/512            2213 us         2213 us          316 items_per_second=7.59291M/s size=3.16333M
node48_random_add/4096          22337 us        22336 us           31 items_per_second=6.01779M/s size=25.3126M