### PR TITLE
Split out UndefinedBehaviorSanitizer into its own separate CMake conf…

### DIFF
--- a/.cmake-build.el
+++ b/.cmake-build.el
@@ -1,20 +1,21 @@
 ((cmake-build-cmake-profiles
   (release "-DCMAKE_BUILD_TYPE=Release")
-  (release-asan "-DCMAKE_BUILD_TYPE=Release -DSANITIZE=ON")
+  (release-asan "-DCMAKE_BUILD_TYPE=Release -DSANITIZE_ADDRESS=ON")
 
   (debug "-DCMAKE_BUILD_TYPE=Debug")
-  (debug-asan "-DCMAKE_BUILD_TYPE=Debug -DSANITIZE=ON")
+  (debug-asan "-DCMAKE_BUILD_TYPE=Debug -DSANITIZE_ADDRESS=ON")
   (debug-tsan "-DCMAKE_BUILD_TYPE=Debug -DSANITIZE_THREAD=ON")
+  (debug-ubsan "-DCMAKE_BUILD_TYPE=Debug -DSANITIZE_UB=ON")
 
   (gcc-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10")
-  (gcc-release-asan "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE=ON")
+  (gcc-release-asan "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_ADDRESS=ON")
   (gcc-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10")
-  (gcc-debug-asan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE=ON")
+  (gcc-debug-asan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_ADDRESS=ON")
   (gcc-debug-tsan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_THREAD=ON")
 
   (llvm-release "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++")
   (llvm-debug "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++")
-  (llvm-debug-asan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE=ON")
+  (llvm-debug-asan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_ADDRESS=ON")
   (llvm-debug-tsan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_THREAD=ON")
 
   (gcc-static-analysis-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSTATIC_ANALYSIS=ON")

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,9 @@ os_setups:
 
 env:
   global:
-    - SANITIZE=OFF
+    - SANITIZE_ADDRESS=OFF
     - SANITIZE_THREAD=OFF
+    - SANITIZE_UB=OFF
     - SCAN_BUILD=
     - COVERAGE=OFF
     - STATIC_ANALYSIS=OFF
@@ -69,26 +70,34 @@ matrix:
       <<: *gcc10
       env:
         - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release
-    - name: "GCC 10 Release with ASan/UBSan"
+    - name: "GCC 10 Release with ASan"
       <<: *gcc10
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE=ON
-    - name: "GCC 10 Release with TSan/UBSan"
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_ADDRESS=ON
+    - name: "GCC 10 Release with TSan"
       <<: *gcc10
       env:
         - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "GCC 10 Release with UBSan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_UB=ON
     - name: "GCC 10 Debug"
       <<: *gcc10
       env:
         - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug
-    - name: "GCC 10 Debug with ASan/UBSan"
+    - name: "GCC 10 Debug with ASan"
       <<: *gcc10
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE=ON
-    - name: "GCC 10 Debug with TSan/UBSan"
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_ADDRESS=ON
+    - name: "GCC 10 Debug with TSan"
       <<: *gcc10
       env:
         - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "GCC 10 Debug with UBSan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_UB=ON
     - name: "GCC 10 static analysis Release"
       <<: *gcc10
       env:
@@ -101,26 +110,34 @@ matrix:
       <<: *clang11
       env:
         - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Release
-    - name: "clang 11 Release with ASan/UBSan"
+    - name: "clang 11 Release with ASan"
       <<: *clang11
       env:
-        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Release SANITIZE=ON
-    - name: "clang 11 Release with TSan/UBSan"
+        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Release SANITIZE_ADDRESS=ON
+    - name: "clang 11 Release with TSan"
       <<: *clang11
       env:
         - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "clang 11 Release with UBSan"
+      <<: *clang11
+      env:
+        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Release SANITIZE_UB=ON
     - name: "clang 11 Debug"
       <<: *clang11
       env:
         - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Debug
-    - name: "clang 11 Debug with ASan/UBSan"
+    - name: "clang 11 Debug with ASan"
       <<: *clang11
       env:
-        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Debug SANITIZE=ON
-    - name: "clang 11 Debug with TSan/UBSan"
+        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Debug SANITIZE_ADDRESS=ON
+    - name: "clang 11 Debug with TSan"
       <<: *clang11
       env:
         - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "clang 11 Debug with UBSan"
+      <<: *clang11
+      env:
+        - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Debug SANITIZE_UB=ON
     - name: "clang 11 static analysis Release"
       <<: *clang11
       env:
@@ -133,26 +150,34 @@ matrix:
       <<: *macos
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Release
-    - name: "XCode 12.2 Release with ASan/UBSan"
+    - name: "XCode 12.2 Release with ASan"
       <<: *macos
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Release SANITIZE=ON
-    - name: "XCode 12.2 Release with TSan/UBSan"
+        - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Release SANITIZE_ADDRESS=ON
+    - name: "XCode 12.2 Release with TSan"
       <<: *macos
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "XCode 12.2 Release with UBSan"
+      <<: *macos
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Release SANITIZE_UB=ON
     - name: "XCode 12.2 Debug"
       <<: *macos
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Debug
-    - name: "XCode 12.2 Debug with ASan/UBSan"
+    - name: "XCode 12.2 Debug with ASan"
       <<: *macos
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Debug SANITIZE=ON
-    - name: "XCode 12.2 Debug with TSan/UBSan"
+        - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Debug SANITIZE_ADDRESS=ON
+    - name: "XCode 12.2 Debug with TSan"
       <<: *macos
       env:
         - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "XCode 12.2 Debug with UBSan"
+      <<: *macos
+      env:
+        - MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Debug SANITIZE_UB=ON
     - name: "Debug coverage"
       <<: *coverage
       env:
@@ -183,7 +208,7 @@ script:
       brew install lcov;
       EXTRA_CMAKE_OPTIONS+="-DGCOV_PATH=/usr/local/bin/gcov-10 ";
     fi
-  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DSANITIZE=${SANITIZE} -DSANITIZE_THREAD=${SANITIZE_THREAD} -DCOVERAGE=${COVERAGE} -DSTATIC_ANALYSIS=${STATIC_ANALYSIS} ${EXTRA_CMAKE_OPTIONS}
+  - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DSANITIZE_ADDRESS=${SANITIZE_ADDRESS} -DSANITIZE_THREAD=${SANITIZE_THREAD} -DSANITIZE_UB=${SANITIZE_UB} -DCOVERAGE=${COVERAGE} -DSTATIC_ANALYSIS=${STATIC_ANALYSIS} ${EXTRA_CMAKE_OPTIONS}
   - if [[ ! -z "${SCAN_BUILD}" ]]; then
       ${SCAN_BUILD} --status-bugs -stats -analyze-headers --force-analyze-debug-code make -j3;
       travis_terminate 0;
@@ -202,6 +227,6 @@ script:
       make -j3 coverage;
       bash <(curl -s https://codecov.io/bash) -f coverage-coverage.info || echo "Codecov did not collect coverage reports";
     fi
-  - if [[ "$SANITIZE" == "OFF" && "$SANITIZE_THREAD" == "OFF" && "$COVERAGE" == "OFF" && "$TRAVIS_OS_NAME" != "osx" ]]; then
+  - if [[ "$SANITIZE" == "OFF" && "$SANITIZE_THREAD" == "OFF" && "$SANITIZE_UB" == "OFF" && "$COVERAGE" == "OFF" && "$TRAVIS_OS_NAME" != "osx" ]]; then
       make valgrind;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,45 +113,26 @@ else()
   endif()
 endif()
 
-macro(ADD_TO_SANITIZER_FLAGS)
+macro(ADD_TO_GNU_SANITIZER_FLAGS)
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     list(APPEND SANITIZER_CXX_FLAGS ${ARGV})
     list(APPEND SANITIZER_LD_FLAGS ${ARGV})
   endif()
 endmacro()
 
-macro(SET_UBSAN_ENV)
-  string(CONCAT UBSAN_ENV "UBSAN_ENV="
-    "print_stacktrace=1:halt_on_error=1:abort_on_error=1")
-  string(CONCAT SANITIZER_ENV "${ASAN_ENV}" " " "${UBSAN_ENV}")
-endmacro()
-
 macro(SET_COMMON_SANITIZER_FLAGS)
-  list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=undefined"
-    "-fno-omit-frame-pointer" "-fno-optimize-sibling-calls")
-  # Boost library 1.72 on macOS from Homebrew produces the following error:
-  # SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/laurynas/unodb/unodb/heap.hpp:83:8 in 
-  # /usr/local/include/boost/container/pmr/memory_resource.hpp:49:20: runtime error: member call on address 0x000105abd0b
-  # 0 which does not point to an object of type 'boost::container::pmr::memory_resource'
-  # 0x000105abd0b0: note: object is of type 'boost::container::pmr::new_delete_resource_imp'
-  # It looks like it's because new_delete_resource_imp is not exported as a
-  # visible symbol in the library?
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"
-      AND CMAKE_BUILD_TYPE MATCHES "Release")
-    list(APPEND SANITIZER_CXX_FLAGS "-fno-sanitize=vptr")
-  endif()
-  set(SANITIZER_LD_FLAGS "-fsanitize=undefined")
-  set_ubsan_env()
+  list(APPEND SANITIZER_CXX_FLAGS "-fno-omit-frame-pointer"
+    "-fno-optimize-sibling-calls")
 endmacro()
 
-option(SANITIZE
-  "Enable AddressSanitizer and UndefinedBehaviorSanitizer runtime checks")
-if(SANITIZE)
+option(SANITIZE_ADDRESS "Enable AddressSanitizer runtime checks")
+if(SANITIZE_ADDRESS)
   set_common_sanitizer_flags()
   list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=address")
   list(APPEND SANITIZER_LD_FLAGS "-fsanitize=address")
-  add_to_sanitizer_flags("-fsanitize=leak" "-fsanitize-address-use-after-scope"
-    "-fsanitize=pointer-compare" "-fsanitize=pointer-subtract")
+  add_to_gnu_sanitizer_flags("-fsanitize=leak"
+    "-fsanitize-address-use-after-scope" "-fsanitize=pointer-compare"
+    "-fsanitize=pointer-subtract")
   string(CONCAT ASAN_ENV "ASAN_ENV="
     "check_initialization_order=true:detect_stack_use_after_return=true:"
     "alloc_dealloc_mismatch=true:strict_string_checks=true")
@@ -169,15 +150,35 @@ if(SANITIZE)
   if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     string(APPEND ASAN_ENV ":detect_leaks=1")
   endif()
-  set_ubsan_env()
+  set(SANITIZER_ENV ${ASAN_ENV})
 endif()
 
-option(SANITIZE_THREAD
-  "Enable ThreadSanitizer and UndefinedBehaviorSanitizer runtime checks")
+option(SANITIZE_THREAD "Enable ThreadSanitizer runtime checks")
 if(SANITIZE_THREAD)
   set_common_sanitizer_flags()
   list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=thread")
   list(APPEND SANITIZER_LD_FLAGS "-fsanitize=thread")
+endif()
+
+option(SANITIZE_UB "Enable UndefinedBehaviorSanitizer runtime checks")
+if(SANITIZE_UB)
+  set_common_sanitizer_flags()
+  list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=undefined")
+  # Boost library 1.72 on macOS from Homebrew produces the following error:
+  # SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/laurynas/unodb/unodb/heap.hpp:83:8 in
+  # /usr/local/include/boost/container/pmr/memory_resource.hpp:49:20: runtime error: member call on address 0x000105abd0b
+  # 0 which does not point to an object of type 'boost::container::pmr::memory_resource'
+  # 0x000105abd0b0: note: object is of type 'boost::container::pmr::new_delete_resource_imp'
+  # It looks like it's because new_delete_resource_imp is not exported as a
+  # visible symbol in the library?
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"
+      AND CMAKE_BUILD_TYPE MATCHES "Release")
+    list(APPEND SANITIZER_CXX_FLAGS "-fno-sanitize=vptr")
+  endif()
+  set(SANITIZER_LD_FLAGS "-fsanitize=undefined")
+  string(CONCAT UBSAN_ENV "UBSAN_ENV="
+    "print_stacktrace=1:halt_on_error=1:abort_on_error=1")
+  set(SANITIZER_ENV ${UBSAN_ENV})
 endif()
 
 option(STATIC_ANALYSIS "Enable compiler static analysis")
@@ -509,11 +510,8 @@ function(ADD_TEST_TARGET TARGET)
   target_link_libraries("${TARGET}" PRIVATE unodb gtest_main test_utils)
   set_clang_tidy_options("${TARGET}" "${DO_CLANG_TIDY_TEST}")
   add_test(NAME "${TARGET}" COMMAND "${TARGET}")
-  if(SANITIZE)
-    set_tests_properties(${TARGET} PROPERTIES ENVIRONMENT "${ASAN_ENV}")
-  endif()
-  if(SANITIZE OR SANITIZE_THREAD)
-    set_property(TEST ${TARGET} APPEND PROPERTY ENVIRONMENT "${UBSAN_ENV}")
+  if(SANITIZE_ADDRESS OR SANITIZE_THREAD OR SANITIZE_UB)
+    set_property(TEST ${TARGET} APPEND PROPERTY ENVIRONMENT "${SANITIZER_ENV}")
   endif()
 endfunction()
 
@@ -567,19 +565,19 @@ if(DEEPSTATE_LF_OK)
 
   add_custom_target(deepstate_lf_1m
     ${CMAKE_COMMAND} -E make_directory deepstate_lf_corpus
-    COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+    COMMAND env ${SANITIZER_ENV}
     ./test_art_fuzz_deepstate_lf deepstate_lf_corpus/ -use_value_profile=1
     -detect_leaks=0  -max_total_time=60)
 
   add_custom_target(deepstate_lf_20m
     ${CMAKE_COMMAND} -E make_directory deepstate_lf_corpus
-    COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+    COMMAND env ${SANITIZER_ENV}
     ./test_art_fuzz_deepstate_lf deepstate_lf_corpus/ -use_value_profile=1
     -detect_leaks=0  -max_total_time=1200)
 
   add_custom_target(deepstate_lf_8h
     ${CMAKE_COMMAND} -E make_directory deepstate_lf_corpus
-    COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+    COMMAND env ${SANITIZER_ENV}
     ./test_art_fuzz_deepstate_lf deepstate_lf_corpus/ -use_value_profile=1
     -detect_leaks=0  -max_total_time=28800)
 

--- a/README.md
+++ b/README.md
@@ -87,13 +87,17 @@ clang-tidy, cppcheck, and cpplint will be invoked automatically during build if
 found. Currently the diagnostic level for them as well as for compiler warnings
 is set very high, and can be relaxed, especially for clang-tidy, as need arises.
 
-To enable Address, Leak, and Undefined Behavior sanitizers, add `-DSANITIZE=ON`
-CMake option. Using this with GCC 9, where std::pmr from libstdc++ is used
-instead of boost::pmr, will result in UBSan false positives due to
-[this][libstdc++ub]. This option is incompatible with `-DSANITIZE_THREAD=ON`.
+To enable AddressSanitizer and LeakSanitizers, add `-DSANITIZE_ADDRESS=ON` CMake
+option. It is incompatible with `-DSANITIZE_THREAD=ON`.
 
-To enable Thread and Undefined Behavior sanitizers, add `-DSANITIZE_THREAD=ON`
-CMake option. It is incompatible with `-DSANITIZE=ON` option.
+To enable ThreadSanitizer, add `-DSANITIZE_THREAD=ON` CMake option. It is
+incompatible with `-DSANITIZE_ADDRESS=ON`
+
+To enable UndefinedBehaviorSanitizer, add `-DSANITIZE_UB=ON` CMake option. It is
+compatible with both `-DSANITIZE_ADDRESS=ON` and `-DSANITIZE_THREAD=ON` options,
+although some [false positives][sanitizer-combination-bug] might occur. Enabling
+it with GCC, where `std::pmr` from libstdc++ is used instead of `boost::pmr`,
+will result in UBSan false positives due to [this][libstdc++ub].
 
 To enable GCC 10+ compiler static analysis, add `-DSTATIC_ANALYSIS=ON` CMake
 option. For LLVM static analysis, no special CMake option is needed, and you
@@ -122,6 +126,8 @@ doi:10.1109/ICDE.2013.6544812
 [boostub1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80963
 
 [boostub2]: https://bugs.llvm.org/show_bug.cgi?id=39191
+
+[sanitizer-combination-bug]: https://github.com/google/sanitizers/issues/1106
 
 [libstdc++ub]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90442
 


### PR DESCRIPTION
…ig option

- CMakeLists.txt: rename SANITIZE CMake option to SANITIZE_ADDRESS, move UB
  parts to a new option SANITIZE_UB, rename ADD_TO_SANITIZER_FLAGS to
  ADD_TO_GNU_SANITIZER_FLAGS, which was a better name all along. Remove
  SET_UBSAN_ENV macro, refactor things.
- Update Travis-CI config
- Update and add a "debug-ubsan" config to .cmake-build.el
- Update README.md