### PR TITLE
Cleanup leaf destruction

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -18,7 +18,7 @@ namespace unodb {
 namespace detail {
 
 struct leaf;
-class raii_leaf_creator;
+class db_leaf_deleter;
 
 // Internal ART key in binary-comparable format
 template <typename KeyType>
@@ -248,6 +248,8 @@ class db final {
   __attribute__((cold, noinline)) void dump(std::ostream &os) const;
 
  private:
+  void delete_subtree(detail::node_ptr) noexcept;
+
   constexpr void increase_memory_use(std::size_t delta) noexcept {
     current_memory_use += delta;
   }
@@ -280,7 +282,11 @@ class db final {
   std::uint64_t key_prefix_splits{0};
 
   friend struct detail::leaf;
-  friend class detail::raii_leaf_creator;
+  friend class detail::db_leaf_deleter;
+  friend class detail::inode_4;
+  friend class detail::inode_16;
+  friend class detail::inode_48;
+  friend class detail::inode_256;
 };
 
 }  // namespace unodb


### PR DESCRIPTION
- Replace leaf_unique_ptr and its leaf_deleter with a db_leaf_unique_ptr /
  db_leaf_deleter. The new deleter takes a db instance argument and manages the
  leaf bookkeeping in the tree.
- Simplify delete_node_ptr_at_scope_exit not to have an unique_ptr union, but to
  have a regular node_ptr union, and construct the right unique_ptr on
  destruction.
- Convert delete_subtree helper to a db class method.
- Get rid of raii_leaf_creator kludge class.