### PR TITLE
Node48 shrinking ctor: restrict source node argument

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1292,19 +1292,20 @@ static_assert(sizeof(inode_256) == 2064);
 inode_48::inode_48(std::unique_ptr<inode_256> &&source_node,
                    std::uint8_t child_to_remove) noexcept
     : basic_inode_48{*source_node} {
+  auto *const __restrict__ source_node_ptr = source_node.get();
   delete_node_ptr_at_scope_exit delete_on_scope_exit{
-      source_node->children[child_to_remove]};
-  source_node->children[child_to_remove] = nullptr;
+      source_node_ptr->children[child_to_remove]};
+  source_node_ptr->children[child_to_remove] = nullptr;
 
   std::memset(&child_indexes[0], empty_child, 256);
 
   std::uint8_t next_child = 0;
   for (unsigned child_i = 0; child_i < 256; child_i++) {
-    const auto child_ptr = source_node->children[child_i];
+    const auto child_ptr = source_node_ptr->children[child_i];
     if (child_ptr == nullptr) continue;
 
     child_indexes[child_i] = next_child;
-    children.pointer_array[next_child] = source_node->children[child_i];
+    children.pointer_array[next_child] = source_node_ptr->children[child_i];
     ++next_child;
 
     if (next_child == f.f.children_count) break;


### PR DESCRIPTION
For some reason it helps:

shrink_node256_to_node48_sequentially/4_pvalue                    0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_sequentially/4_mean                     -0.0215         -0.0180             2             1             1             1
shrink_node256_to_node48_sequentially/8_pvalue                    0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_sequentially/8_mean                     -0.0176         -0.0114             2             2             2             2
shrink_node256_to_node48_sequentially/64_pvalue                   0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_sequentially/64_mean                    -0.0221         -0.0224            12            12            12            12
shrink_node256_to_node48_sequentially/512_pvalue                  0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_sequentially/512_mean                   -0.0059         -0.0063            95            94            94            94
shrink_node256_to_node48_sequentially/2048_pvalue                 0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_sequentially/2048_mean                  -0.0316         -0.0318           435           421           432           418
shrink_node256_to_node48_randomly/4_pvalue                        0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_randomly/4_mean                         -0.0192         -0.0166             2             2             2             2
shrink_node256_to_node48_randomly/8_pvalue                        0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_randomly/8_mean                         -0.0210         -0.0157             2             2             2             2
shrink_node256_to_node48_randomly/64_pvalue                       0.6239          0.4383      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_randomly/64_mean                        -0.0005         -0.0014            12            12            12            12
shrink_node256_to_node48_randomly/512_pvalue                      0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_randomly/512_mean                       -0.0075         -0.0076            95            94            95            94
shrink_node256_to_node48_randomly/2048_pvalue                     0.0000          0.0000      U Test, Repetitions: 18 vs 18
shrink_node256_to_node48_randomly/2048_mean                      -0.0331         -0.0332           483           467           480           465