### PR TITLE
Add GCC 10 static analysis

### DIFF
--- a/.cmake-build.el
+++ b/.cmake-build.el
@@ -15,7 +15,10 @@
   (llvm-release "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++")
   (llvm-debug "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++")
   (llvm-debug-asan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE=ON")
-  (llvm-debug-tsan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_THREAD=ON"))
+  (llvm-debug-tsan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_THREAD=ON")
+
+  (gcc-static-analysis-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSTATIC_ANALYSIS=ON")
+  (gcc-static-analysis-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSTATIC_ANALYSIS=ON"))
 
  (cmake-build-run-configs
   (test

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ env:
     - SANITIZE_THREAD=OFF
     - SCAN_BUILD=
     - COVERAGE=OFF
+    - STATIC_ANALYSIS=OFF
 
 matrix:
   include:
@@ -88,6 +89,14 @@ matrix:
       <<: *gcc10
       env:
         - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "GCC 10 static analysis Release"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release STATIC_ANALYSIS=ON
+    - name: "GCC 10 static analysis Debug"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug STATIC_ANALYSIS=ON
     - name: "clang 11 Release"
       <<: *clang11
       env:
@@ -174,12 +183,14 @@ script:
       brew install lcov;
       EXTRA_CMAKE_OPTIONS+="-DGCOV_PATH=/usr/local/bin/gcov-10 ";
     fi
-  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DSANITIZE=${SANITIZE} -DSANITIZE_THREAD=${SANITIZE_THREAD} -DCOVERAGE=${COVERAGE} ${EXTRA_CMAKE_OPTIONS}
+  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DSANITIZE=${SANITIZE} -DSANITIZE_THREAD=${SANITIZE_THREAD} -DCOVERAGE=${COVERAGE} -DSTATIC_ANALYSIS=${STATIC_ANALYSIS} ${EXTRA_CMAKE_OPTIONS}
   - if [[ ! -z "${SCAN_BUILD}" ]]; then
       ${SCAN_BUILD} --status-bugs -stats -analyze-headers --force-analyze-debug-code make -j3;
       travis_terminate 0;
-    else
-      make -j3;
+    fi
+  - make -j3;
+  - if [[ "$STATIC_ANALYSIS" == "ON" ]]; then
+      travis_terminate 0;
     fi
   - if [[ "$COVERAGE" == "OFF" ]]; then
       ctest -j3 -V;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ if(SANITIZE_THREAD)
   list(APPEND SANITIZER_LD_FLAGS "-fsanitize=thread")
 endif()
 
+option(STATIC_ANALYSIS "Enable compiler static analysis")
+
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(DEBUG "ON")
 endif()
@@ -446,6 +448,9 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   endif()
   if(IWYU_EXE)
     set_target_properties(${TARGET} PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "${DO_IWYU}")
+  endif()
+  if(STATIC_ANALYSIS)
+    target_compile_options(${TARGET} PRIVATE "-fanalyzer")
   endif()
 endfunction()
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ C++ tools and ideas.
 The code uses SSE4.1 intrinsics (Nehalem and higher). This is in contrast to the
 original ART paper needing SSE2 only.
 
+Note: since this is my personal project, it only supports GCC 10 and LLVM 11
+compilers. Drop me a note if you want to try this and need a lower supported
+compiler version.
+
 ## Usage
 
 All the declarations live in the `unodb` namespace, which is omitted in the
@@ -91,6 +95,10 @@ instead of boost::pmr, will result in UBSan false positives due to
 
 To enable Thread and Undefined Behavior sanitizers, add `-DSANITIZE_THREAD=ON`
 CMake option. It is incompatible with `-DSANITIZE=ON` option.
+
+To enable GCC 10+ compiler static analysis, add `-DSTATIC_ANALYSIS=ON` CMake
+option. For LLVM static analysis, no special CMake option is needed, and you
+have to prepend `scan-build` to `make` instead.
 
 To invoke include-what-you-use, add `-DIWYU=ON` CMake option. It will take
 effect if CMake configures to build project with clang.


### PR DESCRIPTION
- New CMake option -DSTATIC_ANALYSIS=ON|OFF, which add -fanalyzer to compiler
  options if enabled
- Add static analysis configs to .cmake-build.el
- Update README.md