### PR TITLE
Port Travis CI config to Github Actions. Fix wrong sanitizer environm…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,347 @@
+name: build
+
+on: [push]
+
+env:
+  DEFAULT_COMPILER: gcc
+  DEFAULT_SANITIZE_ADDRESS: OFF
+  DEFAULT_SANITIZE_THREAD: OFF
+  DEFAULT_SANITIZE_UB: OFF
+  DEFAULT_STATIC_ANALYSIS: OFF
+  DEFAULT_CPPLINT: OFF
+  DEFAULT_CPPCHECK: OFF
+  DEFAULT_COVERAGE: OFF
+
+jobs:
+  build:
+    runs-on: ${{matrix.os}}
+
+    env:
+      BUILD_TYPE: ${{matrix.BUILD_TYPE}}
+      SANITIZE_ADDRESS: ${{matrix.SANITIZE_ADDRESS}}
+      SANITIZE_THREAD: ${{matrix.SANITIZE_THREAD}}
+      SANITIZE_UB: ${{matrix.SANITIZE_UB}}
+      STATIC_ANALYSIS: ${{matrix.STATIC_ANALYSIS}}
+      COVERAGE: ${{matrix.COVERAGE}}
+      COMPILER: ${{matrix.COMPILER}}
+      CPPLINT: ${{matrix.CPPLINT}}
+      CPPCHECK: ${{matrix.CPPCHECK}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: GCC 10 Release
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+
+          - name: GCC 10 Release with ASan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+
+          - name: GCC 10 Release with TSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+
+          - name: GCC 10 Release with UBSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+
+          - name: GCC 10 Debug
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+
+          - name: GCC 10 Debug with ASan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+
+          - name: GCC 10 Debug with TSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+
+          - name: GCC 10 Debug with UBSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+
+          - name: GCC 10 Release static analysis & cpplint
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            STATIC_ANALYSIS: ON
+            CPPLINT: ON
+
+# Compilation gets killed, presumably by the OOM killer
+#          - name: GCC 10 Debug static analysis
+#            os: ubuntu-20.04
+#            BUILD_TYPE: Debug
+#            STATIC_ANALYSIS: ON
+
+          - name: clang 11 Release
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            COMPILER: clang
+
+          - name: clang 11 Release with ASan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+
+          - name: clang 11 Release with TSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+
+          - name: clang 11 Release with UBSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: clang
+
+          - name: clang 11 Debug
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            COMPILER: clang
+
+          - name: clang 11 Debug with ASan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+
+          - name: clang 11 Debug with TSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+
+          - name: clang 11 Debug with UBSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: clang
+
+          - name: clang 11 Release static analysis
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            COMPILER: clang
+            STATIC_ANALYSIS: ON
+
+          - name: clang 11 Debug static analysis
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            COMPILER: clang
+            STATIC_ANALYSIS: ON
+
+          - name: XCode Release
+            os: macos-latest
+            BUILD_TYPE: Release
+            COMPILER: macos-clang
+
+          - name: XCode Release with ASan
+            os: macos-latest
+            BUILD_TYPE: Release
+            COMPILER: macos-clang
+            SANITIZE_ADDRESS: ON
+
+          - name: XCode Release with TSan
+            os: macos-latest
+            BUILD_TYPE: Release
+            COMPILER: macos-clang
+            SANITIZE_THREAD: ON
+
+          - name: XCode Release with UBSan
+            os: macos-latest
+            BUILD_TYPE: Release
+            COMPILER: macos-clang
+            SANITIZE_UB: ON
+
+          - name: XCode Debug with cppcheck
+            os: macos-latest
+            BUILD_TYPE: Debug
+            COMPILER: macos-clang
+            CPPCHECK: ON
+
+          - name: XCode Debug with ASan
+            os: macos-latest
+            BUILD_TYPE: Debug
+            COMPILER: macos-clang
+            SANITIZE_ADDRESS: ON
+
+          - name: XCode Debug with TSan
+            os: macos-latest
+            BUILD_TYPE: Debug
+            COMPILER: macos-clang
+            SANITIZE_THREAD: ON
+
+          - name: XCode Debug with UBSan
+            os: macos-latest
+            BUILD_TYPE: Debug
+            COMPILER: macos-clang
+            SANITIZE_UB: ON
+
+          - name: Debug coverage
+            os: macos-latest
+            BUILD_TYPE: Debug
+            COMPILER: gcc
+            COVERAGE: ON
+
+          - name: Release coverage
+            os: macos-latest
+            BUILD_TYPE: Release
+            COMPILER: gcc
+            COVERAGE: ON
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Setup dependencies for Linux
+        run: |
+          COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
+          CPPLINT="${CPPLINT:-$DEFAULT_CPPLINT}"
+          SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-$DEFAULT_SANITIZE_ADDRESS}"
+          SANITIZE_THREAD="${SANITIZE_THREAD:-$DEFAULT_SANITIZE_THREAD}"
+          SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
+          STATIC_ANALYSIS="${STATIC_ANALYSIS:-$DEFAULT_STATIC_ANALYSIS}"
+          if [[ $COMPILER == "clang" ]]; then
+            sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
+            curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
+            | sudo apt-key add -
+            echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' \
+            | sudo tee -a /etc/apt/sources.list
+          fi
+          sudo apt-get update
+          if [[ $SANITIZE_ADDRESS != "ON" && $SANITIZE_THREAD != "ON" \
+              && $SANITIZE_UB != "ON" && $STATIC_ANALYSIS != "ON" ]]; then
+            sudo apt-get install -y valgrind
+          fi
+          if [[ $COMPILER == "gcc" ]]; then
+            sudo apt-get install -y g++-10
+          elif [[ $COMPILER == "clang" ]]; then
+            sudo apt-get install -y boost1.73 clang-11
+            if [[ $BUILD_TYPE == "Release" ]]; then
+              sudo apt-get install -y llvm-11-dev lld-11
+            fi
+            if [[ $STATIC_ANALYSIS == "ON" ]]; then
+              sudo apt-get install -y clang-tools-11
+            else
+              sudo apt-get install -y clang-tidy-11
+            fi
+          fi
+          if [[ $CPPLINT == "ON" ]]; then
+            pip install cpplint
+          fi
+        if: runner.os == 'Linux'
+
+      - name: Set up dependencies for macOS
+        run: |
+          CPPCHECK="${CPPCHECK:-$DEFAULT_CPPCHECK}"
+          COVERAGE="${COVERAGE:-$DEFAULT_COVERAGE}"
+          brew install boost
+          if [[ $CPPCHECK == "ON" ]]; then
+            brew install cppcheck
+          fi
+          if [[ $COVERAGE == "ON" ]]; then
+            brew install cpanm lcov
+            sudo cpanm install JSON
+          fi
+        if: runner.os == 'macOS'
+
+      - name: Create build environment
+        run: mkdir ${{github.workspace}}/build
+
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment
+        # variable access regardless of the host operating system
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: |
+          COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
+          SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-$DEFAULT_SANITIZE_ADDRESS}"
+          SANITIZE_THREAD="${SANITIZE_THREAD:-$DEFAULT_SANITIZE_THREAD}"
+          SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
+          STATIC_ANALYSIS="${STATIC_ANALYSIS:-$DEFAULT_STATIC_ANALYSIS}"
+          COVERAGE="${COVERAGE:-$DEFAULT_COVERAGE}"
+          export PATH=$HOME/.local/bin:$PATH
+          if [[ $COMPILER == "gcc" ]]; then
+            export CC=gcc-10
+            export CXX=g++-10
+            if [[ $COVERAGE == "ON" ]]; then
+              EXTRA_CMAKE_ARGS="-DGCOV_PATH=/usr/local/bin/gcov-10"
+            fi
+          elif [[ $COMPILER == "clang" ]]; then
+            export CC=clang-11
+            export CXX=clang++-11
+            EXTRA_CMAKE_ARGS=
+            if [[ $BUILD_TYPE == "Release" ]]; then
+              EXTRA_CMAKE_ARGS+="-DLLVMAR_EXECUTABLE=/usr/bin/llvm-ar-11 \
+                -DLLVMNM_EXECUTABLE=/usr/bin/llvm-nm-11 \
+                -DLLVMRANLIB_EXECUTABLE=/usr/bin/llvm-ranlib-11"
+            fi
+            # LLVM static analysis wart
+            if [[ $STATIC_ANALYSIS == "ON" ]]; then
+              STATIC_ANALYSIS=OFF
+            else
+              EXTRA_CMAKE_ARGS+=" -DCLANG_TIDY_EXE=/usr/bin/clang-tidy-11"
+            fi
+          elif [[ $COMPILER == "macos-clang" ]]; then
+            export CC=clang
+            export CXX=clang++
+          fi
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DSANITIZE_ADDRESS=${SANITIZE_ADDRESS} \
+          -DSANITIZE_THREAD=${SANITIZE_THREAD} -DSANITIZE_UB=${SANITIZE_UB} \
+          -DSTATIC_ANALYSIS=${STATIC_ANALYSIS} -DCOVERAGE=${COVERAGE} \
+          ${EXTRA_CMAKE_ARGS}
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: |
+          COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
+          STATIC_ANALYSIS="${STATIC_ANALYSIS:-$DEFAULT_STATIC_ANALYSIS}"
+          if [[ $STATIC_ANALYSIS == "ON" && $COMPILER == "clang" ]]; then
+            /usr/bin/scan-build-11 --status-bugs -stats -analyze-headers \
+              --force-analyze-debug-code make -j3;
+          else
+            make -j3
+          fi
+
+      - name: Correctness test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -j3 -V
+        if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
+
+      - name: Benchmark correctness test
+        working-directory: ${{github.workspace}}/build
+        run: make quick_benchmarks
+        if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
+
+      - name: Valgrind test
+        working-directory: ${{github.workspace}}/build
+        run: make valgrind
+        if: >
+          env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
+          && env.SANITIZE_UB != 'ON' && env.STATIC_ANALYSIS != 'ON'
+          && runner.os == 'Linux' && env.COVERAGE != 'ON'
+
+      - name: Gather coverage data
+        working-directory: ${{github.workspace}}/build
+        run: |
+          make -j3 coverage
+        if: env.COVERAGE == 'ON'
+
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+          directory: ${{github.workspace}}/build
+          functionalities: gcov
+        if: env.COVERAGE == 'ON'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ compile_commands.json
 
 # cmake-build.el build dirs
 build.*
+!build.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,18 +133,21 @@ if(SANITIZE_ADDRESS)
   add_to_gnu_sanitizer_flags("-fsanitize=leak"
     "-fsanitize-address-use-after-scope" "-fsanitize=pointer-compare"
     "-fsanitize=pointer-subtract")
-  string(CONCAT ASAN_ENV "ASAN_ENV="
+  string(CONCAT ASAN_ENV "ASAN_OPTIONS="
     "check_initialization_order=true:detect_stack_use_after_return=true:"
     "alloc_dealloc_mismatch=true:strict_string_checks=true")
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
-      "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 8)
-    # ERROR: AddressSanitizer: invalid-pointer-pair: 0x7fffe8404697
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+      OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    # Not for GCC, up to version 10 at least, because:
+    # 1) AddressSanitizer CHECK failed:
+    # ../../../../src/libsanitizer/asan/asan_thread.cpp:369 "((bottom)) != (0)"
+    # (0x0, 0x0)
+    # https://bugs.llvm.org/show_bug.cgi?id=47626
+    # 2) ERROR: AddressSanitizer: invalid-pointer-pair: 0x7fffe8404697
     # 0x000000000000
     # #0 0x55d21abf7a40 in std::__cxx11::basic_stringbuf<char,
     # std::char_traits<char>, std::allocator<char> >::str() const
     # /usr/include/c++/8/sstream:173
-    string(APPEND ASAN_ENV ":detect_invalid_pointer_pairs=1")
-  else()
     string(APPEND ASAN_ENV ":detect_invalid_pointer_pairs=2")
   endif()
   if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
@@ -165,18 +168,23 @@ if(SANITIZE_UB)
   set_common_sanitizer_flags()
   list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=undefined")
   # Boost library 1.72 on macOS from Homebrew produces the following error:
-  # SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/laurynas/unodb/unodb/heap.hpp:83:8 in
-  # /usr/local/include/boost/container/pmr/memory_resource.hpp:49:20: runtime error: member call on address 0x000105abd0b
-  # 0 which does not point to an object of type 'boost::container::pmr::memory_resource'
-  # 0x000105abd0b0: note: object is of type 'boost::container::pmr::new_delete_resource_imp'
+  # SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
+  # /Users/laurynas/unodb/unodb/heap.hpp:83:8 in
+  # /usr/local/include/boost/container/pmr/memory_resource.hpp:49:20: runtime
+  # error: member call on address 0x000105abd0b
+  # 0 which does not point to an object of type
+  # 'boost::container::pmr::memory_resource'
+  # 0x000105abd0b0: note: object is of type
+  # 'boost::container::pmr::new_delete_resource_imp'
   # It looks like it's because new_delete_resource_imp is not exported as a
-  # visible symbol in the library?
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"
-      AND CMAKE_BUILD_TYPE MATCHES "Release")
+  # visible symbol in the library? I.e.
+  # https://bugs.llvm.org/show_bug.cgi?id=39191,
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80963
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     list(APPEND SANITIZER_CXX_FLAGS "-fno-sanitize=vptr")
   endif()
   set(SANITIZER_LD_FLAGS "-fsanitize=undefined")
-  string(CONCAT UBSAN_ENV "UBSAN_ENV="
+  string(CONCAT UBSAN_ENV "UBSAN_OPTIONS="
     "print_stacktrace=1:halt_on_error=1:abort_on_error=1")
   set(SANITIZER_ENV ${UBSAN_ENV})
 endif()

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # unodb
 
-[![Build
-Status](https://travis-ci.org/laurynas-biveinis/unodb.svg?branch=master)](https://travis-ci.org/laurynas-biveinis/unodb)
+[![Github Actions Build Status](https://github.com/laurynas-biveinis/unodb/workflows/build/badge.svg)](https://github.com/laurynas-biveinis/unodb/actions?query=workflow%3Abuild)
 [![codecov](https://codecov.io/gh/laurynas-biveinis/unodb/branch/master/graph/badge.svg)](https://codecov.io/gh/laurynas-biveinis/unodb)
-[![GitHub Super-Linter](https://github.com/laurynas-biveinis/unodb/workflows/Super-Linter/badge.svg)](https://github.com/marketplace/actions/super-linter)
+[![GitHub
+Super-Linter](https://github.com/laurynas-biveinis/unodb/workflows/Super-Linter/badge.svg)](https://github.com/marketplace/actions/super-linter)
+[![Travis-CI Build
+Status](https://travis-ci.org/laurynas-biveinis/unodb.svg?branch=master)](https://travis-ci.org/laurynas-biveinis/unodb)
 
 ## Introduction
 


### PR DESCRIPTION
…ent variables

Fixing the wrong sanitizer environment variables uncovered more issues fixed as
follows:
- Disable detect_invalid_pointer_pairs for GCC builds due to internal ASan crash (https://bugs.llvm.org/show_bug.cgi?id=47626).
- Disable dynamic type checking for UBSan on macOS due to
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80963 /
https://bugs.llvm.org/show_bug.cgi?id=39191