### PR TITLE
Add the "Super-Linter" Github action from their quickstart docs

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,10 @@
+{
+    "threshold": 20,
+    "reporters": [
+        "consoleFull"
+    ],
+    "ignore": [
+        "**/__snapshots__/**"
+    ],
+    "absolute": true
+}

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,25 @@
+name: Super-Linter
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  super-lint:
+    # Name the Job
+    name: Lint code base
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Runs the Super-Linter action
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build
 Status](https://travis-ci.org/laurynas-biveinis/unodb.svg?branch=master)](https://travis-ci.org/laurynas-biveinis/unodb)
 [![codecov](https://codecov.io/gh/laurynas-biveinis/unodb/branch/master/graph/badge.svg)](https://codecov.io/gh/laurynas-biveinis/unodb)
+[![GitHub Super-Linter](https://github.com/laurynas-biveinis/unodb/workflows/Lint%20code%20base/badge.svg)](https://github.com/marketplace/actions/super-linter)
 
 ## Introduction
 

--- a/pmci-lightstar
+++ b/pmci-lightstar
@@ -4,20 +4,20 @@
 
 readonly WORKDIR=$1
 
-mkdir $WORKDIR
-pushd $WORKDIR
+mkdir "$WORKDIR"
+pushd "$WORKDIR" || exit 1
 
 cmake ../unodb/ -DCMAKE_BUILD_TYPE=Release -DCPPCHECK_AGGRESSIVE=ON
 make -j4 -k
-rm -rf *
+rm -rf ./*
 
 cmake ../unodb/ -DCMAKE_BUILD_TYPE=Debug -DCPPCHECK_AGGRESSIVE=ON
 make -j4 -k
-rm -rf *
+rm -rf ./*
 
-pushd ../unodb
+pushd ../unodb || exit 1
 ../FlintPlusPlus/flint/flint++
-popd
+popd || exit 1
 
-popd
-rm -rf $WORKDIR
+popd || exit 1
+rm -rf "$WORKDIR"

--- a/pmci-unostar
+++ b/pmci-unostar
@@ -3,24 +3,24 @@
 
 readonly WORKDIR=$1
 
-mkdir $WORKDIR
-pushd $WORKDIR
+mkdir "$WORKDIR"
+pushd "$WORKDIR" || exit 1
 
 cmake ../unodb -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_BUILD_TYPE=Release -DCPPCHECK_AGGRESSIVE=ON
 make -j4
-rm -rf *
+rm -rf ./*
 
 cmake ../unodb -DCMAKE_C_COMPILER=gcc-8 -DCMAKE_CXX_COMPILER=g++-8 -DCMAKE_BUILD_TYPE=Debug -DCPPCHECK_AGGRESSIVE=ON
 make -j4
-rm -rf *
+rm -rf ./*
 
 cmake ../unodb -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Release -DIWYU=ON
 make -j4
-rm -rf *
+rm -rf ./*
 
 cmake ../unodb -DCMAKE_C_COMPILER=clang-8 -DCMAKE_CXX_COMPILER=clang++-8 -DCMAKE_BUILD_TYPE=Debug -DIWYU=ON
 make -j4
-rm -rf *
+rm -rf ./*
 
-popd
-rm -rf $WORKDIR
+popd || exit 1
+rm -rf "$WORKDIR"


### PR DESCRIPTION
- Fix the old pmci scripts for shellcheck
- Add a badge
- Configure jscpd linter to raise its duplication threshold due to the way our
  tests and benchmarks look