### PR TITLE
Node48 add: unroll nullptr-searching loop once

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1051,15 +1051,20 @@ class inode_48 final : public basic_inode_48 {
 #ifdef __x86_64
     const auto nullptr_vector = _mm_setzero_si128();
     while (true) {
-      const auto pointer_vector = _mm_load_si128(&children.pointer_vector[i]);
-      const auto vec_cmp = _mm_cmpeq_epi64(pointer_vector, nullptr_vector);
+      const auto ptr_vec0 = _mm_load_si128(&children.pointer_vector[i]);
+      const auto ptr_vec1 = _mm_load_si128(&children.pointer_vector[i + 1]);
+      const auto vec0_cmp = _mm_cmpeq_epi64(ptr_vec0, nullptr_vector);
+      const auto vec1_cmp = _mm_cmpeq_epi64(ptr_vec1, nullptr_vector);
+      // OK to treat 64-bit comparison result as 32-bit vector: we need to find
+      // the first 0xFF only.
+      const auto packed_vec_cmp = _mm_packs_epi32(vec0_cmp, vec1_cmp);
       const auto cmp_mask =
-          static_cast<std::uint64_t>(_mm_movemask_epi8(vec_cmp));
+          static_cast<std::uint64_t>(_mm_movemask_epi8(packed_vec_cmp));
       if (cmp_mask != 0) {
-        i = (i << 1U) + (ffs_nonzero(cmp_mask) >> 3U);
+        i = (i << 1U) + (ffs_nonzero(cmp_mask) >> 2U);
         break;
       }
-      ++i;
+      i += 2;
     }
 #else
     node_ptr child_ptr;


### PR DESCRIPTION
Baseline performance:

$ ./micro_benchmark_node48 --benchmark_filter=add
2020-10-29T18:39:55+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.22, 0.78, 0.31
-------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------
node48_sequential_add/2          5.86 us         5.85 us       119033 items_per_second=10.6005M/s size=12.1895k
node48_sequential_add/8          20.5 us         20.5 us        33997 items_per_second=12.0921M/s size=48.6953k
node48_sequential_add/64          236 us          235 us         2970 items_per_second=8.82452M/s size=402.013k
node48_sequential_add/512        2181 us         2181 us          320 items_per_second=7.70415M/s size=3.16333M
node48_sequential_add/4096      18283 us        18281 us           38 items_per_second=7.35281M/s size=25.3126M
node48_random_add/2              5.25 us         5.25 us       133371 items_per_second=11.8151M/s size=12.1895k
node48_random_add/8              18.3 us         18.3 us        38250 items_per_second=13.5738M/s size=48.6953k
node48_random_add/64              190 us          189 us         3692 items_per_second=10.9681M/s size=402.013k
node48_random_add/512            2195 us         2194 us          319 items_per_second=7.65654M/s size=3.16333M
node48_random_add/4096          22316 us        22315 us           31 items_per_second=6.02353M/s size=25.3126M

With the patch

$ ./micro_benchmark_node48 --benchmark_filter=add
2020-10-29T18:39:24+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.42, 0.76, 0.29
-------------------------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------
node48_sequential_add/2          5.49 us         5.48 us       127762 items_per_second=11.3043M/s size=12.1895k
node48_sequential_add/8          19.0 us         19.0 us        36864 items_per_second=13.0625M/s size=48.6953k
node48_sequential_add/64          222 us          222 us         3153 items_per_second=9.37517M/s size=402.013k
node48_sequential_add/512        2057 us         2057 us          341 items_per_second=8.16844M/s size=3.16333M
node48_sequential_add/4096      17307 us        17305 us           40 items_per_second=7.76758M/s size=25.3126M
node48_random_add/2              4.96 us         4.94 us       141857 items_per_second=12.5505M/s size=12.1895k
node48_random_add/8              17.2 us         17.1 us        40932 items_per_second=14.4975M/s size=48.6953k
node48_random_add/64              178 us          177 us         3943 items_per_second=11.7093M/s size=402.013k
node48_random_add/512            2091 us         2091 us          334 items_per_second=8.03425M/s size=3.16333M
node48_random_add/4096          20888 us        20887 us           33 items_per_second=6.43541M/s size=25.3126M