### PR TITLE
Finish Node48 benchmarks, start Node256 ones, major refectoring

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -3,7 +3,8 @@
 set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
 set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
 set(micro_benchmark_node16_quick_arg "--benchmark_filter='/64'")
-set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64'")
+set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64|/128|/192'")
+set(micro_benchmark_node256_quick_arg "--benchmark_filter='/8'")
 set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
 
@@ -12,6 +13,7 @@ add_custom_target(benchmarks
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node16
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node48
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node256
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex)
 
@@ -24,6 +26,8 @@ add_custom_target(quick_benchmarks
   ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_node256 ${micro_benchmark_node256_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
@@ -38,6 +42,8 @@ add_custom_target(valgrind_benchmarks
   ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_node256 ${micro_benchmark_node256_quick_arg}
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND valgrind --error-exitcode=1 --leak-check=full
@@ -66,5 +72,6 @@ add_benchmark_target(micro_benchmark_key_prefix)
 add_benchmark_target(micro_benchmark_node4)
 add_benchmark_target(micro_benchmark_node16)
 add_benchmark_target(micro_benchmark_node48)
+add_benchmark_target(micro_benchmark_node256)
 add_benchmark_target(micro_benchmark)
 add_benchmark_target(micro_benchmark_mutex)

--- a/benchmark/micro_benchmark_node16.cpp
+++ b/benchmark/micro_benchmark_node16.cpp
@@ -2,9 +2,6 @@
 
 #include "global.hpp"
 
-#include <cstddef>
-#include <cstdint>
-
 #include <benchmark/benchmark.h>
 
 #include "art.hpp"
@@ -12,216 +9,52 @@
 
 namespace {
 
-// Benchmark growing Node4 to Node16: insert to full Node4 tree first:
-// 0x0000000000000000 to ...003
-// 0x0000000000000100 to ...103
-// 0x0000000000000200 to ...203
-// 0x0000000000000300 to ...303
-// 0x0000000000010000 to ...003
-// 0x0000000000010100 to ...103
-// ...
-// Then insert in the gaps a "base-5" value that varies each byte from 0 to 5
-// with the last one being a constant 4 to get a minimal Node16 tree:
-// 0x0000000000000004
-// 0x0000000000000104
-// 0x0000000000000204
-// 0x0000000000000304
-// 0x0000000000000404
-// 0x0000000000010004
-// 0x0000000000010104
-// ...
-
 void grow_node4_to_node16_sequentially(benchmark::State &state) {
-  unodb::benchmark::grow_node_sequentially_benchmark<
-      unodb::db, 4, unodb::benchmark::full_node4_tree_key_zero_bits>(
-      state, unodb::benchmark::number_to_minimal_leaf_node16_over_node4_key);
+  unodb::benchmark::grow_node_sequentially_benchmark<unodb::db, 4>(state);
 }
-
-// Benchmark growing Node4 to Node16: insert to full Node4 tree first. Use 1,
-// 3, 5, 7 as the different key byte values, so that a new byte could be
-// inserted later at any position.
-// 0x0101010101010101 to ...107
-// 0x0101010101010301 to ...307
-// 0x0101010101010501 to ...507
-// 0x0101010101010701 to ...707
-// 0x0101010101030101 to ...107
-// 0x0101010101030301 to ...307
-// ...
-// Then in the gaps insert a value that has the last byte randomly chosen from
-// 0, 2, 4, 6, and 8, and leading bytes enumerating through 1, 3, 5, 7, and one
-// randomly-selected value from 0, 2, 4, 6, and 8.
 
 void grow_node4_to_node16_randomly(benchmark::State &state) {
-  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 4>(
-      state, unodb::benchmark::number_to_full_node4_with_gaps_key,
-      unodb::benchmark::generate_random_keys_over_full_smaller_tree<4>);
-}
-
-auto make_minimal_node16_tree(unodb::db &db, unsigned node16_node_count) {
-  const auto last_inserted_key = unodb::benchmark::insert_n_keys<
-      unodb::db,
-      decltype(unodb::benchmark::number_to_minimal_node_size_tree_key<16>)>(
-      db, node16_node_count * 5,
-      unodb::benchmark::number_to_minimal_node_size_tree_key<16>);
-  unodb::benchmark::assert_mostly_node16_tree(db);
-  return last_inserted_key;
+  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 4>(state);
 }
 
 void node16_sequential_add(benchmark::State &state) {
-  unodb::benchmark::sequential_add_benchmark<unodb::db, 16>(
-      state, unodb::benchmark::number_to_full_leaf_over_minimal_node16_key);
+  unodb::benchmark::sequential_add_benchmark<unodb::db, 16>(state);
 }
 
 void node16_random_add(benchmark::State &state) {
-  unodb::benchmark::random_add_benchmark<unodb::db, 16>(
-      state, unodb::benchmark::number_to_full_leaf_over_minimal_node16_key);
+  unodb::benchmark::random_add_benchmark<unodb::db, 16>(state);
 }
 
 void minimal_node16_tree_full_scan(benchmark::State &state) {
-  const auto node16_node_count = static_cast<unsigned>(state.range(0));
-  unodb::db test_db;
-  const auto key_limit = make_minimal_node16_tree(test_db, node16_node_count);
-  const auto tree_size = test_db.get_current_memory_use();
-  std::int64_t items_processed = 0;
-
-  for (auto _ : state) {
-    std::uint64_t i = 0;
-    while (true) {
-      unodb::key k =
-          unodb::benchmark::number_to_minimal_node_size_tree_key<16>(i);
-      if (k > key_limit) break;
-      unodb::benchmark::get_existing_key(test_db, k);
-      ++i;
-    }
-    items_processed += static_cast<std::int64_t>(i);
-  }
-
-  state.SetItemsProcessed(items_processed);
-  unodb::benchmark::set_size_counter(state, "size", tree_size);
+  unodb::benchmark::minimal_tree_full_scan<unodb::db, 16>(state);
 }
 
 void minimal_node16_tree_random_gets(benchmark::State &state) {
-  const auto node16_node_count = static_cast<unsigned>(state.range(0));
-  unodb::db test_db;
-  const auto key_limit USED_IN_DEBUG =
-      make_minimal_node16_tree(test_db, node16_node_count);
-  assert(unodb::benchmark::number_to_minimal_node_size_tree_key<16>(
-             node16_node_count * 5 - 1) == key_limit);
-  const auto tree_size = test_db.get_current_memory_use();
-  unodb::benchmark::batched_prng random_key_positions{node16_node_count * 5 -
-                                                      1};
-  std::int64_t items_processed = 0;
-
-  for (auto _ : state) {
-    const auto key_index = random_key_positions.get(state);
-    const auto key =
-        unodb::benchmark::number_to_minimal_node_size_tree_key<16>(key_index);
-    unodb::benchmark::get_existing_key(test_db, key);
-    ++items_processed;
-  }
-
-  state.SetItemsProcessed(items_processed);
-  unodb::benchmark::set_size_counter(state, "size", tree_size);
+  unodb::benchmark::minimal_tree_random_gets<unodb::db, 16>(state);
 }
 
-inline constexpr auto full_node16_key_zero_bits = 0xF0F0F0F0'F0F0F0F0U;
-
 void full_node16_tree_full_scan(benchmark::State &state) {
-  unodb::benchmark::full_node_scan_benchmark<unodb::db, 16>(
-      state, full_node16_key_zero_bits);
+  unodb::benchmark::full_node_scan_benchmark<unodb::db, 16>(state);
 }
 
 void full_node16_tree_random_gets(benchmark::State &state) {
-  unodb::benchmark::full_node_random_get_benchmark<unodb::db, 16>(
-      state, full_node16_key_zero_bits);
-}
-
-// Benchmark Node16 delete operation: insert to a full Node16 first, then delete
-// the keys with the last byte value ranging from 5 to 15.
-
-inline constexpr auto number_to_full_node16_delete_key(
-    std::uint64_t i) noexcept {
-  assert(i / (10 * 5 * 5 * 5 * 5 * 5) < 5);
-  return (i % 10 + 5) | unodb::benchmark::to_base_n_value<5>(i / 10) << 8;
+  unodb::benchmark::full_node_random_get_benchmark<unodb::db, 16>(state);
 }
 
 void full_node16_tree_sequential_delete(benchmark::State &state) {
-  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
-  int i{0};
-  std::size_t tree_size{0};
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    unodb::db test_db;
-    const auto key_limit = unodb::benchmark::insert_sequentially(
-        test_db, number_of_keys, full_node16_key_zero_bits);
-    tree_size = test_db.get_current_memory_use();
-    const unodb::benchmark::tree_shape_snapshot<unodb::db> tree_shape{test_db};
-    state.ResumeTiming();
-
-    i = 0;
-    while (true) {
-      const auto delete_key =
-          number_to_full_node16_delete_key(static_cast<std::uint64_t>(i));
-      if (delete_key > key_limit) break;
-      unodb::benchmark::delete_key(test_db, delete_key);
-      ++i;
-    }
-
-    state.PauseTiming();
-#ifndef NDEBUG
-    unodb::benchmark::assert_mostly_node16_tree(test_db);
-    tree_shape.assert_internal_levels_same();
-#endif
-    unodb::benchmark::destroy_tree(test_db, state);
-  }
-
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) * i);
-  unodb::benchmark::set_size_counter(state, "size", tree_size);
+  unodb::benchmark::sequential_delete_benchmark<unodb::db, 16>(state);
 }
 
 void full_node16_tree_random_delete(benchmark::State &state) {
-  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
-  std::size_t tree_size{0};
-  std::size_t remove_key_count{0};
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    unodb::db test_db;
-    const auto key_limit = unodb::benchmark::insert_sequentially(
-        test_db, number_of_keys, full_node16_key_zero_bits);
-    tree_size = test_db.get_current_memory_use();
-    const unodb::benchmark::tree_shape_snapshot<unodb::db> tree_shape{test_db};
-    auto remove_keys = unodb::benchmark::generate_keys_to_limit(
-        key_limit, number_to_full_node16_delete_key);
-    remove_key_count = remove_keys.size();
-    std::shuffle(remove_keys.begin(), remove_keys.end(),
-                 unodb::benchmark::get_prng());
-    state.ResumeTiming();
-
-    unodb::benchmark::delete_keys(test_db, remove_keys);
-
-    state.PauseTiming();
-#ifndef NDEBUG
-    unodb::benchmark::assert_mostly_node16_tree(test_db);
-    tree_shape.assert_internal_levels_same();
-#endif
-    unodb::benchmark::destroy_tree(test_db, state);
-  }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(remove_key_count));
-  unodb::benchmark::set_size_counter(state, "size", tree_size);
+  unodb::benchmark::random_delete_benchmark<unodb::db, 16>(state);
 }
 
 void shrink_node48_to_node16_sequentially(benchmark::State &state) {
-  unodb::benchmark::shrink_node_sequentially_benchmark<
-      unodb::db, 16, unodb::benchmark::full_node16_tree_key_zero_bits>(
-      state, unodb::benchmark::number_to_minimal_leaf_node48_over_node16_key);
+  unodb::benchmark::shrink_node_sequentially_benchmark<unodb::db, 16>(state);
 }
 
 void shrink_node48_to_node16_randomly(benchmark::State &state) {
-  unodb::benchmark::shrink_node_randomly_benchmark<unodb::db, 16>(
-      state, unodb::benchmark::number_to_full_node16_with_gaps_key);
+  unodb::benchmark::shrink_node_randomly_benchmark<unodb::db, 16>(state);
 }
 
 }  // namespace
@@ -246,7 +79,7 @@ BENCHMARK(full_node16_tree_full_scan)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node16_tree_random_gets)
-    ->Range(64, 246000)
+    ->Range(64, 24600)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node16_tree_sequential_delete)
     ->Range(64, 246000)
@@ -255,9 +88,9 @@ BENCHMARK(full_node16_tree_random_delete)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(shrink_node48_to_node16_sequentially)
-    ->Range(64, 246000)
+    ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(shrink_node48_to_node16_randomly)
-    ->Range(64, 246000)
+    ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_node256.cpp
+++ b/benchmark/micro_benchmark_node256.cpp
@@ -1,0 +1,29 @@
+// Copyright 2020 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include "art.hpp"
+#include "micro_benchmark_utils.hpp"
+
+namespace {
+
+void grow_node48_to_node256_sequentially(benchmark::State &state) {
+  unodb::benchmark::grow_node_sequentially_benchmark<unodb::db, 48>(state);
+}
+
+void grow_node48_to_node256_randomly(benchmark::State &state) {
+  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 48>(state);
+}
+
+}  // namespace
+
+BENCHMARK(grow_node48_to_node256_sequentially)
+    ->Range(2, 2048)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(grow_node48_to_node256_randomly)
+    ->Range(2, 2048)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_node4.cpp
+++ b/benchmark/micro_benchmark_node4.cpp
@@ -16,17 +16,16 @@
 
 namespace {
 
-constexpr auto minimal_node4_key_zero_bits = 0xFEFEFEFE'FEFEFEFEULL;
-
-std::vector<unodb::key> make_n_key_sequence(std::size_t n,
-                                            std::uint64_t key_zero_bits) {
+template <unsigned NodeSize>
+std::vector<unodb::key> make_n_key_sequence(std::size_t n) {
   std::vector<unodb::key> result;
   result.reserve(n);
 
   unodb::key insert_key = 0;
   for (decltype(n) i = 0; i < n; ++i) {
     result.push_back(insert_key);
-    insert_key = unodb::benchmark::next_key(insert_key, key_zero_bits);
+    insert_key = unodb::benchmark::next_key(
+        insert_key, unodb::benchmark::node_size_to_key_zero_bits<NodeSize>());
   }
 
   return result;
@@ -46,8 +45,8 @@ std::vector<unodb::key> make_limited_key_sequence(unodb::key limit,
   return result;
 }
 
-void node4_sequential_insert(benchmark::State &state,
-                             std::uint64_t key_zero_bits) {
+template <unsigned NodeSize>
+void node4_sequential_insert(benchmark::State &state) {
   unodb::benchmark::growing_tree_node_stats<unodb::db> growing_tree_stats;
   std::size_t tree_size = 0;
 
@@ -57,8 +56,8 @@ void node4_sequential_insert(benchmark::State &state,
     benchmark::ClobberMemory();
     state.ResumeTiming();
 
-    unodb::benchmark::insert_sequentially(
-        test_db, static_cast<std::uint64_t>(state.range(0)), key_zero_bits);
+    unodb::benchmark::insert_sequentially<unodb::db, NodeSize>(
+        test_db, static_cast<unsigned>(state.range(0)));
 
     state.PauseTiming();
     unodb::benchmark::assert_node4_only_tree(test_db);
@@ -74,17 +73,17 @@ void node4_sequential_insert(benchmark::State &state,
 }
 
 void full_node4_sequential_insert(benchmark::State &state) {
-  node4_sequential_insert(state,
-                          unodb::benchmark::full_node4_tree_key_zero_bits);
+  node4_sequential_insert<4>(state);
 }
 
 void minimal_node4_sequential_insert(benchmark::State &state) {
-  node4_sequential_insert(state, minimal_node4_key_zero_bits);
+  node4_sequential_insert<2>(state);
 }
 
-void node4_random_insert(benchmark::State &state, std::uint64_t key_zero_bits) {
-  auto keys = make_n_key_sequence(static_cast<std::size_t>(state.range(0)),
-                                  key_zero_bits);
+template <unsigned NodeSize>
+void node4_random_insert(benchmark::State &state) {
+  auto keys =
+      make_n_key_sequence<NodeSize>(static_cast<std::size_t>(state.range(0)));
 
   for (auto _ : state) {
     state.PauseTiming();
@@ -105,35 +104,34 @@ void node4_random_insert(benchmark::State &state, std::uint64_t key_zero_bits) {
 }
 
 void full_node4_random_insert(benchmark::State &state) {
-  node4_random_insert(state, unodb::benchmark::full_node4_tree_key_zero_bits);
+  node4_random_insert<4>(state);
 }
 
 void minimal_node4_random_insert(benchmark::State &state) {
-  node4_random_insert(state, minimal_node4_key_zero_bits);
+  node4_random_insert<2>(state);
 }
 
 void node4_full_scan(benchmark::State &state) {
-  unodb::benchmark::full_node_scan_benchmark<unodb::db, 4>(
-      state, unodb::benchmark::full_node4_tree_key_zero_bits);
+  unodb::benchmark::full_node_scan_benchmark<unodb::db, 4>(state);
 }
 
 void node4_random_gets(benchmark::State &state) {
-  unodb::benchmark::full_node_random_get_benchmark<unodb::db, 4>(
-      state, unodb::benchmark::full_node4_tree_key_zero_bits);
+  unodb::benchmark::full_node_random_get_benchmark<unodb::db, 4>(state);
 }
 
+template <unsigned NodeSize>
 void node4_sequential_delete_benchmark(benchmark::State &state,
-                                       std::uint64_t insert_key_zero_bits,
                                        std::uint64_t delete_key_zero_bits) {
-  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+  const auto key_count = static_cast<unsigned>(state.range(0));
   int keys_deleted{0};
   std::size_t tree_size{0};
 
   for (auto _ : state) {
     state.PauseTiming();
     unodb::db test_db;
-    const auto key_limit = unodb::benchmark::insert_sequentially(
-        test_db, number_of_keys, insert_key_zero_bits);
+    const auto key_limit =
+        unodb::benchmark::insert_sequentially<unodb::db, NodeSize>(test_db,
+                                                                   key_count);
     tree_size = test_db.get_current_memory_use();
     unodb::benchmark::assert_node4_only_tree(test_db);
     state.ResumeTiming();
@@ -153,22 +151,22 @@ void node4_sequential_delete_benchmark(benchmark::State &state,
 }
 
 void full_node4_sequential_delete(benchmark::State &state) {
-  node4_sequential_delete_benchmark(
-      state, unodb::benchmark::full_node4_tree_key_zero_bits,
-      unodb::benchmark::full_node4_tree_key_zero_bits);
+  node4_sequential_delete_benchmark<4>(
+      state, unodb::benchmark::node_size_to_key_zero_bits<4>());
 }
 
+template <unsigned NodeSize>
 void node4_random_delete_benchmark(benchmark::State &state,
-                                   std::uint64_t insert_key_zero_bits,
                                    std::uint64_t delete_key_zero_bits) {
-  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
+  const auto key_count = static_cast<unsigned>(state.range(0));
   std::size_t tree_size{0};
 
   for (auto _ : state) {
     state.PauseTiming();
     unodb::db test_db;
-    const auto key_limit = unodb::benchmark::insert_sequentially(
-        test_db, number_of_keys, insert_key_zero_bits);
+    const auto key_limit =
+        unodb::benchmark::insert_sequentially<unodb::db, NodeSize>(test_db,
+                                                                   key_count);
     tree_size = test_db.get_current_memory_use();
     unodb::benchmark::assert_node4_only_tree(test_db);
 
@@ -185,45 +183,29 @@ void node4_random_delete_benchmark(benchmark::State &state,
 }
 
 void full_node4_random_deletes(benchmark::State &state) {
-  node4_random_delete_benchmark(
-      state, unodb::benchmark::full_node4_tree_key_zero_bits,
-      unodb::benchmark::full_node4_tree_key_zero_bits);
+  node4_random_delete_benchmark<4>(
+      state, unodb::benchmark::node_size_to_key_zero_bits<4>());
 }
 
 constexpr auto minimal_node4_tree_full_leaf_level_key_zero_bits =
     0xFCFCFCFC'FCFCFCFEULL;
 
 void full_node4_to_minimal_sequential_delete(benchmark::State &state) {
-  node4_sequential_delete_benchmark(
-      state, unodb::benchmark::full_node4_tree_key_zero_bits,
-      minimal_node4_tree_full_leaf_level_key_zero_bits);
+  node4_sequential_delete_benchmark<4>(
+      state, minimal_node4_tree_full_leaf_level_key_zero_bits);
 }
 
 void full_node4_to_minimal_random_delete(benchmark::State &state) {
-  node4_random_delete_benchmark(
-      state, unodb::benchmark::full_node4_tree_key_zero_bits,
-      minimal_node4_tree_full_leaf_level_key_zero_bits);
+  node4_random_delete_benchmark<4>(
+      state, minimal_node4_tree_full_leaf_level_key_zero_bits);
 }
 
-// Benchmark shrinking Node16 to Node4: insert to minimal Node16 first:
-// 0x0000000000000000 to ...004
-// 0x0000000000000100 to ...104
-// 0x0000000000000200 to ...204
-// 0x0000000000000300 to ...304
-// 0x0000000000000404 (note that no 0x0400..0x403 to avoid creating Node4).
-//
-// Then remove the minimal Node16 over full Node4 key subset, see
-// number_to_minimal_node16_over_node4_key.
-
 void shrink_node16_to_node4_sequentially(benchmark::State &state) {
-  unodb::benchmark::shrink_node_sequentially_benchmark<
-      unodb::db, 4, unodb::benchmark::full_node4_tree_key_zero_bits>(
-      state, unodb::benchmark::number_to_minimal_leaf_node16_over_node4_key);
+  unodb::benchmark::shrink_node_sequentially_benchmark<unodb::db, 4>(state);
 }
 
 void shrink_node16_to_node4_randomly(benchmark::State &state) {
-  unodb::benchmark::shrink_node_randomly_benchmark<unodb::db, 4>(
-      state, unodb::benchmark::number_to_full_node4_with_gaps_key);
+  unodb::benchmark::shrink_node_randomly_benchmark<unodb::db, 4>(state);
 }
 
 }  // namespace
@@ -256,10 +238,10 @@ BENCHMARK(full_node4_to_minimal_random_delete)
     ->Range(100, 65533)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(shrink_node16_to_node4_sequentially)
-    ->Range(100, 65535)
+    ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(shrink_node16_to_node4_randomly)
-    ->Range(100, 65532)
+    ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_node48.cpp
+++ b/benchmark/micro_benchmark_node48.cpp
@@ -2,9 +2,6 @@
 
 #include "global.hpp"
 
-#include <cstddef>
-#include <cstdint>
-
 #include <benchmark/benchmark.h>
 
 #include "art.hpp"
@@ -12,52 +9,52 @@
 
 namespace {
 
-// Benchmark growing Node16 to Node48: insert to full Node16 tree first:
-// 0x0000000000000000 to ...0000F
-// 0x0000000000000100 to ...0010F
-// ...
-// 0x0000000000000F00 to ...00F0F
-// 0x0000000000010000 to ...1000F
-// ...
-// 0x00000000000F0000 to ...F000F
-// 0x0000000000010100 to ...1010F
-// 0x0000000000010200 to ...1020F
-// ...
-// The insert in the gaps a "base-17" value with the last byte being a constant
-// 10 to get a minimal Node48 tree:
-// 0x0000000000000010
-// 0x0000000000000110
-// ...
-// 0x0000000000000F10
-// 0x0000000000010010
-// ...
-
 void grow_node16_to_node48_sequentially(benchmark::State &state) {
-  unodb::benchmark::grow_node_sequentially_benchmark<
-      unodb::db, 16, unodb::benchmark::full_node16_tree_key_zero_bits>(
-      state, unodb::benchmark::number_to_minimal_leaf_node48_over_node16_key);
+  unodb::benchmark::grow_node_sequentially_benchmark<unodb::db, 16>(state);
 }
 
 void grow_node16_to_node48_randomly(benchmark::State &state) {
-  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 16>(
-      state, unodb::benchmark::number_to_full_node16_with_gaps_key,
-      unodb::benchmark::generate_random_keys_over_full_smaller_tree<16>);
-}
-
-inline constexpr auto number_to_full_leaf_over_minimal_node48_key(
-    std::uint64_t i) noexcept {
-  assert(i / (31 * 17 * 17 * 17 * 17 * 17 * 17) < 17);
-  return ((i % 31) + 17) | unodb::benchmark::to_base_n_value<17>(i / 31) << 8;
+  unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 16>(state);
 }
 
 void node48_sequential_add(benchmark::State &state) {
-  unodb::benchmark::sequential_add_benchmark<unodb::db, 48>(
-      state, number_to_full_leaf_over_minimal_node48_key);
+  unodb::benchmark::sequential_add_benchmark<unodb::db, 48>(state);
 }
 
 void node48_random_add(benchmark::State &state) {
-  unodb::benchmark::random_add_benchmark<unodb::db, 48>(
-      state, number_to_full_leaf_over_minimal_node48_key);
+  unodb::benchmark::random_add_benchmark<unodb::db, 48>(state);
+}
+
+void minimal_node48_tree_full_scan(benchmark::State &state) {
+  unodb::benchmark::minimal_tree_full_scan<unodb::db, 48>(state);
+}
+
+void minimal_node48_tree_random_gets(benchmark::State &state) {
+  unodb::benchmark::minimal_tree_random_gets<unodb::db, 48>(state);
+}
+
+void full_node48_tree_full_scan(benchmark::State &state) {
+  unodb::benchmark::full_node_scan_benchmark<unodb::db, 48>(state);
+}
+
+void full_node48_tree_random_gets(benchmark::State &state) {
+  unodb::benchmark::full_node_random_get_benchmark<unodb::db, 48>(state);
+}
+
+void full_node48_tree_sequential_delete(benchmark::State &state) {
+  unodb::benchmark::sequential_delete_benchmark<unodb::db, 48>(state);
+}
+
+void full_node48_tree_random_delete(benchmark::State &state) {
+  unodb::benchmark::random_delete_benchmark<unodb::db, 48>(state);
+}
+
+void shrink_node256_to_node48_sequentially(benchmark::State &state) {
+  unodb::benchmark::shrink_node_sequentially_benchmark<unodb::db, 48>(state);
+}
+
+void shrink_node256_to_node48_randomly(benchmark::State &state) {
+  unodb::benchmark::shrink_node_randomly_benchmark<unodb::db, 48>(state);
 }
 
 }  // namespace
@@ -66,9 +63,33 @@ BENCHMARK(grow_node16_to_node48_sequentially)
     ->Range(8, 8192)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(grow_node16_to_node48_randomly)
-    ->Range(2, 2048)
+    ->Range(8, 8192)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(node48_sequential_add)->Range(2, 4096)->Unit(benchmark::kMicrosecond);
 BENCHMARK(node48_random_add)->Range(2, 4096)->Unit(benchmark::kMicrosecond);
+BENCHMARK(minimal_node48_tree_full_scan)
+    ->Range(4, 6144)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(minimal_node48_tree_random_gets)
+    ->Range(4, 6144)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node48_tree_full_scan)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node48_tree_random_gets)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node48_tree_sequential_delete)
+    ->Range(192, 196608)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node48_tree_random_delete)
+    ->Range(192, 196608)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(shrink_node256_to_node48_sequentially)
+    ->Range(4, 2048)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(shrink_node256_to_node48_randomly)
+    ->Range(4, 2048)
+    ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -12,9 +12,117 @@
 #include "art.hpp"
 #include "mutex_art.hpp"
 
-namespace unodb::benchmark {
+namespace {
+
+// Node sizes
+
+template <unsigned NodeCapacity>
+constexpr inline auto node_capacity_to_minimum_size() noexcept {
+  static_assert(NodeCapacity == 16 || NodeCapacity == 48);
+  if constexpr (NodeCapacity == 16) {
+    return 5;
+  } else if constexpr (NodeCapacity == 48) {
+    return 17;
+  }
+}
+
+template <unsigned NodeCapacity>
+constexpr inline auto node_capacity_over_minimum() noexcept {
+  static_assert(NodeCapacity == 16 || NodeCapacity == 48);
+  return NodeCapacity - node_capacity_to_minimum_size<NodeCapacity>();
+}
+
+template <unsigned NodeSize>
+constexpr inline auto node_size_has_key_zero_bits() noexcept {
+  // If node size is a power of two, then can use key zero bit-based operations
+  return (NodeSize & (NodeSize - 1)) == 0;
+}
+
+// Key manipulation
+
+template <unsigned B, unsigned S, unsigned O>
+inline constexpr auto to_scaled_base_n_value(std::uint64_t i) noexcept {
+  assert(i / (static_cast<std::uint64_t>(B) * B * B * B * B * B * B) < B);
+  return (i % B * S + O) | (i / B % B * S + O) << 8U |
+         ((i / (B * B) % B * S + O) << 16U) |
+         ((i / (B * B * B) % B * S + O) << 24U) |
+         ((i / (B * B * B * B) % B * S + O) << 32U) |
+         ((i / (B * B * B * B * B) % B * S + O) << 40U) |
+         ((i / (static_cast<std::uint64_t>(B) * B * B * B * B * B) % B * S + O)
+          << 48U) |
+         ((i / (static_cast<std::uint64_t>(B) * B * B * B * B * B * B) % B * S +
+           O)
+          << 56U);
+}
+
+template <unsigned B>
+inline constexpr auto to_base_n_value(std::uint64_t i) noexcept {
+  assert(i / (static_cast<std::uint64_t>(B) * B * B * B * B * B * B) < B);
+  return to_scaled_base_n_value<B, 1, 0>(i);
+}
+
+template <unsigned NodeSize>
+inline constexpr auto number_to_full_node_size_tree_key(
+    std::uint64_t i) noexcept {
+  return to_base_n_value<NodeSize>(i);
+}
+
+template <unsigned NodeSize>
+inline constexpr auto number_to_minimal_node_size_tree_key(
+    std::uint64_t i) noexcept {
+  return to_base_n_value<node_capacity_to_minimum_size<NodeSize>()>(i);
+}
+
+template <unsigned NodeSize>
+inline constexpr auto number_to_full_leaf_over_minimal_tree_key(
+    std::uint64_t i) noexcept {
+  constexpr auto min = node_capacity_to_minimum_size<NodeSize>();
+  constexpr auto delta = node_capacity_over_minimum<NodeSize>();
+  assert(i / (delta * min * min * min * min * min * min) < min);
+  return ((i % delta) + min) |
+         number_to_minimal_node_size_tree_key<NodeSize>(i / delta) << 8U;
+}
+
+template <unsigned NodeSize>
+inline constexpr auto number_to_minimal_leaf_over_smaller_node_tree(
+    std::uint64_t i) noexcept {
+  constexpr auto N = static_cast<std::uint64_t>(NodeSize);
+  assert(i / (N * N * N * N * N * N) < N);
+  return N | number_to_full_node_size_tree_key<N>(i) << 8U;
+}
+
+template <unsigned NodeSize>
+inline constexpr auto number_to_full_node_tree_with_gaps_key(
+    std::uint64_t i) noexcept {
+  static_assert(NodeSize == 4 || NodeSize == 16 || NodeSize == 48);
+  // Full Node4 tree keys with 1, 3, 5, & 7 as the different key byte values
+  // so that a new byte could be inserted later at any position:
+  // 0x0101010101010101 to ...107
+  // 0x0101010101010301 to ...307
+  // 0x0101010101010501 to ...507
+  // 0x0101010101010701 to ...707
+  // 0x0101010101030101 to ...107
+  // 0x0101010101030301 to ...307
+  // Full Node16 tree keys with 1, 3, 5, ..., 33 as the different key byte
+  // values so that a new byte could be inserted later at any position.
+  return to_scaled_base_n_value<NodeSize, 2, 1>(i);
+}
 
 // Key vectors
+
+template <typename NumberToKeyFn>
+auto generate_keys_to_limit(unodb::key key_limit,
+                            NumberToKeyFn number_to_key_fn) {
+  std::vector<unodb::key> result;
+  std::uint64_t i = 0;
+  while (true) {
+    const auto key = number_to_key_fn(i);
+    if (key > key_limit) break;
+    ++i;
+    result.push_back(key);
+  }
+  return result;
+}
 
 template <std::uint8_t NumByteValues>
 std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
@@ -46,13 +154,14 @@ std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
               key.as_bytes[2] = static_cast<std::uint8_t>(i6 * 2 + 1);
               for (std::uint8_t i7 = 0; i7 < NumByteValues; ++i7) {
                 key.as_bytes[1] = static_cast<std::uint8_t>(i7 * 2 + 1);
-                key.as_bytes[0] =
-                    static_cast<std::uint8_t>(prng_byte_values(get_prng()) * 2);
+                key.as_bytes[0] = static_cast<std::uint8_t>(
+                    prng_byte_values(unodb::benchmark::get_prng()) * 2);
 
                 const unodb::key k = key.as_int;
                 if (k > key_limit) {
                   result.shrink_to_fit();
-                  std::shuffle(result.begin(), result.end(), get_prng());
+                  std::shuffle(result.begin(), result.end(),
+                               unodb::benchmark::get_prng());
                   return result;
                 }
                 result.push_back(k);
@@ -66,11 +175,250 @@ std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
   cannot_happen();
 }
 
-template std::vector<unodb::key> generate_random_keys_over_full_smaller_tree<4>(
-    unodb::key);
+// Asserts
 
-template std::vector<unodb::key>
-    generate_random_keys_over_full_smaller_tree<16>(unodb::key);
+#ifndef NDEBUG
+
+// In a mostly-Node16 tree a few Node4 are allowed on the rightmost tree edge,
+// including the root
+template <class Db>
+void assert_mostly_node16_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+  if (test_db.get_inode4_count() > 8) {
+    std::cerr << "Too many I4 nodes found in mostly-I16 tree:\n";
+    test_db.dump(std::cerr);
+    assert(test_db.get_inode4_count() <= 8);
+  }
+  assert(test_db.get_inode48_count() == 0);
+  assert(test_db.get_inode256_count() == 0);
+}
+
+template <class Db>
+void assert_mostly_node48_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+  if (test_db.get_inode4_count() + test_db.get_inode16_count() > 8) {
+    std::cerr << "Too many I4/I16 nodes found in mostly-I48 tree:\n";
+    test_db.dump(std::cerr);
+    assert(test_db.get_inode4_count() + test_db.get_inode16_count() <= 8);
+  }
+  assert(test_db.get_inode256_count() == 0);
+}
+
+#endif  // #ifndef NDEBUG
+
+template <class Db, unsigned NodeSize>
+void assert_node_size_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+#ifndef NDEBUG
+  static_assert(NodeSize == 4 || NodeSize == 16 || NodeSize == 48);
+  if constexpr (NodeSize == 4) {
+    unodb::benchmark::assert_node4_only_tree(test_db);
+  } else if constexpr (NodeSize == 16) {
+    assert_mostly_node16_tree(test_db);
+  } else if constexpr (NodeSize == 48) {
+    assert_mostly_node48_tree(test_db);
+  }
+#endif
+}
+
+template <class Db, unsigned SmallerNodeSize>
+void assert_growing_nodes(const Db &test_db USED_IN_DEBUG,
+                          std::uint64_t number_of_nodes
+                              USED_IN_DEBUG) noexcept {
+#ifndef NDEBUG
+  static_assert(SmallerNodeSize == 4 || SmallerNodeSize == 16 ||
+                SmallerNodeSize == 48);
+  if constexpr (SmallerNodeSize == 4) {
+    assert(number_of_nodes == test_db.get_inode4_to_inode16_count());
+  } else if constexpr (SmallerNodeSize == 16) {
+    assert(number_of_nodes == test_db.get_inode16_to_inode48_count());
+  } else {
+    if (number_of_nodes != test_db.get_inode48_to_inode256_count()) {
+      std::cerr << "Difference between inserts: " << number_of_nodes
+                << ", N48 -> N256: " << test_db.get_inode48_to_inode256_count();
+      std::cerr << "\nTree:";
+      test_db.dump(std::cerr);
+      assert(number_of_nodes == test_db.get_inode48_to_inode256_count());
+    }
+  }
+#endif
+}
+
+template <class Db, unsigned SmallerNodeSize>
+void assert_shrinking_nodes(const Db &test_db USED_IN_DEBUG,
+                            std::uint64_t number_of_nodes
+                                USED_IN_DEBUG) noexcept {
+#ifndef NDEBUG
+  static_assert(SmallerNodeSize == 4 || SmallerNodeSize == 16 ||
+                SmallerNodeSize == 48);
+  if constexpr (SmallerNodeSize == 4) {
+    assert(number_of_nodes == test_db.get_inode16_to_inode4_count());
+    unodb::benchmark::assert_node4_only_tree(test_db);
+  } else if constexpr (SmallerNodeSize == 16) {  // NOLINT(readability/braces)
+    assert(number_of_nodes == test_db.get_inode48_to_inode16_count());
+    assert_mostly_node16_tree(test_db);
+  } else {
+    assert(number_of_nodes == test_db.get_inode256_to_inode48_count());
+    assert_mostly_node48_tree(test_db);
+  }
+#endif
+}
+
+template <class Db>
+class tree_shape_snapshot final {
+ public:
+  explicit tree_shape_snapshot(const Db &test_db USED_IN_DEBUG) noexcept
+#ifndef NDEBUG
+      : db{test_db}, stats {
+    test_db
+  }
+#endif
+  {}
+
+  void assert_internal_levels_same() const noexcept {
+#ifndef NDEBUG
+    const unodb::benchmark::tree_stats<Db> current_stats{db};
+    assert(stats.internal_levels_equal(current_stats));
+#endif
+  }
+
+ private:
+#ifndef NDEBUG
+  const Db &db;
+  const unodb::benchmark::tree_stats<Db> stats;
+#endif
+};
+
+// Insertion
+
+template <class Db, typename NumberToKeyFn>
+auto insert_keys_to_limit(Db &db, unodb::key key_limit,
+                          NumberToKeyFn number_to_key_fn) {
+  std::uint64_t i{0};
+  while (true) {
+    unodb::key key = number_to_key_fn(i);
+    if (key > key_limit) break;
+    unodb::benchmark::insert_key(db, key,
+                                 unodb::value_view{unodb::benchmark::value100});
+    ++i;
+  }
+  return i;
+}
+
+template <class Db, typename NumberToKeyFn>
+auto insert_n_keys(Db &db, unsigned n, NumberToKeyFn number_to_key_fn) {
+  unodb::key last_inserted_key{0};
+
+  for (decltype(n) i = 0; i < n; ++i) {
+    last_inserted_key = number_to_key_fn(i);
+    unodb::benchmark::insert_key(db, last_inserted_key,
+                                 unodb::value_view{unodb::benchmark::value100});
+  }
+
+  return last_inserted_key;
+}
+
+template <class Db, unsigned NodeSize, typename NumberToKeyFn>
+auto insert_n_keys_to_empty_tree(Db &db, unsigned n,
+                                 NumberToKeyFn number_to_key_fn) {
+  assert(db.empty());
+  const auto result = insert_n_keys(db, n, number_to_key_fn);
+  assert_node_size_tree<Db, NodeSize>(db);
+  return result;
+}
+
+template <class Db, unsigned NodeSize>
+auto make_full_node_size_tree(Db &db, unsigned key_count) {
+  static_assert(NodeSize == 4 || NodeSize == 16 || NodeSize == 48);
+
+  unodb::key key_limit;
+  if constexpr (node_size_has_key_zero_bits<NodeSize>()) {
+    key_limit =
+        unodb::benchmark::insert_sequentially<Db, NodeSize>(db, key_count);
+  } else {
+    key_limit = insert_n_keys_to_empty_tree<
+        unodb::db, NodeSize,
+        decltype(number_to_full_node_size_tree_key<NodeSize>)>(
+        db, key_count, number_to_full_node_size_tree_key<NodeSize>);
+  }
+
+  assert_node_size_tree<Db, NodeSize>(db);
+  return key_limit;
+}
+
+template <class Db, unsigned NodeCapacity>
+std::tuple<unodb::key, const tree_shape_snapshot<Db>> make_base_tree_for_add(
+    Db &test_db, unsigned node_count) {
+  const auto key_limit = insert_n_keys_to_empty_tree<
+      Db, NodeCapacity,
+      decltype(number_to_minimal_node_size_tree_key<NodeCapacity>)>(
+      test_db, node_count * (node_capacity_to_minimum_size<NodeCapacity>() + 1),
+      number_to_minimal_node_size_tree_key<NodeCapacity>);
+  return std::make_tuple(key_limit, tree_shape_snapshot<unodb::db>{test_db});
+}
+
+template <class Db, unsigned NodeSize>
+auto make_minimal_node_size_tree(unodb::db &db, unsigned key_count) {
+  return insert_n_keys_to_empty_tree<
+      Db, NodeSize, decltype(number_to_minimal_node_size_tree_key<NodeSize>)>(
+      db, key_count * node_capacity_to_minimum_size<NodeSize>(),
+      number_to_minimal_node_size_tree_key<NodeSize>);
+}
+
+template <class Db, unsigned SmallerNodeSize>
+auto grow_full_node_tree_to_minimal_next_size_leaf_level(Db &db,
+                                                         unodb::key key_limit) {
+  static_assert(SmallerNodeSize == 4 || SmallerNodeSize == 16 ||
+                SmallerNodeSize == 48);
+
+#ifndef NDEBUG
+  assert_node_size_tree<Db, SmallerNodeSize>(db);
+  const auto created_node4_count = db.get_created_inode4_count();
+  size_t created_node16_count{0};
+  if constexpr (SmallerNodeSize >= 16) {
+    created_node16_count = db.get_inode4_to_inode16_count();
+  }
+  size_t created_node48_count{0};
+  if constexpr (SmallerNodeSize == 48) {
+    created_node48_count = db.get_inode16_to_inode48_count();
+  }
+#endif
+
+  const auto keys_inserted = insert_keys_to_limit<
+      Db,
+      decltype(number_to_minimal_leaf_over_smaller_node_tree<SmallerNodeSize>)>(
+      db, key_limit,
+      number_to_minimal_leaf_over_smaller_node_tree<SmallerNodeSize>);
+
+#ifndef NDEBUG
+  assert_growing_nodes<Db, SmallerNodeSize>(db, keys_inserted);
+  assert(created_node4_count == db.get_created_inode4_count());
+  if constexpr (SmallerNodeSize >= 16) {
+    assert(created_node16_count == db.get_inode4_to_inode16_count());
+  }
+  if constexpr (SmallerNodeSize == 48) {
+    assert(created_node48_count == db.get_inode16_to_inode48_count());
+  }
+#endif
+
+  return keys_inserted;
+}
+
+// Querying
+
+template <class Db, typename NumberToKeyFn>
+auto get_key_loop(Db &db, unodb::key key_limit,
+                  NumberToKeyFn number_to_key_fn) {
+  std::uint64_t i{0};
+  while (true) {
+    const auto key = number_to_key_fn(i);
+    if (key > key_limit) break;
+    unodb::benchmark::get_existing_key(db, key);
+    ++i;
+  }
+  return static_cast<std::int64_t>(i);
+}
+
+}  // namespace
+
+namespace unodb::benchmark {
 
 // PRNG
 
@@ -102,35 +450,6 @@ void assert_node4_only_tree(const Db &test_db USED_IN_DEBUG) noexcept {
 
 template void assert_node4_only_tree<unodb::db>(const unodb::db &) noexcept;
 
-template <class Db>
-void assert_mostly_node16_tree(const Db &test_db USED_IN_DEBUG) noexcept {
-#ifndef NDEBUG
-  if (test_db.get_inode4_count() > 8) {
-    std::cerr << "Too many I4 nodes found in mostly-I16 tree:\n";
-    test_db.dump(std::cerr);
-    assert(test_db.get_inode4_count() <= 8);
-  }
-  assert(test_db.get_inode48_count() == 0);
-  assert(test_db.get_inode256_count() == 0);
-#endif
-}
-
-template void assert_mostly_node16_tree<unodb::db>(const unodb::db &) noexcept;
-
-template <class Db>
-void assert_mostly_node48_tree(const Db &test_db USED_IN_DEBUG) noexcept {
-#ifndef NDEBUG
-  if (test_db.get_inode4_count() + test_db.get_inode16_count() > 8) {
-    std::cerr << "Too many I4/I16 nodes found in mostly-I48 tree:\n";
-    test_db.dump(std::cerr);
-    assert(test_db.get_inode4_count() + test_db.get_inode16_count() <= 8);
-  }
-  assert(test_db.get_inode256_count() == 0);
-#endif
-}
-
-template void assert_mostly_node48_tree<unodb::db>(const unodb::db &) noexcept;
-
 // Teardown
 
 template <class Db>
@@ -149,77 +468,426 @@ template void destroy_tree<unodb::mutex_db>(unodb::mutex_db &,
 // Benchmarks
 
 template <class Db, unsigned NodeSize>
-void full_node_scan_benchmark(::benchmark::State &state,
-                              std::uint64_t key_zero_bits) {
+void full_node_scan_benchmark(::benchmark::State &state) {
+  const auto key_count = static_cast<unsigned>(state.range(0));
   Db test_db;
-  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
 
-  insert_sequentially(test_db, number_of_keys, key_zero_bits);
-  assert_node_size_tree<Db, NodeSize>(test_db);
+  const auto key_limit =
+      make_full_node_size_tree<Db, NodeSize>(test_db, key_count);
   const auto tree_size = test_db.get_current_memory_use();
 
+  std::int64_t items_processed{0};
   for (auto _ : state) {
-    unodb::key k = 0;
-    for (std::uint64_t j = 0; j < number_of_keys; ++j) {
-      get_existing_key(test_db, k);
-      k = next_key(k, key_zero_bits);
+    if constexpr (node_size_has_key_zero_bits<NodeSize>()) {
+      unodb::key k = 0;
+      for (std::uint64_t j = 0; j < key_count; ++j) {
+        assert(k <= key_limit);
+        get_existing_key(test_db, k);
+        k = next_key(k, node_size_to_key_zero_bits<NodeSize>());
+      }
+      items_processed += key_count;
+    } else {
+      items_processed += get_key_loop(
+          test_db, key_limit, number_to_full_node_size_tree_key<NodeSize>);
     }
   }
 
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          state.range(0));
+  state.SetItemsProcessed(items_processed);
   set_size_counter(state, "size", tree_size);
 }
 
-template void full_node_scan_benchmark<unodb::db, 4>(::benchmark::State &,
-                                                     std::uint64_t);
-template void full_node_scan_benchmark<unodb::db, 16>(::benchmark::State &,
-                                                      std::uint64_t);
+template void full_node_scan_benchmark<unodb::db, 4>(::benchmark::State &);
+template void full_node_scan_benchmark<unodb::db, 16>(::benchmark::State &);
+template void full_node_scan_benchmark<unodb::db, 48>(::benchmark::State &);
 
-// TODO(laurynas): can derive zero bits from base?
-template <class Db, unsigned Full_Key_Base>
-void full_node_random_get_benchmark(::benchmark::State &state,
-                                    std::uint64_t key_zero_bits) {
+template <class Db, unsigned NodeSize>
+void full_node_random_get_benchmark(::benchmark::State &state) {
   Db test_db;
-  const auto number_of_keys = static_cast<std::uint64_t>(state.range(0));
-  batched_prng random_key_positions{number_of_keys - 1};
-  insert_sequentially(test_db, number_of_keys, key_zero_bits);
+  const auto key_count = static_cast<unsigned>(state.range(0));
+
+  make_full_node_size_tree<Db, NodeSize>(test_db, key_count);
   const auto tree_size = test_db.get_current_memory_use();
-  // TODO(laurynas): assert desired tree shape here?
+
+  batched_prng random_key_positions{key_count - 1};
 
   for (auto _ : state) {
-    for (std::uint64_t i = 0; i < number_of_keys; ++i) {
+    for (std::uint64_t i = 0; i < key_count; ++i) {
       const auto key_index = random_key_positions.get(state);
-      const auto key = to_base_n_value<Full_Key_Base>(key_index);
+      const auto key = number_to_full_node_size_tree_key<NodeSize>(key_index);
       get_existing_key(test_db, key);
     }
   }
 
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          state.range(0));
+                          key_count);
   set_size_counter(state, "size", tree_size);
 }
 
-template void full_node_random_get_benchmark<unodb::db, 4>(::benchmark::State &,
-                                                           std::uint64_t);
+template void full_node_random_get_benchmark<unodb::db, 4>(
+    ::benchmark::State &);
 template void full_node_random_get_benchmark<unodb::db, 16>(
-    ::benchmark::State &, std::uint64_t);
+    ::benchmark::State &);
+template void full_node_random_get_benchmark<unodb::db, 48>(
+    ::benchmark::State &);
 
-template <class Db, unsigned NodeCapacity>
-std::tuple<unodb::key, const tree_shape_snapshot<Db>> make_base_tree_for_add(
-    Db &test_db, unsigned node_count) {
-  const auto key_limit = insert_n_keys<
-      Db, decltype(number_to_minimal_node_size_tree_key<NodeCapacity>)>(
-      test_db, node_count * (node_capacity_to_minimum_size<NodeCapacity>() + 1),
-      number_to_minimal_node_size_tree_key<NodeCapacity>);
-  assert_node_size_tree<Db, NodeCapacity>(test_db);
-  return std::make_tuple(key_limit, tree_shape_snapshot<unodb::db>{test_db});
+template <class Db, unsigned NodeSize>
+void minimal_tree_full_scan(::benchmark::State &state) {
+  const auto key_count = static_cast<unsigned>(state.range(0));
+  Db test_db;
+
+  const auto key_limit =
+      make_minimal_node_size_tree<Db, NodeSize>(test_db, key_count);
+  const auto tree_size = test_db.get_current_memory_use();
+
+  std::int64_t items_processed = 0;
+  for (auto _ : state) {
+    // cppcheck-suppress useStlAlgorithm
+    items_processed += get_key_loop(
+        test_db, key_limit, number_to_minimal_node_size_tree_key<NodeSize>);
+  }
+
+  state.SetItemsProcessed(items_processed);
+  set_size_counter(state, "size", tree_size);
 }
 
-template std::tuple<unodb::key, const tree_shape_snapshot<unodb::db>>
-make_base_tree_for_add<unodb::db, 16>(unodb::db &, unsigned);
+template void minimal_tree_full_scan<unodb::db, 16>(::benchmark::State &);
+template void minimal_tree_full_scan<unodb::db, 48>(::benchmark::State &);
 
-template std::tuple<unodb::key, const tree_shape_snapshot<unodb::db>>
-make_base_tree_for_add<unodb::db, 48>(unodb::db &, unsigned);
+template <class Db, unsigned NodeSize>
+void minimal_tree_random_gets(::benchmark::State &state) {
+  const auto node_count = static_cast<unsigned>(state.range(0));
+  Db test_db;
+  const auto key_limit USED_IN_DEBUG =
+      make_minimal_node_size_tree<Db, NodeSize>(test_db, node_count);
+  assert(number_to_minimal_node_size_tree_key<NodeSize>(
+             node_count * node_capacity_to_minimum_size<NodeSize>() - 1) ==
+         key_limit);
+  const auto tree_size = test_db.get_current_memory_use();
+  batched_prng random_key_positions{
+      node_count * node_capacity_to_minimum_size<16>() - 1};
+  std::int64_t items_processed = 0;
+
+  for (auto _ : state) {
+    const auto key_index = random_key_positions.get(state);
+    const auto key = number_to_minimal_node_size_tree_key<NodeSize>(key_index);
+    get_existing_key(test_db, key);
+    ++items_processed;
+  }
+
+  state.SetItemsProcessed(items_processed);
+  set_size_counter(state, "size", tree_size);
+}
+
+template void minimal_tree_random_gets<unodb::db, 16>(::benchmark::State &);
+template void minimal_tree_random_gets<unodb::db, 48>(::benchmark::State &);
+
+template <class Db, unsigned NodeSize>
+void sequential_add_benchmark(::benchmark::State &state) {
+  std::size_t tree_size{0};
+  const auto node_count = static_cast<unsigned>(state.range(0));
+  std::uint64_t benchmark_keys_inserted{0};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    auto [key_limit, tree_shape] =
+        make_base_tree_for_add<Db, NodeSize>(test_db, node_count);
+    state.ResumeTiming();
+
+    benchmark_keys_inserted = insert_keys_to_limit<
+        Db, decltype(number_to_full_leaf_over_minimal_tree_key<NodeSize>)>(
+        test_db, key_limit,
+        number_to_full_leaf_over_minimal_tree_key<NodeSize>);
+
+    state.PauseTiming();
+#ifndef NDEBUG
+    assert_node_size_tree<Db, NodeSize>(test_db);
+    tree_shape.assert_internal_levels_same();
+#endif
+    tree_size = test_db.get_current_memory_use();
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(benchmark_keys_inserted));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void sequential_add_benchmark<unodb::db, 16>(::benchmark::State &);
+template void sequential_add_benchmark<unodb::db, 48>(::benchmark::State &);
+
+template <class Db, unsigned NodeSize>
+void random_add_benchmark(::benchmark::State &state) {
+  std::size_t tree_size{0};
+  const auto node_count = static_cast<unsigned>(state.range(0));
+  std::int64_t benchmark_keys_inserted{0};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    auto [key_limit, tree_shape] =
+        make_base_tree_for_add<Db, NodeSize>(test_db, node_count);
+    auto benchmark_keys = generate_keys_to_limit(
+        key_limit, number_to_full_leaf_over_minimal_tree_key<NodeSize>);
+    std::shuffle(benchmark_keys.begin(), benchmark_keys.end(), get_prng());
+    state.ResumeTiming();
+
+    insert_keys(test_db, benchmark_keys);
+
+    state.PauseTiming();
+#ifndef NDEBUG
+    assert_node_size_tree<Db, NodeSize>(test_db);
+    tree_shape.assert_internal_levels_same();
+#endif
+    tree_size = test_db.get_current_memory_use();
+    benchmark_keys_inserted = static_cast<std::int64_t>(benchmark_keys.size());
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          benchmark_keys_inserted);
+  set_size_counter(state, "size", tree_size);
+}
+
+template void random_add_benchmark<unodb::db, 16>(::benchmark::State &);
+template void random_add_benchmark<unodb::db, 48>(::benchmark::State &);
+
+template <class Db, unsigned NodeSize>
+void sequential_delete_benchmark(::benchmark::State &state) {
+  const auto key_count = static_cast<unsigned>(state.range(0));
+  int i{0};
+  std::size_t tree_size{0};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    const auto key_limit =
+        make_full_node_size_tree<Db, NodeSize>(test_db, key_count);
+    tree_size = test_db.get_current_memory_use();
+    const tree_shape_snapshot<Db> tree_shape{test_db};
+    state.ResumeTiming();
+
+    i = 0;
+    while (true) {
+      const auto k = number_to_full_leaf_over_minimal_tree_key<NodeSize>(
+          static_cast<std::uint64_t>(i));
+      if (k > key_limit) break;
+      delete_key(test_db, k);
+      ++i;
+    }
+
+    state.PauseTiming();
+#ifndef NDEBUG
+    assert_node_size_tree<Db, NodeSize>(test_db);
+    tree_shape.assert_internal_levels_same();
+#endif
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) * i);
+  set_size_counter(state, "size", tree_size);
+}
+
+template void sequential_delete_benchmark<unodb::db, 16>(::benchmark::State &);
+template void sequential_delete_benchmark<unodb::db, 48>(::benchmark::State &);
+
+template <class Db, unsigned NodeSize>
+void random_delete_benchmark(::benchmark::State &state) {
+  const auto key_count{static_cast<unsigned>(state.range(0))};
+  std::size_t tree_size{0};
+  std::size_t remove_key_count{0};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    const auto key_limit =
+        make_full_node_size_tree<Db, NodeSize>(test_db, key_count);
+    tree_size = test_db.get_current_memory_use();
+    const tree_shape_snapshot<Db> tree_shape{test_db};
+    auto remove_keys = generate_keys_to_limit(
+        key_limit, number_to_full_leaf_over_minimal_tree_key<NodeSize>);
+    remove_key_count = remove_keys.size();
+    std::shuffle(remove_keys.begin(), remove_keys.end(), get_prng());
+    state.ResumeTiming();
+
+    delete_keys(test_db, remove_keys);
+
+    state.PauseTiming();
+#ifndef NDEBUG
+    assert_node_size_tree<Db, NodeSize>(test_db);
+    tree_shape.assert_internal_levels_same();
+#endif
+    destroy_tree(test_db, state);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(remove_key_count));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void random_delete_benchmark<unodb::db, 16>(::benchmark::State &);
+template void random_delete_benchmark<unodb::db, 48>(::benchmark::State &);
+
+template <class Db, unsigned SmallerNodeSize>
+void shrink_node_sequentially_benchmark(::benchmark::State &state) {
+  std::size_t tree_size{0};
+  std::uint64_t removed_key_count{0};
+
+  const auto smaller_node_count = static_cast<unsigned>(state.range(0));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    unodb::key key_limit = make_full_node_size_tree<Db, SmallerNodeSize>(
+        test_db, smaller_node_count * SmallerNodeSize);
+
+    const auto node_growing_keys_inserted =
+        grow_full_node_tree_to_minimal_next_size_leaf_level<Db,
+                                                            SmallerNodeSize>(
+            test_db, key_limit);
+    assert_growing_nodes<Db, SmallerNodeSize>(test_db,
+                                              node_growing_keys_inserted);
+    tree_size = test_db.get_current_memory_use();
+    state.ResumeTiming();
+
+    for (removed_key_count = 0; removed_key_count < node_growing_keys_inserted;
+         ++removed_key_count) {
+      const auto remove_key =
+          number_to_minimal_leaf_over_smaller_node_tree<SmallerNodeSize>(
+              removed_key_count);
+      delete_key(test_db, remove_key);
+    }
+
+    state.PauseTiming();
+    assert_shrinking_nodes<Db, SmallerNodeSize>(test_db, removed_key_count);
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(
+      static_cast<std::int64_t>(state.iterations() * removed_key_count));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void shrink_node_sequentially_benchmark<unodb::db, 4>(
+    ::benchmark::State &);
+template void shrink_node_sequentially_benchmark<unodb::db, 16>(
+    ::benchmark::State &);
+template void shrink_node_sequentially_benchmark<unodb::db, 48>(
+    ::benchmark::State &);
+
+template <class Db, unsigned SmallerNodeSize>
+void shrink_node_randomly_benchmark(::benchmark::State &state) {
+  std::size_t tree_size{0};
+  std::uint64_t removed_key_count{0};
+
+  const auto smaller_node_count = static_cast<unsigned>(state.range(0));
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    const auto key_limit = insert_n_keys_to_empty_tree<
+        Db, SmallerNodeSize,
+        decltype(number_to_full_node_tree_with_gaps_key<SmallerNodeSize>)>(
+        test_db, smaller_node_count * SmallerNodeSize,
+        number_to_full_node_tree_with_gaps_key<SmallerNodeSize>);
+
+    const auto node_growing_keys =
+        generate_random_keys_over_full_smaller_tree<SmallerNodeSize>(key_limit);
+    insert_keys(test_db, node_growing_keys);
+    assert_growing_nodes<Db, SmallerNodeSize>(test_db,
+                                              node_growing_keys.size());
+    tree_size = test_db.get_current_memory_use();
+    state.ResumeTiming();
+
+    delete_keys(test_db, node_growing_keys);
+
+    state.PauseTiming();
+    removed_key_count = node_growing_keys.size();
+    assert_shrinking_nodes<Db, SmallerNodeSize>(test_db, removed_key_count);
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(
+      static_cast<std::int64_t>(state.iterations() * removed_key_count));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void shrink_node_randomly_benchmark<unodb::db, 4>(
+    ::benchmark::State &);
+template void shrink_node_randomly_benchmark<unodb::db, 16>(
+    ::benchmark::State &);
+template void shrink_node_randomly_benchmark<unodb::db, 48>(
+    ::benchmark::State &);
+
+template <class Db, unsigned SmallerNodeSize>
+void grow_node_sequentially_benchmark(::benchmark::State &state) {
+  std::size_t tree_size{0};
+  const auto smaller_node_count = static_cast<unsigned>(state.range(0));
+  std::uint64_t benchmark_keys_inserted{0};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    unodb::key key_limit = make_full_node_size_tree<Db, SmallerNodeSize>(
+        test_db, smaller_node_count * SmallerNodeSize);
+    ::benchmark::ClobberMemory();
+    state.ResumeTiming();
+
+    benchmark_keys_inserted =
+        grow_full_node_tree_to_minimal_next_size_leaf_level<Db,
+                                                            SmallerNodeSize>(
+            test_db, key_limit);
+
+    state.PauseTiming();
+    assert_growing_nodes<Db, SmallerNodeSize>(test_db, benchmark_keys_inserted);
+    tree_size = test_db.get_current_memory_use();
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(benchmark_keys_inserted));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void grow_node_sequentially_benchmark<unodb::db, 4>(
+    ::benchmark::State &);
+template void grow_node_sequentially_benchmark<unodb::db, 16>(
+    ::benchmark::State &);
+template void grow_node_sequentially_benchmark<unodb::db, 48>(
+    ::benchmark::State &);
+
+template <class Db, unsigned SmallerNodeSize>
+void grow_node_randomly_benchmark(::benchmark::State &state) {
+  std::size_t tree_size{0};
+  const auto smaller_node_count = static_cast<unsigned>(state.range(0));
+  std::uint64_t benchmark_keys_inserted{0};
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db test_db;
+    const auto key_limit = insert_n_keys_to_empty_tree<Db, SmallerNodeSize>(
+        test_db, smaller_node_count * SmallerNodeSize,
+        number_to_full_node_tree_with_gaps_key<SmallerNodeSize>);
+
+    const auto larger_tree_keys =
+        generate_random_keys_over_full_smaller_tree<SmallerNodeSize>(key_limit);
+    state.ResumeTiming();
+
+    insert_keys(test_db, larger_tree_keys);
+
+    state.PauseTiming();
+    benchmark_keys_inserted = larger_tree_keys.size();
+    assert_growing_nodes<Db, SmallerNodeSize>(test_db, benchmark_keys_inserted);
+    tree_size = test_db.get_current_memory_use();
+    destroy_tree(test_db, state);
+  }
+
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(benchmark_keys_inserted));
+  set_size_counter(state, "size", tree_size);
+}
+
+template void grow_node_randomly_benchmark<unodb::db, 4>(::benchmark::State &);
+template void grow_node_randomly_benchmark<unodb::db, 16>(::benchmark::State &);
+template void grow_node_randomly_benchmark<unodb::db, 48>(::benchmark::State &);
 
 }  // namespace unodb::benchmark


### PR DESCRIPTION
- Add minimal Node48 tree full scan and random get, full Node48 tree full scan
  and random get, full Node48 tree sequential and random delete, Node256
  sequential and random shrink to Node48 benchmarks
- Add micro_benchmark_node256 benchmark target, with Node48->Node256 growth
  benchmarks for now
- Add Node256 -> Node48 shrinking stats to class shrinking_tree_node_stats
- Refactor Node16/Node48/Node256 benchmarks to use common benchmark framework.
  Node4 is not unified because it is different.
- Introduce unodb::benchmark::detail namespace for declarations that are
  internal to benchmark implementation
- Push regular key zero bit constants to unodb::benchmark, make all benchmarks
  use them, including Node4 ones.
- Templatize more functions on node size instead of passing various
  number-to-key, key zero bits, etc. arguments. Since this reduces template
  function parameter space, push more code to micro_benchmark_utils.cpp with
  extern templates in micro_benchmark_utils.hpp.
- Rename "number_of_keys" to "key_count" consistently
- Adjust quick benchmark args for the new added tests