### PR TITLE
Implement Node256 benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -4,7 +4,7 @@ set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
 set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
 set(micro_benchmark_node16_quick_arg "--benchmark_filter='/64'")
 set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64|/128|/192'")
-set(micro_benchmark_node256_quick_arg "--benchmark_filter='/8'")
+set(micro_benchmark_node256_quick_arg "--benchmark_filter='/8|/128|/192'")
 set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
 

--- a/benchmark/micro_benchmark_node256.cpp
+++ b/benchmark/micro_benchmark_node256.cpp
@@ -17,6 +17,38 @@ void grow_node48_to_node256_randomly(benchmark::State &state) {
   unodb::benchmark::grow_node_randomly_benchmark<unodb::db, 48>(state);
 }
 
+void node256_sequential_add(benchmark::State &state) {
+  unodb::benchmark::sequential_add_benchmark<unodb::db, 256>(state);
+}
+
+void node256_random_add(benchmark::State &state) {
+  unodb::benchmark::random_add_benchmark<unodb::db, 256>(state);
+}
+
+void minimal_node256_tree_full_scan(benchmark::State &state) {
+  unodb::benchmark::minimal_tree_full_scan<unodb::db, 256>(state);
+}
+
+void minimal_node256_tree_random_gets(benchmark::State &state) {
+  unodb::benchmark::minimal_tree_random_gets<unodb::db, 256>(state);
+}
+
+void full_node256_tree_full_scan(benchmark::State &state) {
+  unodb::benchmark::full_node_scan_benchmark<unodb::db, 256>(state);
+}
+
+void full_node256_tree_random_gets(benchmark::State &state) {
+  unodb::benchmark::full_node_random_get_benchmark<unodb::db, 256>(state);
+}
+
+void full_node256_tree_sequential_delete(benchmark::State &state) {
+  unodb::benchmark::sequential_delete_benchmark<unodb::db, 256>(state);
+}
+
+void full_node256_tree_random_delete(benchmark::State &state) {
+  unodb::benchmark::random_delete_benchmark<unodb::db, 256>(state);
+}
+
 }  // namespace
 
 BENCHMARK(grow_node48_to_node256_sequentially)
@@ -24,6 +56,28 @@ BENCHMARK(grow_node48_to_node256_sequentially)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(grow_node48_to_node256_randomly)
     ->Range(2, 2048)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(node256_sequential_add)
+    ->Range(1, 1024)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(node256_random_add)->Range(1, 1024)->Unit(benchmark::kMicrosecond);
+BENCHMARK(minimal_node256_tree_full_scan)
+    ->Range(4, 4096)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(minimal_node256_tree_random_gets)
+    ->Range(4, 4096)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node256_tree_full_scan)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node256_tree_random_gets)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node256_tree_sequential_delete)
+    ->Range(192, 196608)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK(full_node256_tree_random_delete)
+    ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_node4.cpp
+++ b/benchmark/micro_benchmark_node4.cpp
@@ -36,7 +36,7 @@ std::vector<unodb::key> make_limited_key_sequence(unodb::key limit,
   std::vector<unodb::key> result;
 
   unodb::key insert_key = 0;
-  while (insert_key < limit) {
+  while (insert_key <= limit) {
     result.push_back(insert_key);
     insert_key = unodb::benchmark::next_key(insert_key, key_zero_bits);
   }
@@ -138,7 +138,7 @@ void node4_sequential_delete_benchmark(benchmark::State &state,
 
     unodb::key k = 0;
     keys_deleted = 0;
-    while (k < key_limit) {
+    while (k <= key_limit) {
       unodb::benchmark::delete_key(test_db, k);
       ++keys_deleted;
       k = unodb::benchmark::next_key(k, delete_key_zero_bits);
@@ -226,16 +226,16 @@ BENCHMARK(minimal_node4_random_insert)
 BENCHMARK(node4_full_scan)->Range(100, 65535)->Unit(benchmark::kMicrosecond);
 BENCHMARK(node4_random_gets)->Range(100, 65535)->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node4_sequential_delete)
-    ->Range(100, 65535)
+    ->Range(100, 65534)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node4_random_deletes)
-    ->Range(100, 65535)
+    ->Range(100, 65534)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node4_to_minimal_sequential_delete)
-    ->Range(100, 65533)
+    ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(full_node4_to_minimal_random_delete)
-    ->Range(100, 65533)
+    ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
 BENCHMARK(shrink_node16_to_node4_sequentially)
     ->Range(25, 16383)

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -45,13 +45,16 @@ inline constexpr std::array<unodb::value_view, 5> values = {
 
 template <unsigned NodeSize>
 constexpr inline auto node_size_to_key_zero_bits() noexcept {
-  static_assert(NodeSize == 2 || NodeSize == 4 || NodeSize == 16);
+  static_assert(NodeSize == 2 || NodeSize == 4 || NodeSize == 16 ||
+                NodeSize == 256);
   if constexpr (NodeSize == 2) {
     return 0xFEFEFEFE'FEFEFEFEULL;
   } else if constexpr (NodeSize == 4) {
     return 0xFCFCFCFC'FCFCFCFCULL;
+  } else if constexpr (NodeSize == 16) {
+    return 0xF0F0F0F0'F0F0F0F0ULL;
   }
-  return 0xF0F0F0F0'F0F0F0F0ULL;
+  return 0ULL;
 }
 
 inline constexpr auto next_key(unodb::key k,
@@ -269,8 +272,11 @@ void insert_key_ignore_dups(Db &db, unodb::key k, unodb::value_view v) {
 template <class Db, unsigned NodeSize>
 unodb::key insert_sequentially(Db &db, unsigned key_count) {
   unodb::key k = 0;
-  for (decltype(key_count) i = 0; i < key_count; ++i) {
+  decltype(key_count) i = 0;
+  while (true) {
     insert_key(db, k, unodb::value_view{value100});
+    if (i == key_count) break;
+    ++i;
     k = next_key(k, node_size_to_key_zero_bits<NodeSize>());
   }
   return k;
@@ -355,6 +361,8 @@ extern template void full_node_scan_benchmark<unodb::db, 16>(
     ::benchmark::State &);
 extern template void full_node_scan_benchmark<unodb::db, 48>(
     ::benchmark::State &);
+extern template void full_node_scan_benchmark<unodb::db, 256>(
+    ::benchmark::State &);
 
 template <class Db, unsigned NodeSize>
 void full_node_random_get_benchmark(::benchmark::State &state);
@@ -364,6 +372,8 @@ extern template void full_node_random_get_benchmark<unodb::db, 4>(
 extern template void full_node_random_get_benchmark<unodb::db, 16>(
     ::benchmark::State &);
 extern template void full_node_random_get_benchmark<unodb::db, 48>(
+    ::benchmark::State &);
+extern template void full_node_random_get_benchmark<unodb::db, 256>(
     ::benchmark::State &);
 
 // Benchmark e.g. growing Node4 to Node16: insert to full Node4 tree first:
@@ -477,12 +487,15 @@ extern template void sequential_add_benchmark<unodb::db, 16>(
     ::benchmark::State &);
 extern template void sequential_add_benchmark<unodb::db, 48>(
     ::benchmark::State &);
+extern template void sequential_add_benchmark<unodb::db, 256>(
+    ::benchmark::State &);
 
 template <class Db, unsigned NodeSize>
 void random_add_benchmark(::benchmark::State &state);
 
 extern template void random_add_benchmark<unodb::db, 16>(::benchmark::State &);
 extern template void random_add_benchmark<unodb::db, 48>(::benchmark::State &);
+extern template void random_add_benchmark<unodb::db, 256>(::benchmark::State &);
 
 template <class Db, unsigned NodeSize>
 void minimal_tree_full_scan(::benchmark::State &state);
@@ -490,6 +503,8 @@ void minimal_tree_full_scan(::benchmark::State &state);
 extern template void minimal_tree_full_scan<unodb::db, 16>(
     ::benchmark::State &);
 extern template void minimal_tree_full_scan<unodb::db, 48>(
+    ::benchmark::State &);
+extern template void minimal_tree_full_scan<unodb::db, 256>(
     ::benchmark::State &);
 
 template <class Db, unsigned NodeSize>
@@ -499,6 +514,8 @@ extern template void minimal_tree_random_gets<unodb::db, 16>(
     ::benchmark::State &);
 extern template void minimal_tree_random_gets<unodb::db, 48>(
     ::benchmark::State &);
+extern template void minimal_tree_random_gets<unodb::db, 256>(
+    ::benchmark::State &);
 
 template <class Db, unsigned NodeSize>
 void sequential_delete_benchmark(::benchmark::State &state);
@@ -507,6 +524,8 @@ extern template void sequential_delete_benchmark<unodb::db, 16>(
     ::benchmark::State &);
 extern template void sequential_delete_benchmark<unodb::db, 48>(
     ::benchmark::State &);
+extern template void sequential_delete_benchmark<unodb::db, 256>(
+    ::benchmark::State &);
 
 template <class Db, unsigned NodeSize>
 void random_delete_benchmark(::benchmark::State &state);
@@ -514,6 +533,8 @@ void random_delete_benchmark(::benchmark::State &state);
 extern template void random_delete_benchmark<unodb::db, 16>(
     ::benchmark::State &);
 extern template void random_delete_benchmark<unodb::db, 48>(
+    ::benchmark::State &);
+extern template void random_delete_benchmark<unodb::db, 256>(
     ::benchmark::State &);
 
 }  // namespace unodb::benchmark


### PR DESCRIPTION
At the same time fix minor boundary condition issue with
micro_benchmark_node4.cpp:make_limited_key_sequence,
node4_sequential_delete_benchmark, and insert_sequentially: treat key limit as
the last key present in the tree, instead of one past.