### PR TITLE
Annotate unreachable code with LCOV_EXCL macros

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -499,7 +499,7 @@ class delete_db_node_ptr_at_scope_exit final {
         return;
       }
     }
-    cannot_happen();
+    cannot_happen();  // LCOV_EXCL_LINE
   }
 
   delete_db_node_ptr_at_scope_exit(const delete_db_node_ptr_at_scope_exit &) =
@@ -1425,10 +1425,12 @@ constexpr inline bool inode::is_full() const noexcept {
       return static_cast<const inode_48 *>(this)->is_full();
     case node_type::I256:
       return static_cast<const inode_256 *>(this)->is_full();
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
   }
   cannot_happen();
+  // LCOV_EXCL_STOP
 }
 
 constexpr inline bool inode::is_min_size() const noexcept {
@@ -1441,10 +1443,12 @@ constexpr inline bool inode::is_min_size() const noexcept {
       return static_cast<const inode_48 *>(this)->is_min_size();
     case node_type::I256:
       return static_cast<const inode_256 *>(this)->is_min_size();
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
   }
   cannot_happen();
+  // LCOV_EXCL_STOP
 }
 
 inline void inode::add(db_leaf_unique_ptr &&child, tree_depth depth) noexcept {
@@ -1464,8 +1468,10 @@ inline void inode::add(db_leaf_unique_ptr &&child, tree_depth depth) noexcept {
     case node_type::I256:
       static_cast<inode_256 *>(this)->add(std::move(child), depth);
       break;
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
+      // LCOV_EXCL_STOP
   }
 }
 
@@ -1486,8 +1492,10 @@ constexpr inline void inode::remove(std::uint8_t child_index,
     case node_type::I256:
       static_cast<inode_256 *>(this)->remove(child_index, db_instance);
       break;
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
+      // LCOV_EXCL_STOP
   }
 }
 
@@ -1502,10 +1510,12 @@ constexpr inline inode::find_result_type inode::find_child(
       return static_cast<inode_48 *>(this)->find_child(key_byte);
     case node_type::I256:
       return static_cast<inode_256 *>(this)->find_child(key_byte);
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
   }
   cannot_happen();
+  // LCOV_EXCL_STOP
 }
 
 constexpr void inode::delete_subtree(db &db_instance) noexcept {
@@ -1518,10 +1528,12 @@ constexpr void inode::delete_subtree(db &db_instance) noexcept {
       return static_cast<inode_48 *>(this)->delete_subtree(db_instance);
     case node_type::I256:
       return static_cast<inode_256 *>(this)->delete_subtree(db_instance);
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
   }
   cannot_happen();
+  // LCOV_EXCL_STOP
 }
 
 void inode::dump(std::ostream &os) const {
@@ -1538,8 +1550,10 @@ void inode::dump(std::ostream &os) const {
     case node_type::I256:
       os << "I256: ";
       break;
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
+      // LCOV_EXCL_STOP
   }
   os << "# children = "
      << (f.f.children_count == 0 ? 256
@@ -1558,8 +1572,10 @@ void inode::dump(std::ostream &os) const {
     case node_type::I256:
       static_cast<const inode_256 *>(this)->dump(os);
       break;
+    // LCOV_EXCL_START
     case node_type::LEAF:
       cannot_happen();
+      // LCOV_EXCL_STOP
   }
 }
 

--- a/global.hpp
+++ b/global.hpp
@@ -58,10 +58,12 @@
 #define likely(x) __builtin_expect(x, 1)
 #define unlikely(x) __builtin_expect(x, 0)
 
+// LCOV_EXCL_START
 inline __attribute__((noreturn)) void cannot_happen() {
   assert(0);
   __builtin_unreachable();
 }
+// LCOV_EXCL_STOP
 
 #ifdef NDEBUG
 #define USED_IN_DEBUG __attribute__((unused))

--- a/heap.hpp
+++ b/heap.hpp
@@ -59,7 +59,7 @@ using pmr_unsynchronized_pool_resource =
 #endif
 
 template <typename T>
-constexpr std::size_t alignment_for_new() noexcept {
+constexpr auto alignment_for_new() noexcept {
   return std::max(alignof(T),
                   static_cast<std::size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__));
 }

--- a/test_utils.hpp
+++ b/test_utils.hpp
@@ -46,9 +46,11 @@ void assert_result_eq(Db &db, unodb::key key, unodb::value_view expected,
   testing::ScopedTrace trace(__FILE__, caller_line, msg.str());
   const auto result = db.get(key);
   if (!result) {
+    // LCOV_EXCL_START
     std::cerr << "db.get did not find key: " << key << '\n';
     db.dump(std::cerr);
     FAIL();
+    // LCOV_EXCL_STOP
   }
   ASSERT_TRUE(std::equal(result->cbegin(), result->cend(), expected.cbegin(),
                          expected.cend()));
@@ -145,9 +147,11 @@ class tree_verifier final {
     ASSERT_TRUE(mem_use_before > 0);
 
     if (!test_db.remove(k)) {
+      // LCOV_EXCL_START
       std::cerr << "test_db.remove failed for key " << k << '\n';
       test_db.dump(std::cerr);
       FAIL();
+      // LCOV_EXCL_STOP
     }
 
     if (!parallel_test) {
@@ -215,10 +219,12 @@ class tree_verifier final {
     }
     if (inode4_count.has_value() &&
         test_db.get_inode4_count() != *inode4_count) {
+      // LCOV_EXCL_START
       std::cerr << "inode4 count mismatch! Expected: " << *inode4_count
                 << ", actual: " << test_db.get_inode4_count() << '\n';
       test_db.dump(std::cerr);
       FAIL();
+      // LCOV_EXCL_STOP
     }
     if (inode16_count.has_value()) {
       ASSERT_EQ(test_db.get_inode16_count(), *inode16_count);


### PR DESCRIPTION
to exclude such code from coverage reports.

At the same time change the return type of alignment_for_new to auto.