### PR TITLE
Node256 growing ctor: copy only until we get 48 children

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1314,12 +1314,21 @@ inode_48::inode_48(std::unique_ptr<inode_256> &&source_node,
 inode_256::inode_256(std::unique_ptr<inode_48> &&source_node,
                      leaf_unique_ptr &&child, tree_depth depth) noexcept
     : basic_inode_256{*source_node} {
-  for (unsigned i = 0; i < 256; i++) {
+  unsigned children_copied = 0;
+  unsigned i = 0;
+  for (; i < capacity; ++i) {
     const auto children_i = source_node->child_indexes[i];
-    children[i] = children_i == inode_48::empty_child
-                      ? nullptr
-                      : source_node->children.pointer_array[children_i];
+    if (children_i == inode_48::empty_child) {
+      children[i] = nullptr;
+    } else {
+      children[i] = source_node->children.pointer_array[children_i];
+      ++children_copied;
+      if (children_copied == inode_48::capacity) break;
+    }
   }
+
+  ++i;
+  for (; i < capacity; ++i) children[i] = nullptr;
 
   const auto key_byte = static_cast<uint8_t>(leaf::key(child.get())[depth]);
   assert(children[key_byte] == nullptr);


### PR DESCRIPTION
At that point, we know we can initialize the rest with nullptr.

Performance: baseline:

$ perf stat taskset -c 0 ./micro_benchmark_node256
2020-11-12T19:23:11+01:00
Running ./micro_benchmark_node256
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.00, 0.00, 0.00
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
grow_node48_to_node256_sequentially/2          1.36 us         1.34 us       524389 items_per_second=748.534k/s size=13.4072k
grow_node48_to_node256_sequentially/8          3.32 us         3.27 us       214291 items_per_second=2.14366M/s size=58.0537k
grow_node48_to_node256_sequentially/64         22.0 us         21.8 us        32139 items_per_second=2.89524M/s size=474.421k
grow_node48_to_node256_sequentially/512         192 us          192 us         3647 items_per_second=2.66435M/s size=3.71701M
grow_node48_to_node256_sequentially/2048        865 us          864 us          811 items_per_second=2.37055M/s size=14.8718M
grow_node48_to_node256_randomly/2              1.68 us         1.65 us       423977 items_per_second=1.20985M/s size=14.8926k
grow_node48_to_node256_randomly/8              3.58 us         3.53 us       198501 items_per_second=2.26948M/s size=59.5391k
grow_node48_to_node256_randomly/64             21.5 us         21.3 us        32925 items_per_second=3.008M/s size=475.906k
grow_node48_to_node256_randomly/512             165 us          165 us         4245 items_per_second=3.10574M/s size=3.71846M
grow_node48_to_node256_randomly/2048            809 us          806 us          871 items_per_second=2.53973M/s size=14.8732M

 Performance counter stats for 'taskset -c 0 ./micro_benchmark_node256':

        123,431.01 msec task-clock                #    1.000 CPUs utilized
               281      context-switches          #    0.002 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         6,305,316      page-faults               #    0.051 M/sec
   469,553,424,833      cycles                    #    3.804 GHz                      (83.33%)
   113,326,599,159      stalled-cycles-frontend   #   24.13% frontend cycles idle     (83.33%)
    47,684,890,431      stalled-cycles-backend    #   10.16% backend cycles idle      (66.67%)
 1,084,515,852,363      instructions              #    2.31  insn per cycle
                                                  #    0.10  stalled cycles per insn  (83.33%)
   214,453,980,353      branches                  # 1737.440 M/sec                    (83.33%)
       465,135,200      branch-misses             #    0.22% of all branches          (83.33%)

     123.450671909 seconds time elapsed

     115.440073000 seconds user
       7.992005000 seconds sys

With the patch:

$ perf stat taskset -c 0 ./micro_benchmark_node256
2020-11-13T05:26:11+01:00
Running ./micro_benchmark_node256
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.68, 0.68, 0.40
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
grow_node48_to_node256_sequentially/2          1.23 us         1.23 us       570115 items_per_second=815.01k/s size=13.4072k
grow_node48_to_node256_sequentially/8          2.50 us         2.45 us       285769 items_per_second=2.85728M/s size=58.0537k
grow_node48_to_node256_sequentially/64         15.1 us         14.9 us        46754 items_per_second=4.21961M/s size=474.421k
grow_node48_to_node256_sequentially/512         136 us          136 us         5146 items_per_second=3.75738M/s size=3.71701M
grow_node48_to_node256_sequentially/2048        807 us          806 us          868 items_per_second=2.54032M/s size=14.8718M
grow_node48_to_node256_randomly/2              1.46 us         1.45 us       482632 items_per_second=1.37867M/s size=14.8926k
grow_node48_to_node256_randomly/8              2.84 us         2.80 us       250049 items_per_second=2.85618M/s size=59.5391k
grow_node48_to_node256_randomly/64             16.4 us         16.2 us        43208 items_per_second=3.9511M/s size=475.906k
grow_node48_to_node256_randomly/512             126 us          125 us         5594 items_per_second=4.08608M/s size=3.71846M
grow_node48_to_node256_randomly/2048            768 us          766 us          895 items_per_second=2.67465M/s size=14.8732M

 Performance counter stats for 'taskset -c 0 ./micro_benchmark_node256':

        145,007.52 msec task-clock                #    1.000 CPUs utilized
               385      context-switches          #    0.003 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         7,534,623      page-faults               #    0.052 M/sec
   551,492,725,283      cycles                    #    3.803 GHz                      (83.33%)
   132,568,873,482      stalled-cycles-frontend   #   24.04% frontend cycles idle     (83.33%)
    56,795,272,557      stalled-cycles-backend    #   10.30% backend cycles idle      (66.67%)
 1,272,159,326,239      instructions              #    2.31  insn per cycle
                                                  #    0.10  stalled cycles per insn  (83.33%)
   245,300,982,977      branches                  # 1691.643 M/sec                    (83.33%)
       566,823,046      branch-misses             #    0.23% of all branches          (83.33%)

     145.027935754 seconds time elapsed

     134.916378000 seconds user
      10.092028000 seconds sys