### PR TITLE
Node48 ctor: memset child_indexes before the loop

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1296,23 +1296,19 @@ inode_48::inode_48(std::unique_ptr<inode_256> &&source_node,
       source_node->children[child_to_remove]};
   source_node->children[child_to_remove] = nullptr;
 
+  std::memset(&child_indexes[0], empty_child, 256);
+
   std::uint8_t next_child = 0;
-  unsigned child_i = 0;
-  for (; child_i < 256; child_i++) {
+  for (unsigned child_i = 0; child_i < 256; child_i++) {
     const auto child_ptr = source_node->children[child_i];
-    if (child_ptr == nullptr) {
-      child_indexes[child_i] = empty_child;
-      continue;
-    }
-    assert(child_ptr != nullptr);
+    if (child_ptr == nullptr) continue;
+
     child_indexes[child_i] = next_child;
     children.pointer_array[next_child] = source_node->children[child_i];
     ++next_child;
+
     if (next_child == f.f.children_count) break;
   }
-
-  ++child_i;
-  for (; child_i < 256; child_i++) child_indexes[child_i] = empty_child;
 }
 
 inode_256::inode_256(std::unique_ptr<inode_48> &&source_node,


### PR DESCRIPTION
Performance: baseline:

$ perf stat taskset -c 0 ./micro_benchmark_node48 --benchmark_filter=shrink
2020-11-12T05:13:37+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.25, 0.59, 0.22
-----------------------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------
shrink_node256_to_node48_sequentially/4          1.55 us         1.51 us       464326 items_per_second=1.98977M/s size=28.2529k
shrink_node256_to_node48_sequentially/8          2.20 us         2.14 us       326110 items_per_second=3.26501M/s size=58.0537k
shrink_node256_to_node48_sequentially/64         12.5 us         12.3 us        56764 items_per_second=5.12043M/s size=474.421k
shrink_node256_to_node48_sequentially/512        95.4 us         95.0 us         7369 items_per_second=5.37943M/s size=3.71701M
shrink_node256_to_node48_sequentially/2048        445 us          443 us         1581 items_per_second=4.62517M/s size=14.8718M
shrink_node256_to_node48_randomly/4              1.80 us         1.75 us       399474 items_per_second=2.28027M/s size=29.7383k
shrink_node256_to_node48_randomly/8              2.53 us         2.47 us       282739 items_per_second=3.23417M/s size=59.5391k
shrink_node256_to_node48_randomly/64             13.9 us         13.7 us        51240 items_per_second=4.68371M/s size=475.906k
shrink_node256_to_node48_randomly/512             104 us          103 us         6784 items_per_second=4.96207M/s size=3.71846M
shrink_node256_to_node48_randomly/2048            528 us          525 us         1334 items_per_second=3.89889M/s size=14.8732M

 Performance counter stats for 'taskset -c 0 ./micro_benchmark_node48 --benchmark_filter=shrink':

        190,752.93 msec task-clock                #    1.000 CPUs utilized
               452      context-switches          #    0.002 K/sec
                 1      cpu-migrations            #    0.000 K/sec
           178,997      page-faults               #    0.938 K/sec
   725,312,047,243      cycles                    #    3.802 GHz                      (83.33%)
   144,582,078,949      stalled-cycles-frontend   #   19.93% frontend cycles idle     (83.33%)
    52,160,201,957      stalled-cycles-backend    #    7.19% backend cycles idle      (66.67%)
 1,818,226,761,941      instructions              #    2.51  insn per cycle
                                                  #    0.08  stalled cycles per insn  (83.33%)
   355,486,329,262      branches                  # 1863.596 M/sec                    (83.33%)
       629,519,943      branch-misses             #    0.18% of all branches          (83.33%)

     190.777214002 seconds time elapsed

     188.274360000 seconds user
       2.480031000 seconds sys

With the patch:

$ perf stat taskset -c 0 ./micro_benchmark_node48 --benchmark_filter=shrink
2020-11-12T05:31:09+01:00
Running ./micro_benchmark_node48
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.60, 0.59, 0.33
-----------------------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------
shrink_node256_to_node48_sequentially/4          1.48 us         1.45 us       482243 items_per_second=2.07333M/s size=28.2529k
shrink_node256_to_node48_sequentially/8          2.07 us         2.02 us       347170 items_per_second=3.47134M/s size=58.0537k
shrink_node256_to_node48_sequentially/64         12.5 us         12.3 us        56921 items_per_second=5.12425M/s size=474.421k
shrink_node256_to_node48_sequentially/512        94.4 us         94.0 us         7450 items_per_second=5.43537M/s size=3.71701M
shrink_node256_to_node48_sequentially/2048        426 us          423 us         1654 items_per_second=4.83848M/s size=14.8718M
shrink_node256_to_node48_randomly/4              1.67 us         1.63 us       429485 items_per_second=2.45345M/s size=29.7383k
shrink_node256_to_node48_randomly/8              2.33 us         2.27 us       308255 items_per_second=3.52211M/s size=59.5391k
shrink_node256_to_node48_randomly/64             12.6 us         12.4 us        56622 items_per_second=5.17185M/s size=475.906k
shrink_node256_to_node48_randomly/512            93.8 us         93.4 us         7497 items_per_second=5.48147M/s size=3.71846M
shrink_node256_to_node48_randomly/2048            470 us          467 us         1497 items_per_second=4.38361M/s size=14.8732M

 Performance counter stats for 'taskset -c 0 ./micro_benchmark_node48 --benchmark_filter=shrink':

        212,016.52 msec task-clock                #    1.000 CPUs utilized
               566      context-switches          #    0.003 K/sec
                 1      cpu-migrations            #    0.000 K/sec
           233,054      page-faults               #    0.001 M/sec
   806,237,697,553      cycles                    #    3.803 GHz                      (83.33%)
   164,752,506,533      stalled-cycles-frontend   #   20.43% frontend cycles idle     (83.33%)
    60,834,664,660      stalled-cycles-backend    #    7.55% backend cycles idle      (66.67%)
 2,011,445,310,964      instructions              #    2.49  insn per cycle
                                                  #    0.08  stalled cycles per insn  (83.33%)
   393,262,387,394      branches                  # 1854.867 M/sec                    (83.33%)
       770,012,444      branch-misses             #    0.20% of all branches          (83.33%)

     212.037978214 seconds time elapsed

     209.234293000 seconds user
       2.784030000 seconds sys