### PR TITLE
Fix node addresses in the dumps

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -1878,9 +1878,9 @@ void db::clear() {
 namespace {
 
 void dump_node(std::ostream &os, const unodb::detail::node_ptr &node) {
-  os << "node at: " << &node;
+  os << "node at: " << node.header;
   if (node.header == nullptr) {
-    os << ", <null>\n";
+    os << '\n';
     return;
   }
   os << ", type = ";


### PR DESCRIPTION
Print the actual node address, not the address of the pointer pointing to the
node being dumped.