### PR TITLE
Generalize unodb::benchmark::number_to_minimal_node16_key

### DIFF
--- a/benchmark/micro_benchmark_node48.cpp
+++ b/benchmark/micro_benchmark_node48.cpp
@@ -44,10 +44,6 @@ void grow_node16_to_node48_randomly(benchmark::State &state) {
       unodb::benchmark::generate_random_keys_over_full_smaller_tree<16>);
 }
 
-inline constexpr auto number_to_minimal_node48_key(std::uint64_t i) noexcept {
-  return unodb::benchmark::to_base_n_value<17>(i);
-}
-
 inline constexpr auto number_to_full_leaf_over_minimal_node48_key(
     std::uint64_t i) noexcept {
   assert(i / (31 * 17 * 17 * 17 * 17 * 17 * 17) < 17);
@@ -56,14 +52,12 @@ inline constexpr auto number_to_full_leaf_over_minimal_node48_key(
 
 void node48_sequential_add(benchmark::State &state) {
   unodb::benchmark::sequential_add_benchmark<unodb::db, 48>(
-      state, number_to_minimal_node48_key,
-      number_to_full_leaf_over_minimal_node48_key);
+      state, number_to_full_leaf_over_minimal_node48_key);
 }
 
 void node48_random_add(benchmark::State &state) {
   unodb::benchmark::random_add_benchmark<unodb::db, 48>(
-      state, number_to_minimal_node48_key,
-      number_to_full_leaf_over_minimal_node48_key);
+      state, number_to_full_leaf_over_minimal_node48_key);
 }
 
 }  // namespace

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -205,4 +205,21 @@ template void full_node_random_get_benchmark<unodb::db, 4>(::benchmark::State &,
 template void full_node_random_get_benchmark<unodb::db, 16>(
     ::benchmark::State &, std::uint64_t);
 
+template <class Db, unsigned NodeCapacity>
+std::tuple<unodb::key, const tree_shape_snapshot<Db>> make_base_tree_for_add(
+    Db &test_db, unsigned node_count) {
+  const auto key_limit = insert_n_keys<
+      Db, decltype(number_to_minimal_node_size_tree_key<NodeCapacity>)>(
+      test_db, node_count * (node_capacity_to_minimum_size<NodeCapacity>() + 1),
+      number_to_minimal_node_size_tree_key<NodeCapacity>);
+  assert_node_size_tree<Db, NodeCapacity>(test_db);
+  return std::make_tuple(key_limit, tree_shape_snapshot<unodb::db>{test_db});
+}
+
+template std::tuple<unodb::key, const tree_shape_snapshot<unodb::db>>
+make_base_tree_for_add<unodb::db, 16>(unodb::db &, unsigned);
+
+template std::tuple<unodb::key, const tree_shape_snapshot<unodb::db>>
+make_base_tree_for_add<unodb::db, 48>(unodb::db &, unsigned);
+
 }  // namespace unodb::benchmark


### PR DESCRIPTION
to number_to_minimal_node_size_tree_key<unsigned NodeSize>. Use it from
unodb::benchmark::sequential_add_benchmark, random_add_benchmark, and
make_base_tree_for_add directly, removing the need for a template parameter. As
a result, micro_benchmark_node48.cpp:number_to_minimal_node48_key goes away too.

This enables to use extern template for
unodb::benchmark::make_base_tree_for_add.