### PR TITLE
Node256 shrinking ctor: make loop infinite

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1317,7 +1317,7 @@ inode_256::inode_256(std::unique_ptr<inode_48> &&source_node,
     : basic_inode_256{*source_node} {
   unsigned children_copied = 0;
   unsigned i = 0;
-  for (; i < capacity; ++i) {
+  while (true) {
     const auto children_i = source_node->child_indexes[i];
     if (children_i == inode_48::empty_child) {
       children[i] = nullptr;
@@ -1326,6 +1326,7 @@ inode_256::inode_256(std::unique_ptr<inode_48> &&source_node,
       ++children_copied;
       if (children_copied == inode_48::capacity) break;
     }
+    ++i;
   }
 
   ++i;


### PR DESCRIPTION
The already-existing loop exit condition is enough.

Performance: baseline:

$ perf stat taskset -c 0 ./micro_benchmark_node256
2020-11-13T05:26:11+01:00
Running ./micro_benchmark_node256
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 1.68, 0.68, 0.40
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
grow_node48_to_node256_sequentially/2          1.23 us         1.23 us       570115 items_per_second=815.01k/s size=13.4072k
grow_node48_to_node256_sequentially/8          2.50 us         2.45 us       285769 items_per_second=2.85728M/s size=58.0537k
grow_node48_to_node256_sequentially/64         15.1 us         14.9 us        46754 items_per_second=4.21961M/s size=474.421k
grow_node48_to_node256_sequentially/512         136 us          136 us         5146 items_per_second=3.75738M/s size=3.71701M
grow_node48_to_node256_sequentially/2048        807 us          806 us          868 items_per_second=2.54032M/s size=14.8718M
grow_node48_to_node256_randomly/2              1.46 us         1.45 us       482632 items_per_second=1.37867M/s size=14.8926k
grow_node48_to_node256_randomly/8              2.84 us         2.80 us       250049 items_per_second=2.85618M/s size=59.5391k
grow_node48_to_node256_randomly/64             16.4 us         16.2 us        43208 items_per_second=3.9511M/s size=475.906k
grow_node48_to_node256_randomly/512             126 us          125 us         5594 items_per_second=4.08608M/s size=3.71846M
grow_node48_to_node256_randomly/2048            768 us          766 us          895 items_per_second=2.67465M/s size=14.8732M

 Performance counter stats for 'taskset -c 0 ./micro_benchmark_node256':

        145,007.52 msec task-clock                #    1.000 CPUs utilized
               385      context-switches          #    0.003 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         7,534,623      page-faults               #    0.052 M/sec
   551,492,725,283      cycles                    #    3.803 GHz                      (83.33%)
   132,568,873,482      stalled-cycles-frontend   #   24.04% frontend cycles idle     (83.33%)
    56,795,272,557      stalled-cycles-backend    #   10.30% backend cycles idle      (66.67%)
 1,272,159,326,239      instructions              #    2.31  insn per cycle
                                                  #    0.10  stalled cycles per insn  (83.33%)
   245,300,982,977      branches                  # 1691.643 M/sec                    (83.33%)
       566,823,046      branch-misses             #    0.23% of all branches          (83.33%)

     145.027935754 seconds time elapsed

     134.916378000 seconds user
      10.092028000 seconds sys

With the patch:

$ perf stat taskset -c 0 ./micro_benchmark_node256
2020-11-13T18:44:35+01:00
Running ./micro_benchmark_node256
Run on (8 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 256 KiB (x4)
  L3 Unified 8192 KiB (x1)
Load Average: 0.18, 0.30, 0.23
---------------------------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------------------------------------
grow_node48_to_node256_sequentially/2          1.25 us         1.25 us       560037 items_per_second=800.225k/s size=13.4072k
grow_node48_to_node256_sequentially/8          2.47 us         2.43 us       288768 items_per_second=2.8829M/s size=58.0537k
grow_node48_to_node256_sequentially/64         15.0 us         14.8 us        47303 items_per_second=4.25656M/s size=474.421k
grow_node48_to_node256_sequentially/512         134 us          134 us         5228 items_per_second=3.81096M/s size=3.71701M
grow_node48_to_node256_sequentially/2048        797 us          795 us          876 items_per_second=2.57416M/s size=14.8718M
grow_node48_to_node256_randomly/2              1.47 us         1.47 us       474508 items_per_second=1.35866M/s size=14.8926k
grow_node48_to_node256_randomly/8              2.73 us         2.70 us       259106 items_per_second=2.96294M/s size=59.5391k
grow_node48_to_node256_randomly/64             15.4 us         15.2 us        46018 items_per_second=4.20448M/s size=475.906k
grow_node48_to_node256_randomly/512             117 us          117 us         6000 items_per_second=4.38632M/s size=3.71846M
grow_node48_to_node256_randomly/2048            772 us          769 us          915 items_per_second=2.66312M/s size=14.8732M

 Performance counter stats for 'taskset -c 0 ./micro_benchmark_node256':

        147,816.27 msec task-clock                #    1.000 CPUs utilized
               359      context-switches          #    0.002 K/sec
                 1      cpu-migrations            #    0.000 K/sec
         7,595,979      page-faults               #    0.051 M/sec
   562,023,264,573      cycles                    #    3.802 GHz                      (83.33%)
   136,031,330,923      stalled-cycles-frontend   #   24.20% frontend cycles idle     (83.33%)
    57,839,995,865      stalled-cycles-backend    #   10.29% backend cycles idle      (66.67%)
 1,298,234,822,760      instructions              #    2.31  insn per cycle
                                                  #    0.10  stalled cycles per insn  (83.33%)
   248,850,852,827      branches                  # 1683.515 M/sec                    (83.33%)
       552,923,177      branch-misses             #    0.22% of all branches          (83.33%)

     147.836212824 seconds time elapsed

     138.481791000 seconds user
       9.335851000 seconds sys