### PR TITLE
The initial implementation of OLC ART

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,13 +212,14 @@ jobs:
           SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
           STATIC_ANALYSIS="${STATIC_ANALYSIS:-$DEFAULT_STATIC_ANALYSIS}"
           if [[ $COMPILER == "clang" ]]; then
-            sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
             curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
             | sudo apt-key add -
             echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' \
             | sudo tee -a /etc/apt/sources.list
           fi
+          sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
           sudo apt-get update
+          sudo apt-get install -y boost1.74
           if [[ $SANITIZE_ADDRESS != "ON" && $SANITIZE_THREAD != "ON" \
               && $SANITIZE_UB != "ON" && $STATIC_ANALYSIS != "ON" ]]; then
             sudo apt-get install -y valgrind
@@ -226,7 +227,7 @@ jobs:
           if [[ $COMPILER == "gcc" ]]; then
             sudo apt-get install -y g++-10
           elif [[ $COMPILER == "clang" ]]; then
-            sudo apt-get install -y boost1.74 clang-11
+            sudo apt-get install -y clang-11
             if [[ $BUILD_TYPE == "Release" ]]; then
               sudo apt-get install -y llvm-11-dev lld-11
             fi
@@ -246,9 +247,7 @@ jobs:
           CPPCHECK="${CPPCHECK:-$DEFAULT_CPPCHECK}"
           COVERAGE="${COVERAGE:-$DEFAULT_COVERAGE}"
           COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
-          if [[ $COMPILER != "gcc" ]]; then
-            brew install boost
-          fi
+          brew install boost
           if [[ $CPPCHECK == "ON" ]]; then
             brew install cppcheck
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ os_setups:
     compiler: gcc
     addons:
       apt:
+        sources:
+          - sourceline: 'ppa:mhier/libboost-latest'
         packages:
           - python3-pip
+          - boost1.73
           - g++-10
           - valgrind
   clang11_setup: &clang11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 Laurynas Biveinis
+# Copyright 2019-2021 Laurynas Biveinis
 cmake_minimum_required(VERSION 3.12)
 
 project(unodb VERSION 0.1
@@ -203,8 +203,8 @@ find_package(Threads REQUIRED)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   message(STATUS "Using GCC, using std::pmr instead of boost::pmr")
-  set(USE_BOOST FALSE)
 else()
+  list(APPEND BOOST_COMPONENTS container)
   # Workaround https://github.com/boostorg/boost_install/issues/13: Homebrew
   # Boost 1.71 installs single-thread and MT build to the same prefix, resulting
   # in -
@@ -213,9 +213,9 @@ else()
   # '/usr/local/lib/libboost_container-mt.dylib', which will be overwritten
   # with '/usr/local/lib/libboost_container.dylib'
   set(Boost_NO_BOOST_CMAKE ON)
-  find_package(Boost REQUIRED COMPONENTS container)
-  set(USE_BOOST TRUE)
 endif()
+
+find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 
 string(REPLACE ";" " " CXX_FLAGS_FOR_SUBDIR_STR "${SANITIZER_CXX_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS ${CXX_FLAGS_FOR_SUBDIR_STR})
@@ -303,8 +303,10 @@ else()
   else()
     message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
     string(CONCAT CLANG_TIDY_DISABLED
-      "-fuchsia-default-arguments,"
+      "-bugprone-use-after-move,"
       "-clang-diagnostic-error,"
+      # Moved-from object states are asserted
+      "-clang-analyzer-cplusplus.Move,"
       # Duplicated by modernize-avoid-c-arrays
       "-cppcoreguidelines-avoid-c-arrays,"
       "-cppcoreguidelines-avoid-magic-numbers,"
@@ -323,6 +325,7 @@ else()
       "-cppcoreguidelines-pro-type-reinterpret-cast,"
       "-cppcoreguidelines-pro-type-static-cast-downcast,"
       "-cppcoreguidelines-pro-type-union-access,"
+      "-fuchsia-default-arguments,"
       "-fuchsia-default-arguments-calls,"
       "-fuchsia-overloaded-operator,"
       "-google-readability-braces-around-statements,"
@@ -330,6 +333,7 @@ else()
       # Duplicated by modernize-avoid-c-arrays
       "-hicpp-avoid-c-arrays,"
       "-hicpp-braces-around-statements,"
+      "-hicpp-invalid-access-moved,"
       "-hicpp-member-init,"
       "-hicpp-named-parameter,"
       "-hicpp-no-array-decay,"
@@ -408,6 +412,7 @@ else()
   string(CONCAT CPPLINT_DISABLED_TESTS "--filter="
     "-build/c++11," # <thread> is an unapproved C++11 header
     "-build/include_order,"
+    "-build/include_subdir,"
     "-readability/nolint," # clang-tidy owns NOLINT
     "-runtime/references,"
     # Does not understand C++17 structured bindings and we use clang-format
@@ -469,17 +474,24 @@ function(SET_CLANG_TIDY_OPTIONS TARGET COMMAND)
   endif()
 endfunction()
 
-add_library(unodb art.cpp art.hpp art_common.hpp global.hpp mutex_art.hpp
-  heap.hpp)
+add_library(unodb_qsbr qsbr.cpp qsbr.hpp heap.hpp global.hpp
+  debug_thread_sync.h)
+common_target_properties(unodb_qsbr)
+target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
+if(DO_CLANG_TIDY)
+  set_target_properties(unodb_qsbr PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
+endif()
+target_link_libraries(unodb_qsbr PUBLIC Threads::Threads)
+
+add_library(unodb art.cpp art.hpp art_common.hpp mutex_art.hpp
+  optimistic_lock.hpp art_internal_impl.hpp olc_art.hpp olc_art.cpp
+  art_internal.hpp)
 common_target_properties(unodb)
+target_link_libraries(unodb PUBLIC unodb_qsbr)
 target_include_directories(unodb PUBLIC ".")
 target_include_directories(unodb SYSTEM PUBLIC "${GSL_INCLUDES}")
-if(USE_BOOST)
-  target_include_directories(unodb SYSTEM PRIVATE "${Boost_INCLUDE_DIRS}")
-  target_link_libraries(unodb PRIVATE "${Boost_LIBRARIES}")
-endif()
 set_clang_tidy_options(unodb "${DO_CLANG_TIDY}")
-target_link_libraries(unodb PUBLIC Threads::Threads)
 
 enable_testing()
 
@@ -507,15 +519,23 @@ function(ADD_COVERAGE_TARGET)
     DEPENDS ${ARG_DEPENDENCY})
 endfunction()
 
-add_library(test_utils STATIC test_utils.hpp test_utils.cpp)
-common_target_properties(test_utils)
-target_link_libraries(test_utils PRIVATE unodb gtest_main)
-set_clang_tidy_options(test_utils "${DO_CLANG_TIDY_TEST}")
+add_library(db_test_utils STATIC db_test_utils.hpp db_test_utils.cpp)
+common_target_properties(db_test_utils)
+target_link_libraries(db_test_utils PRIVATE unodb gtest_main)
+set_clang_tidy_options(db_test_utils "${DO_CLANG_TIDY_TEST}")
 
+# FIXME(laurynas): unduplicate
+add_library(qsbr_test_utils STATIC qsbr_test_utils.hpp qsbr_test_utils.cpp)
+common_target_properties(qsbr_test_utils)
+target_link_libraries(qsbr_test_utils PRIVATE unodb_qsbr gtest_main)
+set_clang_tidy_options(qsbr_test_utils "${DO_CLANG_TIDY_TEST}")
+
+# FIXME(laurynas): merge with add_db_test_target, pass which test utils libs
+# to link with
 function(ADD_TEST_TARGET TARGET)
   add_executable("${TARGET}" "${TARGET}.cpp")
   common_target_properties("${TARGET}")
-  target_link_libraries("${TARGET}" PRIVATE unodb gtest_main test_utils)
+  target_link_libraries("${TARGET}" PRIVATE unodb_qsbr gtest_main)
   set_clang_tidy_options("${TARGET}" "${DO_CLANG_TIDY_TEST}")
   add_test(NAME "${TARGET}" COMMAND "${TARGET}")
   if(SANITIZE_ADDRESS OR SANITIZE_THREAD OR SANITIZE_UB)
@@ -523,12 +543,22 @@ function(ADD_TEST_TARGET TARGET)
   endif()
 endfunction()
 
-add_test_target(test_art)
-add_test_target(test_art_mutex_concurrency)
+function(ADD_DB_TEST_TARGET TARGET)
+  add_test_target("${TARGET}")
+  target_link_libraries("${TARGET}" PRIVATE unodb db_test_utils)
+endfunction()
+
+add_test_target(test_qsbr)
+target_link_libraries(test_qsbr PRIVATE qsbr_test_utils)
+add_db_test_target(test_art)
+add_db_test_target(test_art_mutex_concurrency)
+add_db_test_target(test_olc_art_concurrency)
+target_link_libraries(test_olc_art_concurrency PRIVATE qsbr_test_utils)
 
 if(COVERAGE)
   add_custom_target(tests_for_coverage ctest -E test_art_fuzz_deepstate
-    DEPENDS test_art test_art_mutex_concurrency)
+    DEPENDS test_art test_art_mutex_concurrency test_qsbr
+    test_olc_art_concurrency)
   add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)
 endif()
 

--- a/art.hpp
+++ b/art.hpp
@@ -1,90 +1,34 @@
-// Copyright 2019-2020 Laurynas Biveinis
+// Copyright 2019-2021 Laurynas Biveinis
 #ifndef UNODB_ART_HPP_
 #define UNODB_ART_HPP_
 
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cassert>
-#include <cstddef>  // for std::uint8_t
-#include <cstdint>  // IWYU pragma: keep
-#include <cstring>
-#include <memory>
-#include <vector>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
 
 #include "art_common.hpp"
+#include "art_internal.hpp"
 
 namespace unodb {
 
 namespace detail {
 
-struct leaf;
-class db_leaf_deleter;
-
-// Internal ART key in binary-comparable format
-template <typename KeyType>
-struct basic_art_key final {
-  [[nodiscard]] constexpr static KeyType make_binary_comparable(
-      KeyType key) noexcept;
-
-  constexpr basic_art_key() noexcept = default;
-
-  constexpr explicit basic_art_key(KeyType key_) noexcept
-      : key{make_binary_comparable(key_)} {}
-
-  [[nodiscard]] constexpr static auto create(const std::byte from[]) noexcept {
-    struct basic_art_key result;
-    std::memcpy(&result, from, size);
-    return result;
-  }
-
-  constexpr void copy_to(std::byte to[]) const noexcept {
-    std::memcpy(to, &key, size);
-  }
-
-  [[nodiscard]] constexpr bool operator==(
-      const std::byte key2[]) const noexcept {
-    return !std::memcmp(&key, key2, size);
-  }
-
-  [[nodiscard]] constexpr bool operator==(
-      basic_art_key<KeyType> key2) const noexcept {
-    return !std::memcmp(&key, &key2.key, size);
-  }
-
-  [[nodiscard]] constexpr bool operator!=(
-      basic_art_key<KeyType> key2) const noexcept {
-    return std::memcmp(&key, &key2.key, size);
-  }
-
-  [[nodiscard]] __attribute__((pure)) constexpr auto operator[](
-      std::size_t index) const noexcept {
-    assert(index < size);
-    return (reinterpret_cast<const std::byte *>(&key))[index];
-  }
-
-  [[nodiscard]] constexpr explicit operator KeyType() const noexcept {
-    return key;
-  }
-
-  constexpr void shift_right(const std::size_t num_bytes) noexcept {
-    key >>= (num_bytes * 8);
-  }
-
-  KeyType key;
-
-  static constexpr auto size = sizeof(KeyType);
-};
-
-using art_key = basic_art_key<key>;
-
 struct node_header;
 
-// This corresponds to the "single value leaf" type in the ART paper. Since we
-// have only one kind of leaf nodes, we call them simply "leaf" nodes. Should we
-// ever implement other kinds, rename this and related types to
-// single_value_leaf.
-using raw_leaf = std::byte;
-using raw_leaf_ptr = raw_leaf *;
+template <class>
+class basic_inode_4;
+
+template <class>
+class basic_inode_16;
+
+template <class>
+class basic_inode_48;
+
+template <class>
+class basic_inode_256;
 
 class inode;
 
@@ -93,69 +37,12 @@ class inode_16;
 class inode_48;
 class inode_256;
 
-enum class node_type : std::uint8_t;
+using inode_defs = basic_inode_def<inode_4, inode_16, inode_48, inode_256>;
 
-class tree_depth final {
- public:
-  using value_type = unsigned;
+using node_ptr = basic_node_ptr<node_header, inode, inode_defs>;
 
-  explicit constexpr tree_depth(value_type value_ = 0) noexcept
-      : value{value_} {
-    assert(value <= art_key::size);
-  }
-
-  [[nodiscard]] constexpr operator value_type() const noexcept {
-    assert(value <= art_key::size);
-    return value;
-  }
-
-  constexpr tree_depth &operator++() noexcept {
-    ++value;
-    assert(value <= art_key::size);
-    return *this;
-  }
-
-  constexpr void operator+=(value_type delta) noexcept {
-    value += delta;
-    assert(value <= art_key::size);
-  }
-
- private:
-  value_type value;
-};
-
-// A pointer to some kind of node. It can be accessed either as a node header,
-// to query the right node type, a leaf, or as one of the internal nodes. This
-// depends on all types being of standard layout and node_header being at the
-// same location in node_header and all node types. This is checked by static
-// asserts in the implementation file.
-union node_ptr {
-  node_header *header;
-  raw_leaf_ptr leaf;
-  inode *internal;
-  inode_4 *node_4;
-  inode_16 *node_16;
-  inode_48 *node_48;
-  inode_256 *node_256;
-
-  node_ptr() noexcept {}
-  constexpr node_ptr(std::nullptr_t) noexcept : header{nullptr} {}
-  constexpr node_ptr(raw_leaf_ptr leaf_) noexcept : leaf{leaf_} {}
-  constexpr node_ptr(inode_4 *node_4_) noexcept : node_4{node_4_} {}
-  constexpr node_ptr(inode_16 *node_16_) noexcept : node_16{node_16_} {}
-  constexpr node_ptr(inode_48 *node_48_) noexcept : node_48{node_48_} {}
-  constexpr node_ptr(inode_256 *node_256_) noexcept : node_256{node_256_} {}
-
-  [[nodiscard]] constexpr auto operator==(std::nullptr_t) const noexcept {
-    return header == nullptr;
-  }
-
-  [[nodiscard]] constexpr auto operator!=(std::nullptr_t) const noexcept {
-    return header != nullptr;
-  }
-
-  [[nodiscard]] __attribute__((pure)) constexpr node_type type() const noexcept;
-};
+template <class Header, class Db>
+auto make_db_leaf_ptr(art_key, value_view, Db &);
 
 }  // namespace detail
 
@@ -261,6 +148,13 @@ class db final {
     current_memory_use -= delta;
   }
 
+  constexpr void decrement_leaf_count(std::size_t leaf_size) noexcept {
+    decrease_memory_use(leaf_size);
+
+    assert(leaf_count > 0);
+    --leaf_count;
+  }
+
   detail::node_ptr root{nullptr};
 
   std::size_t current_memory_use{0};
@@ -283,8 +177,24 @@ class db final {
 
   std::uint64_t key_prefix_splits{0};
 
-  friend struct detail::leaf;
-  friend class detail::db_leaf_deleter;
+  friend auto detail::make_db_leaf_ptr<detail::node_header, db>(detail::art_key,
+                                                         value_view, db &);
+
+  template <class, class>
+  friend class detail::basic_db_leaf_deleter;
+
+  template <class>
+  friend class detail::basic_inode_4;
+
+  template <class>
+  friend class detail::basic_inode_16;
+
+  template <class>
+  friend class detail::basic_inode_48;
+
+  template <class>
+  friend class detail::basic_inode_256;
+
   friend class detail::inode_4;
   friend class detail::inode_16;
   friend class detail::inode_48;

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -1,0 +1,207 @@
+// Copyright 2019-2021 Laurynas Biveinis
+#ifndef UNODB_ART_INTERNAL_HPP_
+#define UNODB_ART_INTERNAL_HPP_
+
+#include "global.hpp"
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <type_traits>
+
+#include "art_common.hpp"
+
+namespace unodb::detail {
+
+// Forward declarations to use in unodb::db and its siblings
+template <class>
+struct basic_leaf;
+
+template <class, class>
+class basic_db_leaf_deleter;
+
+// Internal ART key in binary-comparable format
+template <typename KeyType>
+struct basic_art_key final {
+  [[nodiscard]] static constexpr KeyType make_binary_comparable(
+      KeyType key) noexcept;
+
+  constexpr basic_art_key() noexcept = default;
+
+  explicit constexpr basic_art_key(KeyType key_) noexcept
+      : key{make_binary_comparable(key_)} {}
+
+  [[nodiscard]] static constexpr auto create(const std::byte from[]) noexcept {
+    struct basic_art_key result;
+    std::memcpy(&result, from, size);
+    return result;
+  }
+
+  constexpr void copy_to(std::byte to[]) const noexcept {
+    std::memcpy(to, &key, size);
+  }
+
+  [[nodiscard]] constexpr bool operator==(
+      const std::byte key2[]) const noexcept {
+    return !std::memcmp(&key, key2, size);
+  }
+
+  [[nodiscard]] constexpr bool operator==(
+      basic_art_key<KeyType> key2) const noexcept {
+    return !std::memcmp(&key, &key2.key, size);
+  }
+
+  [[nodiscard]] constexpr bool operator!=(
+      basic_art_key<KeyType> key2) const noexcept {
+    return std::memcmp(&key, &key2.key, size);
+  }
+
+  [[nodiscard]] __attribute__((pure)) constexpr auto operator[](
+      std::size_t index) const noexcept {
+    assert(index < size);
+    return (reinterpret_cast<const std::byte *>(&key))[index];
+  }
+
+  [[nodiscard]] constexpr explicit operator KeyType() const noexcept {
+    return key;
+  }
+
+  constexpr void shift_right(const std::size_t num_bytes) noexcept {
+    key >>= (num_bytes * 8);
+  }
+
+  KeyType key;
+
+  static constexpr auto size = sizeof(KeyType);
+
+  static void static_asserts() {
+    static_assert(std::is_trivially_copyable_v<basic_art_key<KeyType>>);
+    static_assert(sizeof(basic_art_key<KeyType>) == sizeof(KeyType));
+  }
+};
+
+using art_key = basic_art_key<unodb::key>;
+
+// This corresponds to the "single value leaf" type in the ART paper. Since we
+// have only one kind of leaf nodes, we call them simply "leaf" nodes. Should we
+// ever implement other kinds, rename this and related types to
+// single_value_leaf.
+using raw_leaf = std::byte;
+// This pointer should be aligned as node header, but we can only attach alignas
+// to a struct or union, which is inconvenient here.
+using raw_leaf_ptr = raw_leaf *;
+
+enum class node_type : std::uint8_t { LEAF, I4, I16, I48, I256 };
+
+class tree_depth final {
+ public:
+  using value_type = unsigned;
+
+  explicit constexpr tree_depth(value_type value_ = 0) noexcept
+      : value{value_} {
+    assert(value <= art_key::size);
+  }
+
+  [[nodiscard]] constexpr operator value_type() const noexcept {
+    assert(value <= art_key::size);
+    return value;
+  }
+
+  constexpr tree_depth &operator++() noexcept {
+    ++value;
+    assert(value <= art_key::size);
+    return *this;
+  }
+
+  constexpr void operator+=(value_type delta) noexcept {
+    value += delta;
+    assert(value <= art_key::size);
+  }
+
+ private:
+  value_type value;
+};
+
+template <class Header, class Db>
+class basic_db_leaf_deleter {
+ public:
+  // cppcheck-suppress constParameter
+  constexpr explicit basic_db_leaf_deleter(Db &db_) noexcept : db{db_} {}
+
+  void operator()(raw_leaf_ptr to_delete) const noexcept;
+
+ private:
+  Db &db;
+};
+
+template <class Header, class Db>
+using basic_db_leaf_unique_ptr =
+    std::unique_ptr<raw_leaf, basic_db_leaf_deleter<Header, Db>>;
+
+template <class Node4, class Node16, class Node48, class Node256>
+struct basic_inode_def final {
+  using n4 = Node4;
+  using n16 = Node16;
+  using n48 = Node48;
+  using n256 = Node256;
+
+  basic_inode_def() = delete;
+};
+
+// A pointer to some kind of node. It can be accessed either as a node header,
+// to query the right node type, a leaf, or as one of the internal nodes. This
+// depends on all types being of standard layout and Header being at the same
+// location in Header and all node types. This is checked by static asserts in
+// the implementation file.
+template <class Header, class INode, class INodeDefs>
+union basic_node_ptr {
+  using header_type = Header;
+  using inode = INode;
+  using inode4_type = typename INodeDefs::n4;
+  using inode16_type = typename INodeDefs::n16;
+  using inode48_type = typename INodeDefs::n48;
+  using inode256_type = typename INodeDefs::n256;
+
+  header_type *header;
+  raw_leaf_ptr leaf;
+  INode *internal;
+  inode4_type *node_4;
+  inode16_type *node_16;
+  inode48_type *node_48;
+  inode256_type *node_256;
+
+  basic_node_ptr() noexcept {}
+  constexpr basic_node_ptr(std::nullptr_t) noexcept : header{nullptr} {}
+  constexpr basic_node_ptr(raw_leaf_ptr leaf_) noexcept : leaf{leaf_} {}
+  constexpr basic_node_ptr(inode4_type *node_4_) noexcept : node_4{node_4_} {}
+  constexpr basic_node_ptr(inode16_type *node_16_) noexcept
+      : node_16{node_16_} {}
+  constexpr basic_node_ptr(inode48_type *node_48_) noexcept
+      : node_48{node_48_} {}
+  constexpr basic_node_ptr(inode256_type *node_256_) noexcept
+      : node_256{node_256_} {}
+
+  [[nodiscard]] __attribute__((pure)) constexpr auto type() const noexcept {
+    return header->type();
+  }
+
+  [[nodiscard]] constexpr auto operator==(std::nullptr_t) const noexcept {
+    return header == nullptr;
+  }
+
+  [[nodiscard]] constexpr auto operator!=(std::nullptr_t) const noexcept {
+    return header != nullptr;
+  }
+
+  static auto static_asserts() {
+    static_assert(
+        sizeof(basic_node_ptr<Header, INode, INodeDefs>) == sizeof(void *),
+        "node_ptr union must be of equal size to a raw pointer");
+  }
+};
+
+}  // namespace unodb::detail
+
+#endif  // UNODB_ART_INTERNAL_HPP_

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1,0 +1,1773 @@
+// Copyright 2019-2021 Laurynas Biveinis
+#ifndef UNODB_ART_INTERNAL_IMPL_HPP_
+#define UNODB_ART_INTERNAL_IMPL_HPP_
+
+#include "global.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+
+#ifdef __x86_64
+#include <emmintrin.h>
+#include <smmintrin.h>
+#endif
+
+#include <gsl/gsl_util>
+
+#include "art_common.hpp"
+#include "art_internal.hpp"
+#include "heap.hpp"
+
+namespace unodb {
+class db;
+class olc_db;
+}  // namespace unodb
+
+namespace unodb::detail {
+
+__attribute__((cold, noinline)) inline void dump_byte(std::ostream &os,
+                                                      std::byte byte) {
+  os << ' ' << std::hex << std::setfill('0') << std::setw(2)
+     << static_cast<unsigned>(byte) << std::dec;
+}
+
+__attribute__((cold, noinline)) inline void dump_key(std::ostream &os,
+                                                     art_key key) {
+  for (std::size_t i = 0; i < sizeof(key); i++) dump_byte(os, key[i]);
+}
+
+// For internal node pools, approximate requesting ~2MB blocks from backing
+// storage (when ported to Linux, ask for 2MB huge pages directly)
+template <class INode>
+[[nodiscard]] inline auto get_inode_pool_options() noexcept {
+  pmr_pool_options inode_pool_options;
+  inode_pool_options.max_blocks_per_chunk = 2 * 1024 * 1024 / sizeof(INode);
+  inode_pool_options.largest_required_pool_block = sizeof(INode);
+  return inode_pool_options;
+}
+
+[[nodiscard]] inline auto &get_leaf_node_pool() noexcept {
+  return *pmr_new_delete_resource();
+}
+
+template <>
+__attribute__((const)) inline constexpr std::uint64_t
+basic_art_key<std::uint64_t>::make_binary_comparable(std::uint64_t k) noexcept {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return __builtin_bswap64(k);
+#else
+#error Needs implementing
+#endif
+}
+
+// On x86_64 with GCC up to and including version 10, __builtin_ffs compiles to
+// BSF/CMOVE pair if TZCNT is not available. CMOVE is only required if arg is
+// zero, which we know not to be. Only GCC 11 gets the hint by "if (arg == 0)
+// __builtin_unreachable()"
+__attribute__((const)) inline unsigned ffs_nonzero(std::uint64_t arg) {
+  std::int64_t result;
+#ifdef __x86_64
+  __asm__("bsfq %1, %0" : "=r"(result) : "rm"(arg) : "cc");
+  return gsl::narrow_cast<unsigned>(result + 1);
+#else
+  return static_cast<unsigned>(__builtin_ffsl(static_cast<std::int64_t>(arg)));
+#endif
+}
+
+#ifdef __x86_64
+
+// Idea from https://stackoverflow.com/a/32945715/80458
+inline auto _mm_cmple_epu8(__m128i x, __m128i y) noexcept {
+  return _mm_cmpeq_epi8(_mm_max_epu8(y, x), y);
+}
+
+#else  // #ifdef __x86_64
+
+// From public domain
+// https://graphics.stanford.edu/~seander/bithacks.html
+inline constexpr __attribute__((const)) std::uint32_t has_zero_byte(
+    std::uint32_t v) noexcept {
+  return ((v - 0x01010101UL) & ~v & 0x80808080UL);
+}
+
+inline constexpr __attribute__((const)) std::uint32_t contains_byte(
+    std::uint32_t v, std::byte b) noexcept {
+  return has_zero_byte(v ^ (~0U / 255 * static_cast<std::uint8_t>(b)));
+}
+
+#endif  // #ifdef __x86_64
+
+// A common prefix shared by all node types
+struct node_header final {
+  explicit constexpr node_header(node_type type_) : m_type{type_} {}
+
+  [[nodiscard]] constexpr auto type() const noexcept { return m_type; }
+
+  constexpr void reinit_in_inode() noexcept {}
+
+ private:
+  const node_type m_type;
+};
+
+static_assert(std::is_standard_layout_v<node_header>);
+static_assert(sizeof(node_header) == 1);
+
+// Helper struct for leaf node-related data and (static) code. We
+// don't use a regular class because leaf nodes are of variable size, C++ does
+// not support flexible array members, and we want to save one level of
+// (heap) indirection.
+template <class Header>
+struct basic_leaf final {
+  using value_size_type = std::uint32_t;
+
+  static constexpr auto offset_header = 0;
+  static constexpr auto offset_key = sizeof(Header);
+  static constexpr auto offset_value_size = offset_key + sizeof(art_key);
+
+  static constexpr auto offset_value =
+      offset_value_size + sizeof(value_size_type);
+
+  [[nodiscard]] static constexpr auto key(raw_leaf_ptr leaf) noexcept {
+    assert_invariants(leaf);
+
+    return art_key::create(&leaf[offset_key]);
+  }
+
+  [[nodiscard]] static constexpr auto matches(raw_leaf_ptr leaf,
+                                              art_key k) noexcept {
+    assert_invariants(leaf);
+
+    return k == leaf + offset_key;
+  }
+
+  [[nodiscard]] static constexpr auto value(raw_leaf_ptr leaf) noexcept {
+    assert_invariants(leaf);
+
+    return value_view{&leaf[offset_value], value_size(leaf)};
+  }
+
+  [[nodiscard]] static constexpr std::size_t size(raw_leaf_ptr leaf) noexcept {
+    assert_invariants(leaf);
+
+    return value_size(leaf) + offset_value;
+  }
+
+  __attribute__((cold, noinline)) static void dump(std::ostream &os,
+                                                   raw_leaf_ptr leaf);
+
+  static constexpr void assert_invariants(
+      USED_IN_DEBUG raw_leaf_ptr leaf) noexcept {
+#ifndef NDEBUG
+    assert(reinterpret_cast<std::uintptr_t>(leaf) % alignof(Header) == 0);
+    const auto *const assume_aligned =
+        __builtin_assume_aligned(leaf, alignof(Header));
+    assert(reinterpret_cast<const Header *>(assume_aligned)->type() ==
+           node_type::LEAF);
+#endif
+  }
+
+ private:
+  static constexpr auto minimum_size = offset_value;
+
+  DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
+  [[nodiscard]] static auto value_size(raw_leaf_ptr leaf) noexcept {
+    assert_invariants(leaf);
+
+    value_size_type result;
+    std::memcpy(&result, &leaf[offset_value_size], sizeof(result));
+    return result;
+  }
+  RESTORE_GCC_WARNINGS()
+};
+
+template <class Header, class Db>
+auto make_db_leaf_ptr(art_key k, value_view v, Db &db) {
+  using leaf_type = basic_leaf<Header>;
+  using value_size_type = typename leaf_type::value_size_type;
+
+  if (unlikely(v.size() > std::numeric_limits<value_size_type>::max())) {
+    throw std::length_error("Value length must fit in std::uint32_t");
+  }
+
+  const auto value_size = static_cast<value_size_type>(v.size());
+  const auto leaf_size =
+      static_cast<std::size_t>(leaf_type::offset_value) + value_size;
+
+  auto *const leaf_mem = static_cast<std::byte *>(pmr_allocate(
+      get_leaf_node_pool(), leaf_size, alignment_for_new<Header>()));
+  new (leaf_mem) Header{node_type::LEAF};
+
+  db.increase_memory_use(leaf_size);
+  ++db.leaf_count;
+
+  k.copy_to(&leaf_mem[leaf_type::offset_key]);
+  std::memcpy(&leaf_mem[leaf_type::offset_value_size], &value_size,
+              sizeof(value_size_type));
+  if (!v.empty())
+    std::memcpy(&leaf_mem[leaf_type::offset_value], &v[0],
+                static_cast<std::size_t>(v.size()));
+  leaf_type::assert_invariants(leaf_mem);
+  return basic_db_leaf_unique_ptr<Header, Db>{
+      leaf_mem, basic_db_leaf_deleter<Header, Db>{db}};
+}
+
+template <class Header>
+void basic_leaf<Header>::dump(std::ostream &os, raw_leaf_ptr leaf) {
+  os << "LEAF: key:";
+  dump_key(os, key(leaf));
+  os << ", value size: " << value_size(leaf) << '\n';
+}
+
+// Implementation of things declared in art_internal.hpp
+template <class Header, class Db>
+inline void basic_db_leaf_deleter<Header, Db>::operator()(
+    raw_leaf_ptr to_delete) const noexcept {
+  if (to_delete == nullptr) return;
+
+  const auto leaf_size = basic_leaf<Header>::size(to_delete);
+  pmr_deallocate(get_leaf_node_pool(), to_delete, leaf_size,
+                 alignment_for_new<Header>());
+
+  db.decrement_leaf_count(leaf_size);
+}
+
+template <class Header, class Db, template <class, class> class Reclamator>
+using leaf_reclaimable_ptr = std::unique_ptr<raw_leaf, Reclamator<Header, Db>>;
+
+template <class NodePtr, template <class, class> class LeafReclamator, class Db>
+struct basic_reclaim_db_node_ptr_at_scope_exit final {
+  using header_type = typename NodePtr::header_type;
+  using inode4_type = typename NodePtr::inode4_type;
+  using inode16_type = typename NodePtr::inode16_type;
+  using inode48_type = typename NodePtr::inode48_type;
+  using inode256_type = typename NodePtr::inode256_type;
+  using leaf_reclaimable_ptr_type =
+      leaf_reclaimable_ptr<header_type, Db, LeafReclamator>;
+  using db_leaf_reclamator_type = LeafReclamator<header_type, Db>;
+
+  constexpr explicit basic_reclaim_db_node_ptr_at_scope_exit(
+      NodePtr node_ptr_,
+      Db &db_) noexcept  // cppcheck-suppress constParameter
+      : node_ptr{node_ptr_}, db{db_} {}
+
+  ~basic_reclaim_db_node_ptr_at_scope_exit() {
+    if (node_ptr == nullptr) return;
+
+    switch (node_ptr.type()) {
+      case node_type::LEAF: {
+        // cppcheck-suppress unreadVariable
+        const auto leaf_unique_ptr = leaf_reclaimable_ptr_type{
+            node_ptr.leaf, db_leaf_reclamator_type{db}};
+        return;
+      }
+      case node_type::I4: {
+        // TODO(laurynas): move inode accounting on destruction to unique_ptr
+        // deleter too same as for leaves
+        // cppcheck-suppress unreadVariable
+        const auto node4_unique_ptr =
+            std::unique_ptr<inode4_type>{node_ptr.node_4};
+        return;
+      }
+      case node_type::I16: {
+        // cppcheck-suppress unreadVariable
+        const auto node16_unique_ptr =
+            std::unique_ptr<inode16_type>{node_ptr.node_16};
+        return;
+      }
+      case node_type::I48: {
+        // cppcheck-suppress unreadVariable
+        const auto node48_unique_ptr =
+            std::unique_ptr<inode48_type>{node_ptr.node_48};
+        return;
+      }
+      case node_type::I256: {
+        // cppcheck-suppress unreadVariable
+        const auto node256_unique_ptr =
+            std::unique_ptr<inode256_type>{node_ptr.node_256};
+        return;
+      }
+    }
+    cannot_happen();  // LCOV_EXCL_LINE
+  }
+
+  void delete_subtree() noexcept {
+    if (node_ptr == nullptr || node_ptr.type() == node_type::LEAF) return;
+
+    node_ptr.internal->delete_subtree(db);
+  }
+
+ private:
+  basic_reclaim_db_node_ptr_at_scope_exit(
+      const basic_reclaim_db_node_ptr_at_scope_exit &) = delete;
+  basic_reclaim_db_node_ptr_at_scope_exit(
+      basic_reclaim_db_node_ptr_at_scope_exit &&) = delete;
+  auto &operator=(const basic_reclaim_db_node_ptr_at_scope_exit &) = delete;
+  auto &operator=(basic_reclaim_db_node_ptr_at_scope_exit &&) = delete;
+
+  const NodePtr node_ptr;
+  Db &db;
+};
+
+template <class NodePtr>
+__attribute__((cold, noinline)) void dump_node(std::ostream &os,
+                                               const NodePtr &node) {
+  using local_leaf_type = basic_leaf<typename NodePtr::header_type>;
+
+  os << "node at: " << node.header;
+  if (node.header == nullptr) {
+    os << '\n';
+    return;
+  }
+  os << ", type = ";
+  switch (node.type()) {
+    case node_type::LEAF:
+      local_leaf_type::dump(os, node.leaf);
+      break;
+    case node_type::I4:
+    case node_type::I16:
+    case node_type::I48:
+    case node_type::I256:
+      node.internal->dump(os);
+      break;
+  }
+}
+
+DISABLE_GCC_WARNING("-Wctor-dtor-privacy")
+// A class used as a sentinel for basic_inode template args: the
+// larger node type for the largest node type and the smaller node type for
+// the smallest node type.
+class fake_inode final {
+  fake_inode() = delete;
+};
+RESTORE_GCC_WARNINGS()
+
+template <class Db, template <class> class AtomicPolicy, class NodePtr,
+          template <class, class> class LeafReclamator,
+          template <class> class INodePoolGetter>
+struct basic_art_policy final {
+  template <typename T>
+  using atomic_policy = AtomicPolicy<T>;
+
+  using node_ptr = NodePtr;
+  using header_type = typename node_ptr::header_type;
+  using db = Db;
+  using db_leaf_unique_ptr = basic_db_leaf_unique_ptr<header_type, db>;
+  using inode4_type = typename node_ptr::inode4_type;
+  using inode16_type = typename node_ptr::inode16_type;
+  using inode48_type = typename node_ptr::inode48_type;
+  using inode256_type = typename node_ptr::inode256_type;
+
+  template <class T>
+  using inode_pool_getter_type = INodePoolGetter<T>;
+
+  using leaf_type = basic_leaf<header_type>;
+  static_assert(std::is_standard_layout_v<leaf_type>,
+                "basic_leaf must be standard layout type to support aliasing"
+                " through header");
+
+  using db_leaf_reclaimable_ptr =
+      leaf_reclaimable_ptr<header_type, db, LeafReclamator>;
+
+  using delete_db_node_ptr_at_scope_exit =
+      basic_reclaim_db_node_ptr_at_scope_exit<node_ptr, basic_db_leaf_deleter,
+                                              db>;
+
+  using reclaim_node_ptr_at_scope_exit_type =
+      basic_reclaim_db_node_ptr_at_scope_exit<node_ptr, LeafReclamator, db>;
+
+  static auto make_db_leaf_ptr(art_key k, value_view v, db &db_instance) {
+    return ::unodb::detail::make_db_leaf_ptr<header_type, db>(k, v,
+                                                              db_instance);
+  }
+
+  static auto make_db_reclaimable_leaf_ptr(raw_leaf_ptr leaf, db &db_instance) {
+    return db_leaf_reclaimable_ptr{
+        leaf, LeafReclamator<header_type, db>{db_instance}};
+  }
+
+  basic_art_policy() = delete;
+};
+
+template <class ArtPolicy>
+class basic_inode_impl {
+ public:
+  using node_ptr = typename ArtPolicy::node_ptr;
+  template <typename T>
+  using atomic_policy = typename ArtPolicy::template atomic_policy<T>;
+  using db_leaf_unique_ptr = typename ArtPolicy::db_leaf_unique_ptr;
+  using db = typename ArtPolicy::db;
+  // The first element is the child index in the node, the 2nd is pointer
+  // to the child. If not present, the pointer is nullptr, and the index
+  // is undefined
+  using find_result = std::pair<std::uint8_t, atomic_policy<node_ptr> *>;
+
+ protected:
+  using inode_type = typename node_ptr::inode;
+
+ private:
+  using header_type = typename ArtPolicy::header_type;
+  using inode4_type = typename ArtPolicy::inode4_type;
+  using inode16_type = typename ArtPolicy::inode16_type;
+  using inode48_type = typename ArtPolicy::inode48_type;
+  using inode256_type = typename ArtPolicy::inode256_type;
+
+  // key_prefix fields and methods
+ public:
+  using key_prefix_size = std::uint8_t;
+
+ private:
+  static constexpr key_prefix_size key_prefix_capacity = 7;
+
+  // Padding between minimum node_header and an actual header type used
+  static constexpr auto header_extra_size =
+      sizeof(header_type) - sizeof(node_header);
+  static constexpr auto header_pad_u32 = (header_extra_size >> 3U) << 1U;
+  static constexpr auto header_pad_bytes = header_pad_u32 * 4;
+
+ public:
+  using key_prefix_data = std::array<atomic_policy<std::byte>,
+                                     key_prefix_capacity + header_pad_bytes>;
+
+  [[nodiscard]] __attribute__((pure)) constexpr auto
+  get_shared_key_prefix_length(
+      unodb::detail::art_key shifted_key) const noexcept {
+    const auto prefix_u64 = header_as_uint64() >> 8U;
+    return shared_len(static_cast<std::uint64_t>(shifted_key), prefix_u64,
+                      key_prefix_length());
+  }
+
+  [[nodiscard]] constexpr unsigned key_prefix_length() const noexcept {
+    const auto result = f.f.key_prefix_length.load();
+    assert(result <= key_prefix_capacity);
+    return result;
+  }
+
+  constexpr void cut_key_prefix(unsigned cut_len) noexcept {
+    assert(cut_len > 0);
+    assert(cut_len <= key_prefix_length());
+
+    const auto type = static_cast<std::uint8_t>(f.header.type());
+    const auto prefix_u64 = header_as_uint64();
+    const auto cut_prefix_u64 =
+        ((prefix_u64 >> (cut_len * 8)) & key_bytes_mask) | type;
+    set_header(cut_prefix_u64);
+
+    f.f.key_prefix_length =
+        gsl::narrow_cast<key_prefix_size>(key_prefix_length() - cut_len);
+  }
+
+  constexpr void prepend_key_prefix(const basic_inode_impl &prefix1,
+                                    std::byte prefix2) noexcept {
+    assert(key_prefix_length() + prefix1.key_prefix_length() <
+           key_prefix_capacity);
+
+    const auto type = static_cast<std::uint8_t>(f.header.type());
+    const auto prefix_u64 = header_as_uint64() & key_bytes_mask;
+    const auto trailing_prefix_shift = (prefix1.key_prefix_length() + 1U) * 8U;
+    const auto shifted_prefix_u64 = prefix_u64 << trailing_prefix_shift;
+    const auto shifted_prefix2 = static_cast<std::uint64_t>(prefix2)
+                                 << trailing_prefix_shift;
+    const auto prefix1_mask = ((1ULL << trailing_prefix_shift) - 1) ^ 0xFFU;
+    const auto masked_prefix1 = prefix1.header_as_uint64() & prefix1_mask;
+    const auto prefix_result =
+        shifted_prefix_u64 | shifted_prefix2 | masked_prefix1 | type;
+    set_header(prefix_result);
+
+    f.f.key_prefix_length = gsl::narrow_cast<key_prefix_size>(
+        key_prefix_length() + prefix1.key_prefix_length() + 1);
+  }
+
+  [[nodiscard]] constexpr const auto &get_key_prefix() const noexcept {
+    return f.f.key_prefix;
+  }
+
+  __attribute__((cold, noinline)) void dump_key_prefix(std::ostream &os) const {
+    const auto len = key_prefix_length();
+    os << ", key prefix len = " << static_cast<unsigned>(len);
+    if (len > 0) {
+      os << ", key prefix =";
+      for (std::size_t i = 0; i < len; ++i) dump_byte(os, f.f.key_prefix[i]);
+    }
+  }
+
+ public:
+  // Only for unodb::detail use
+  constexpr const auto &get_header() const noexcept { return f.header; }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        os << "I4: ";
+        break;
+      case node_type::I16:
+        os << "I16: ";
+        break;
+      case node_type::I48:
+        os << "I48: ";
+        break;
+      case node_type::I256:
+        os << "I256: ";
+        break;
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+        // LCOV_EXCL_STOP
+    }
+    os << "# children = "
+       << (f.f.children_count == 0 ? 256
+                                   : static_cast<unsigned>(f.f.children_count));
+    dump_key_prefix(os);
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        static_cast<const inode4_type *>(this)->dump(os);
+        break;
+      case node_type::I16:
+        static_cast<const inode16_type *>(this)->dump(os);
+        break;
+      case node_type::I48:
+        static_cast<const inode48_type *>(this)->dump(os);
+        break;
+      case node_type::I256:
+        static_cast<const inode256_type *>(this)->dump(os);
+        break;
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+        // LCOV_EXCL_STOP
+    }
+  }
+
+  constexpr void add(db_leaf_unique_ptr &&child, tree_depth depth) noexcept {
+    assert(!is_full());
+    assert(child.get() != nullptr);
+
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        static_cast<inode4_type *>(this)->add(std::move(child), depth);
+        break;
+      case node_type::I16:
+        static_cast<inode16_type *>(this)->add(std::move(child), depth);
+        break;
+      case node_type::I48:
+        static_cast<inode48_type *>(this)->add(std::move(child), depth);
+        break;
+      case node_type::I256:
+        static_cast<inode256_type *>(this)->add(std::move(child), depth);
+        break;
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+        // LCOV_EXCL_STOP
+    }
+  }
+
+  constexpr void remove(std::uint8_t child_index, db &db_instance) noexcept {
+    assert(!is_min_size());
+
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        static_cast<inode4_type *>(this)->remove(child_index, db_instance);
+        break;
+      case node_type::I16:
+        static_cast<inode16_type *>(this)->remove(child_index, db_instance);
+        break;
+      case node_type::I48:
+        static_cast<inode48_type *>(this)->remove(child_index, db_instance);
+        break;
+      case node_type::I256:
+        static_cast<inode256_type *>(this)->remove(child_index, db_instance);
+        break;
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+        // LCOV_EXCL_STOP
+    }
+  }
+
+  constexpr void delete_subtree(db &db_instance) noexcept {
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        return static_cast<inode4_type *>(this)->delete_subtree(db_instance);
+      case node_type::I16:
+        return static_cast<inode16_type *>(this)->delete_subtree(db_instance);
+      case node_type::I48:
+        return static_cast<inode48_type *>(this)->delete_subtree(db_instance);
+      case node_type::I256:
+        return static_cast<inode256_type *>(this)->delete_subtree(db_instance);
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+        // LCOV_EXCL_STOP
+    }
+  }
+
+  [[nodiscard]] constexpr find_result find_child(detail::node_type type,
+                                                 std::byte key_byte) noexcept {
+    assert(type != node_type::LEAF);
+    // type == this->f.header.type(), but this node can be updated in parallel
+    // in OLC. Even though the node type byte stays constant, the header word
+    // containing it does not, so don't risk it. Because of the same parallel
+    // updates, the callees below may work on inconsistent nodes and must not
+    // assert, just produce results, which are OK to be incorrect/inconsistent
+    // as the node state will be checked before acting on them.
+
+    switch (type) {
+      case node_type::I4:
+        return static_cast<inode4_type *>(this)->find_child(key_byte);
+      case node_type::I16:
+        return static_cast<inode16_type *>(this)->find_child(key_byte);
+      case node_type::I48:
+        return static_cast<inode48_type *>(this)->find_child(key_byte);
+      case node_type::I256:
+        return static_cast<inode256_type *>(this)->find_child(key_byte);
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+    }
+    cannot_happen();
+    // LCOV_EXCL_STOP
+  }
+
+  [[nodiscard]] constexpr bool is_full() const noexcept {
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        return static_cast<const inode4_type *>(this)->is_full();
+      case node_type::I16:
+        return static_cast<const inode16_type *>(this)->is_full();
+      case node_type::I48:
+        return static_cast<const inode48_type *>(this)->is_full();
+      case node_type::I256:
+        return static_cast<const inode256_type *>(this)->is_full();
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+    }
+    cannot_happen();
+    // LCOV_EXCL_STOP
+  }
+
+  [[nodiscard]] constexpr bool is_min_size() const noexcept {
+    switch (this->f.header.type()) {
+      case node_type::I4:
+        return static_cast<const inode4_type *>(this)->is_min_size();
+      case node_type::I16:
+        return static_cast<const inode16_type *>(this)->is_min_size();
+      case node_type::I48:
+        return static_cast<const inode48_type *>(this)->is_min_size();
+      case node_type::I256:
+        return static_cast<const inode256_type *>(this)->is_min_size();
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        cannot_happen();
+    }
+    cannot_happen();
+    // LCOV_EXCL_STOP
+  }
+
+  // inode must not be allocated directly on heap, concrete subclasses will
+  // define their own new and delete operators using node pools
+  [[nodiscard]] __attribute__((cold, noinline)) static void *operator new(
+      std::size_t) {
+    cannot_happen();
+  }
+
+  DISABLE_CLANG_WARNING("-Wmissing-noreturn")
+  __attribute__((cold, noinline)) static void operator delete(void *) {
+    cannot_happen();
+  }
+  RESTORE_CLANG_WARNINGS()
+
+  constexpr basic_inode_impl(node_type type, unsigned children_count,
+                             art_key k1, art_key k2, tree_depth depth) noexcept
+      : f{type, k1, k2, depth, children_count} {
+    assert(type != node_type::LEAF);
+  }
+
+  constexpr basic_inode_impl(node_type type, unsigned children_count,
+                             unsigned key_prefix_len,
+                             const inode_type &key_prefix_source_node) noexcept
+      : f{type, children_count, key_prefix_len, key_prefix_source_node} {
+    assert(type != node_type::LEAF);
+  }
+
+  constexpr basic_inode_impl(node_type type, unsigned children_count,
+                             const basic_inode_impl &other) noexcept
+      : f{type, children_count, other} {
+    assert(type != node_type::LEAF);
+  }
+
+ private:
+  static constexpr auto key_bytes_mask = 0xFFFFFFFF'FFFFFF00ULL;
+
+  [[nodiscard]] constexpr __attribute__((const)) std::uint64_t
+  header_as_uint64() const noexcept {
+    return static_cast<std::uint64_t>(f.u32[1]) << 32U | f.u32[0];
+  }
+
+  [[nodiscard]] static constexpr __attribute__((pure)) unsigned shared_len(
+      std::uint64_t k1, std::uint64_t k2, unsigned clamp_byte_pos) noexcept {
+    assert(clamp_byte_pos < 8);
+
+    const auto diff = k1 ^ k2;
+    const auto clamped = diff | (1ULL << (clamp_byte_pos * 8U));
+    return (ffs_nonzero(clamped) - 1) >> 3U;
+  }
+
+  constexpr void set_header(std::uint64_t u64) noexcept {
+#ifdef UNODB_THREAD_SANITIZER
+    // If we write the initial 4 bytes of a header as one uint32_t integer, we
+    // overwrite the type byte (with an identical value of course), which gets
+    // flagged as a data race. Thus don't touch it under ThreadSanitizer. An
+    // alternative would be to access the type byte through a relaxed atomic.
+    f.header_bytes[1] =
+        gsl::narrow_cast<std::uint8_t>((u64 & 0x0000FF00ULL) >> 8U);
+    f.header_bytes[2] =
+        gsl::narrow_cast<std::uint8_t>((u64 & 0x00FF0000ULL) >> 16U);
+    f.header_bytes[3] =
+        gsl::narrow_cast<std::uint8_t>((u64 & 0xFF000000ULL) >> 24U);
+#else
+    f.u32[0] = gsl::narrow_cast<std::uint32_t>(u64 & 0xFFFFFFFFULL);
+#endif
+    f.u32[1] = gsl::narrow_cast<std::uint32_t>(u64 >> 32U);
+  }
+
+  union inode_union {
+    struct inode_fields {
+      const node_type type;
+      key_prefix_data key_prefix;
+      atomic_policy<key_prefix_size> key_prefix_length;
+      atomic_policy<std::uint8_t> children_count;
+    } f;
+    header_type header;
+    std::array<atomic_policy<std::uint32_t>, 2 + header_pad_u32> u32;
+#ifdef UNODB_THREAD_SANITIZER
+    std::array<atomic_policy<std::uint8_t>, 4> header_bytes;
+#endif
+
+    static void static_asserts() noexcept {
+      static_assert(offsetof(inode_fields, type) == 0);
+      static_assert(offsetof(inode_fields, key_prefix_data) == 1);
+      static_assert(offsetof(inode_fields, key_prefix_length) ==
+                    8 + header_pad_u32 * 4);
+      static_assert(offsetof(inode_fields, children_count) ==
+                    9 + header_pad_u32 * 4);
+      static_assert(sizeof(inode_fields) == 10 + header_pad_u32 * 4);
+    }
+
+    inode_union(node_type type, art_key k1, art_key shifted_k2,
+                tree_depth depth, unsigned children_count) noexcept {
+      k1.shift_right(depth);
+
+      const auto k1_u64 = static_cast<std::uint64_t>(k1);
+
+      u32[0] = gsl::narrow_cast<std::uint32_t>(
+          static_cast<std::uint32_t>(type) | (k1_u64 & 0xFFFFFFFULL) << 8U);
+      header.reinit_in_inode();
+      u32[1] = gsl::narrow_cast<std::uint32_t>(k1_u64 >> 24U);
+
+      f.key_prefix_length = gsl::narrow_cast<key_prefix_size>(shared_len(
+          k1_u64, static_cast<std::uint64_t>(shifted_k2), key_prefix_capacity));
+      f.children_count = gsl::narrow_cast<std::uint8_t>(children_count);
+    }
+
+    inode_union(node_type type, unsigned children_count,
+                unsigned key_prefix_len,
+                const basic_inode_impl &key_prefix_source_node) noexcept {
+      assert(key_prefix_len <= key_prefix_capacity);
+
+      u32[0] = (key_prefix_source_node.f.u32[0] & 0xFFFFFF00U) |
+               static_cast<std::uint8_t>(type);
+      header.reinit_in_inode();
+      u32[1] = key_prefix_source_node.f.u32[1];
+      f.key_prefix_length = gsl::narrow_cast<key_prefix_size>(key_prefix_len);
+      f.children_count = gsl::narrow_cast<std::uint8_t>(children_count);
+    }
+
+    inode_union(node_type type, unsigned children_count,
+                const basic_inode_impl &other) noexcept
+        : inode_union{type, children_count, other.key_prefix_length(), other} {}
+
+  } f;
+
+ protected:
+  using leaf_type = basic_leaf<header_type>;
+
+  friend class inode_4;
+  friend class inode_16;
+  friend class inode_48;
+  friend class inode_256;
+  friend class unodb::db;
+
+  friend class olc_inode_4;
+  friend class olc_inode_16;
+  friend class olc_inode_48;
+  friend class olc_inode_256;
+  friend class unodb::olc_db;
+
+  friend struct olc_inode_immediate_deleter;
+
+  template <class, unsigned, unsigned, node_type, class, class, class>
+  friend class basic_inode;
+
+  template <class>
+  friend class basic_inode_4;
+
+  template <class>
+  friend class basic_inode_16;
+
+  template <class>
+  friend class basic_inode_48;
+
+  template <class>
+  friend class basic_inode_256;
+};
+
+template <class ArtPolicy, unsigned MinSize, unsigned Capacity,
+          node_type NodeType, class SmallerDerived, class LargerDerived,
+          class Derived>
+class basic_inode : public basic_inode_impl<ArtPolicy> {
+  static_assert(NodeType != detail::node_type::LEAF);
+  static_assert(!std::is_same_v<Derived, LargerDerived>);
+  static_assert(!std::is_same_v<SmallerDerived, Derived>);
+  static_assert(!std::is_same_v<SmallerDerived, LargerDerived>);
+  static_assert(MinSize < Capacity);
+
+  template <class T>
+  using inode_pool_getter_type =
+      typename ArtPolicy::template inode_pool_getter_type<T>;
+
+ public:
+  using db_leaf_unique_ptr = typename ArtPolicy::db_leaf_unique_ptr;
+  using db = typename ArtPolicy::db;
+
+  [[nodiscard]] static constexpr auto create(
+      std::unique_ptr<LargerDerived> &&source_node,
+      std::uint8_t child_to_delete, db &db_instance) {
+    return std::make_unique<Derived>(std::move(source_node), child_to_delete,
+                                     db_instance);
+  }
+
+  [[nodiscard]] static constexpr auto create(
+      std::unique_ptr<SmallerDerived> &&source_node, db_leaf_unique_ptr &&child,
+      tree_depth depth) {
+    return std::make_unique<Derived>(std::move(source_node), std::move(child),
+                                     depth);
+  }
+
+  [[nodiscard]] static void *operator new(std::size_t size) {
+    assert(size == sizeof(Derived));
+
+    return pmr_allocate(inode_pool_getter_type<Derived>::get(), size,
+                        alignment_for_new<Derived>());
+  }
+
+  static void operator delete(void *to_delete) {
+    pmr_deallocate(inode_pool_getter_type<Derived>::get(), to_delete,
+                   sizeof(Derived), alignment_for_new<Derived>());
+  }
+
+  [[nodiscard]] constexpr bool is_full() const noexcept {
+    assert(reinterpret_cast<const node_header *>(this)->type() == NodeType);
+
+    return this->f.f.children_count == capacity;
+  }
+
+  [[nodiscard]] constexpr bool is_min_size() const noexcept {
+    assert(reinterpret_cast<const node_header *>(this)->type() == NodeType);
+
+    return this->f.f.children_count == min_size;
+  }
+
+  static constexpr auto min_size = MinSize;
+  static constexpr auto capacity = Capacity;
+  static constexpr auto static_node_type = NodeType;
+
+  using smaller_derived_type = SmallerDerived;
+  using inode_type = typename basic_inode_impl<ArtPolicy>::inode_type;
+
+ protected:
+  constexpr basic_inode(art_key k1, art_key k2, tree_depth depth) noexcept
+      : basic_inode_impl<ArtPolicy>{NodeType, MinSize, k1, k2, depth} {
+    assert(is_min_size());
+  }
+
+  constexpr basic_inode(unsigned key_prefix_len,
+                        const inode_type &key_prefix_source_node) noexcept
+      : basic_inode_impl<ArtPolicy>{NodeType, MinSize, key_prefix_len,
+                                    key_prefix_source_node} {
+    assert(is_min_size());
+  }
+
+  explicit constexpr basic_inode(const SmallerDerived &source_node) noexcept
+      : basic_inode_impl<ArtPolicy>{NodeType, MinSize, source_node} {
+    assert(source_node.is_full());
+    assert(is_min_size());
+  }
+
+  explicit constexpr basic_inode(const LargerDerived &source_node) noexcept
+      : basic_inode_impl<ArtPolicy>{NodeType, Capacity, source_node} {
+    assert(source_node.is_min_size());
+    assert(is_full());
+  }
+};
+
+template <class ArtPolicy>
+using basic_inode_4_parent =
+    basic_inode<ArtPolicy, 2, 4, node_type::I4, fake_inode,
+                typename ArtPolicy::inode16_type,
+                typename ArtPolicy::inode4_type>;
+
+template <class ArtPolicy>
+class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
+  using inode4_type = typename ArtPolicy::inode4_type;
+  using inode16_type = typename ArtPolicy::inode16_type;
+
+  using leaf_type = typename ArtPolicy::leaf_type;
+  using node_ptr = typename ArtPolicy::node_ptr;
+  template <typename T>
+  using atomic_policy = typename ArtPolicy::template atomic_policy<T>;
+  using db_leaf_unique_ptr = typename ArtPolicy::db_leaf_unique_ptr;
+  using reclaim_node_ptr_at_scope_exit_type =
+      typename ArtPolicy::reclaim_node_ptr_at_scope_exit_type;
+  using find_result = typename basic_inode_impl<ArtPolicy>::find_result;
+
+  using parent_class = basic_inode_4_parent<ArtPolicy>;
+
+ public:
+  using db = typename ArtPolicy::db;
+
+  // Create a new node with two given child nodes
+  [[nodiscard]] static constexpr auto create(art_key k1, art_key shifted_k2,
+                                             tree_depth depth, node_ptr child1,
+                                             db_leaf_unique_ptr &&child2) {
+    return std::make_unique<inode4_type>(k1, shifted_k2, depth, child1,
+                                         std::move(child2));
+  }
+
+  using parent_class::create;
+
+  // Create a new node, split the key prefix of an existing node, and make the
+  // new node contain that existing node and a given new node which caused this
+  // key prefix split.
+  [[nodiscard]] static constexpr auto create(node_ptr source_node, unsigned len,
+                                             tree_depth depth,
+                                             db_leaf_unique_ptr &&child1) {
+    return std::make_unique<inode4_type>(source_node, len, depth,
+                                         std::move(child1));
+  }
+
+  constexpr basic_inode_4(art_key k1, art_key shifted_k2, tree_depth depth,
+                          node_ptr child1, db_leaf_unique_ptr &&child2) noexcept
+      : parent_class{k1, shifted_k2, depth} {
+    const auto k2_next_byte_depth = this->key_prefix_length();
+    const auto k1_next_byte_depth = k2_next_byte_depth + depth;
+    add_two_to_empty(k1[k1_next_byte_depth], child1,
+                     shifted_k2[k2_next_byte_depth], std::move(child2));
+  }
+
+  constexpr basic_inode_4(node_ptr source_node, unsigned len, tree_depth depth,
+                          db_leaf_unique_ptr &&child1) noexcept
+      : parent_class{len, *source_node.internal} {
+    assert(source_node.type() != node_type::LEAF);
+    assert(len < source_node.internal->key_prefix_length());
+    assert(depth + len < art_key::size);
+
+    const auto source_node_key_byte =
+        source_node.internal->get_key_prefix()[len].load();
+    source_node.internal->cut_key_prefix(len + 1);
+    const auto new_key_byte = leaf_type::key(child1.get())[depth + len];
+    add_two_to_empty(source_node_key_byte, source_node, new_key_byte,
+                     std::move(child1));
+  }
+
+  constexpr basic_inode_4(std::unique_ptr<inode16_type> source_node,
+                          std::uint8_t child_to_delete, db &db_instance)
+      : parent_class{*source_node} {
+    const auto *source_keys_itr = source_node->keys.byte_array.cbegin();
+    auto *keys_itr = keys.byte_array.begin();
+    const auto *source_children_itr = source_node->children.cbegin();
+    auto *children_itr = children.begin();
+
+    while (source_keys_itr !=
+           source_node->keys.byte_array.cbegin() + child_to_delete) {
+      *keys_itr++ = *source_keys_itr++;
+      *children_itr++ = *source_children_itr++;
+    }
+
+    reclaim_node_ptr_at_scope_exit_type reclaim_on_scope_exit{
+        *source_children_itr, db_instance};
+
+    ++source_keys_itr;
+    ++source_children_itr;
+
+    while (source_keys_itr !=
+           source_node->keys.byte_array.cbegin() + inode16_type::min_size) {
+      *keys_itr++ = *source_keys_itr++;
+      *children_itr++ = *source_children_itr++;
+    }
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + this->f.f.children_count));
+  }
+
+  constexpr void add(db_leaf_unique_ptr child, tree_depth depth) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_4::static_node_type);
+
+    auto children_count = this->f.f.children_count.load();
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+
+    const auto key_byte =
+        static_cast<std::uint8_t>(leaf_type::key(child.get())[depth]);
+
+    const auto first_lt = ((keys.integer & 0xFFU) < key_byte) ? 1 : 0;
+    const auto second_lt = (((keys.integer >> 8U) & 0xFFU) < key_byte) ? 1 : 0;
+    const auto third_lt =
+        ((children_count == 3) && ((keys.integer >> 16U) & 0xFFU) < key_byte)
+            ? 1
+            : 0;
+    const auto insert_pos_index =
+        static_cast<unsigned>(first_lt + second_lt + third_lt);
+
+    for (typename decltype(keys.byte_array)::size_type i = children_count;
+         i > insert_pos_index; --i) {
+      keys.byte_array[i] = keys.byte_array[i - 1];
+      // TODO(laurynas): Node4 children fit into a single YMM register on AVX
+      // onwards, see if it is possible to do shift/insert with it. Checked
+      // plain AVX, it seems that at least AVX2 is required.
+      children[i] = children[i - 1];
+    }
+    keys.byte_array[insert_pos_index] = static_cast<std::byte>(key_byte);
+    children[insert_pos_index] = child.release();
+
+    ++children_count;
+    this->f.f.children_count = children_count;
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+  }
+
+  constexpr void remove(std::uint8_t child_index, db &db_instance) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_4::static_node_type);
+
+    auto children_count = this->f.f.children_count.load();
+
+    assert(child_index < children_count);
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+
+    reclaim_node_ptr_at_scope_exit_type reclaim_on_scope_exit{
+        children[child_index], db_instance};
+
+    for (typename decltype(keys.byte_array)::size_type i = child_index;
+         i < static_cast<unsigned>(this->f.f.children_count - 1); ++i) {
+      // TODO(laurynas): see the AVX2 TODO at add method
+      keys.byte_array[i] = keys.byte_array[i + 1];
+      children[i] = children[i + 1];
+    }
+
+    --children_count;
+    this->f.f.children_count = children_count;
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+  }
+
+  constexpr auto leave_last_child(std::uint8_t child_to_delete,
+                                  db &db_instance) noexcept {
+    assert(this->is_min_size());
+    assert(child_to_delete == 0 || child_to_delete == 1);
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_4::static_node_type);
+
+    const auto child_to_delete_ptr = children[child_to_delete].load();
+    const std::uint8_t child_to_leave = (child_to_delete == 0) ? 1 : 0;
+    const auto child_to_leave_ptr = children[child_to_leave].load();
+    reclaim_node_ptr_at_scope_exit_type reclaim_on_scope_exit{
+        child_to_delete_ptr, db_instance};
+    if (child_to_leave_ptr.type() != node_type::LEAF) {
+      child_to_leave_ptr.internal->prepend_key_prefix(
+          *this, keys.byte_array[child_to_leave]);
+    }
+    return child_to_leave_ptr;
+  }
+
+  [[nodiscard]] __attribute__((pure)) find_result find_child(
+      std::byte key_byte) noexcept {
+#ifdef __x86_64
+    const auto replicated_search_key =
+        _mm_set1_epi8(static_cast<char>(key_byte));
+    const auto keys_in_sse_reg =
+        _mm_cvtsi32_si128(static_cast<std::int32_t>(keys.integer.load()));
+    const auto matching_key_positions =
+        _mm_cmpeq_epi8(replicated_search_key, keys_in_sse_reg);
+    const auto mask = (1U << this->f.f.children_count.load()) - 1;
+    const auto bit_field =
+        static_cast<unsigned>(_mm_movemask_epi8(matching_key_positions)) & mask;
+    if (bit_field != 0) {
+      const auto i = static_cast<unsigned>(__builtin_ctz(bit_field));
+      return std::make_pair(
+          i, static_cast<atomic_policy<node_ptr> *>(&children[i]));
+    }
+    return std::make_pair(0xFF, nullptr);
+#else  // #ifdef __x86_64
+    // Bit twiddling:
+    // contains_byte:     __builtin_ffs:   for key index:
+    //    0x80000000               0x20                3
+    //      0x800000               0x18                2
+    //      0x808000               0x10                1
+    //          0x80                0x8                0
+    //           0x0                0x0        not found
+    const auto result =
+        static_cast<decltype(keys.byte_array.load())::size_type>(
+            // __builtin_ffs takes signed argument:
+            // NOLINTNEXTLINE(hicpp-signed-bitwise)
+            __builtin_ffs(static_cast<std::int32_t>(
+                contains_byte(keys.integer, key_byte))) >>
+            3);
+
+    if ((result == 0) || (result > this->children_count.load()))
+      return std::make_pair(0xFF, nullptr);
+
+    return std::make_pair(result - 1, static_cast<atomic_policy<node_ptr> *>(
+                                          &children[result - 1]));
+#endif  // #ifdef __x86_64
+  }
+
+  constexpr void delete_subtree(db &db_instance) noexcept {
+    const auto children_count_copy = this->f.f.children_count.load();
+    for (std::uint8_t i = 0; i < children_count_copy; ++i) {
+      db_instance.delete_subtree(children[i]);
+    }
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    const auto children_count_copy = this->f.f.children_count.load();
+    os << ", key bytes =";
+    for (std::uint8_t i = 0; i < children_count_copy; i++)
+      dump_byte(os, this->keys.byte_array[i]);
+    os << ", children:\n";
+    for (std::uint8_t i = 0; i < children_count_copy; i++)
+      dump_node(os, children[i].load());
+  }
+
+ protected:
+  constexpr void add_two_to_empty(std::byte key1, node_ptr child1,
+                                  std::byte key2,
+                                  db_leaf_unique_ptr child2) noexcept {
+    assert(key1 != key2);
+    assert(this->f.f.children_count == 2);
+
+    const std::uint8_t key1_i = key1 < key2 ? 0 : 1;
+    const std::uint8_t key2_i = key1_i == 0 ? 1 : 0;
+    this->keys.byte_array[key1_i] = key1;
+    this->children[key1_i] = child1;
+    this->keys.byte_array[key2_i] = key2;
+    this->children[key2_i] = child2.release();
+    keys.byte_array[2] = std::byte{0};
+    keys.byte_array[3] = std::byte{0};
+
+    assert(std::is_sorted(
+        this->keys.byte_array.cbegin(),
+        this->keys.byte_array.cbegin() + this->f.f.children_count));
+  }
+
+  union {
+    std::array<atomic_policy<std::byte>, basic_inode_4::capacity> byte_array;
+    atomic_policy<std::uint32_t> integer;
+  } keys;
+
+  std::array<atomic_policy<node_ptr>, basic_inode_4::capacity> children;
+
+ private:
+  template <class>
+  friend class basic_inode_16;
+};
+
+template <class ArtPolicy>
+using basic_inode_16_parent = basic_inode<
+    ArtPolicy, 5, 16, node_type::I16, typename ArtPolicy::inode4_type,
+    typename ArtPolicy::inode48_type, typename ArtPolicy::inode16_type>;
+
+template <class ArtPolicy>
+class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
+ private:
+  using inode4_type = typename ArtPolicy::inode4_type;
+  using inode16_type = typename ArtPolicy::inode16_type;
+  using inode48_type = typename ArtPolicy::inode48_type;
+  using leaf_type = typename basic_inode_impl<ArtPolicy>::leaf_type;
+  template <typename T>
+  using atomic_policy = typename ArtPolicy::template atomic_policy<T>;
+  using node_ptr = typename ArtPolicy::node_ptr;
+  using reclaim_node_ptr_at_scope_exit_type =
+      typename ArtPolicy::reclaim_node_ptr_at_scope_exit_type;
+  using parent_class = basic_inode_16_parent<ArtPolicy>;
+
+ public:
+  using db_leaf_unique_ptr = typename ArtPolicy::db_leaf_unique_ptr;
+  using db = typename ArtPolicy::db;
+  using find_result = typename basic_inode_impl<ArtPolicy>::find_result;
+
+  constexpr basic_inode_16(std::unique_ptr<inode4_type> source_node,
+                           db_leaf_unique_ptr child, tree_depth depth) noexcept
+      : parent_class{*source_node} {
+    const auto key_byte =
+        static_cast<std::uint8_t>(leaf_type::key(child.get())[depth]);
+
+    const auto keys_integer = source_node->keys.integer.load();
+    const auto first_lt = ((keys_integer & 0xFFU) < key_byte) ? 1 : 0;
+    const auto second_lt = (((keys_integer >> 8U) & 0xFFU) < key_byte) ? 1 : 0;
+    const auto third_lt = (((keys_integer >> 16U) & 0xFFU) < key_byte) ? 1 : 0;
+    const auto fourth_lt = (((keys_integer >> 24U) & 0xFFU) < key_byte) ? 1 : 0;
+    const auto insert_pos_index =
+        static_cast<unsigned>(first_lt + second_lt + third_lt + fourth_lt);
+
+    unsigned i = 0;
+    for (; i < insert_pos_index; ++i) {
+      keys.byte_array[i] = source_node->keys.byte_array[i];
+      children[i] = source_node->children[i];
+    }
+
+    keys.byte_array[i] = static_cast<std::byte>(key_byte);
+    children[i] = child.release();
+    ++i;
+
+    for (; i <= inode4_type::capacity; ++i) {
+      keys.byte_array[i] = source_node->keys.byte_array[i - 1];
+      children[i] = source_node->children[i - 1];
+    }
+  }
+
+  constexpr basic_inode_16(std::unique_ptr<inode48_type> source_node,
+                           std::uint8_t child_to_delete,
+                           db &db_instance) noexcept
+      : parent_class{*source_node} {
+    source_node->remove_child_pointer(child_to_delete, db_instance);
+    source_node->child_indexes[child_to_delete] = inode48_type::empty_child;
+
+    // TODO(laurynas): consider AVX512 gather?
+    unsigned next_child = 0;
+    unsigned i = 0;
+    while (true) {
+      const auto source_child_i = source_node->child_indexes[i].load();
+      if (source_child_i != inode48_type::empty_child) {
+        keys.byte_array[next_child] = gsl::narrow_cast<std::byte>(i);
+        const auto source_child_ptr =
+            source_node->children.pointer_array[source_child_i].load();
+        assert(source_child_ptr != nullptr);
+        this->children[next_child] = source_child_ptr;
+        ++next_child;
+        if (next_child == basic_inode_16::capacity) break;
+      }
+      assert(i < 255);
+      ++i;
+    }
+
+    assert(basic_inode_16::capacity == this->f.f.children_count);
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + basic_inode_16::capacity));
+  }
+
+  constexpr void add(db_leaf_unique_ptr child, tree_depth depth) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_16::static_node_type);
+
+    const auto key_byte = leaf_type::key(child.get())[depth];
+    auto children_count = this->f.f.children_count.load();
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+
+    const auto insert_pos_index =
+        get_sorted_key_array_insert_position(key_byte);
+    if (insert_pos_index != children_count) {
+      assert(keys.byte_array[insert_pos_index] != key_byte);
+      std::copy_backward(keys.byte_array.cbegin() + insert_pos_index,
+                         keys.byte_array.cbegin() + children_count,
+                         keys.byte_array.begin() + children_count + 1);
+      std::copy_backward(children.begin() + insert_pos_index,
+                         children.begin() + children_count,
+                         children.begin() + children_count + 1);
+    }
+    keys.byte_array[insert_pos_index] = key_byte;
+    children[insert_pos_index] = node_ptr{child.release()};
+    ++children_count;
+    this->f.f.children_count = children_count;
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+   }
+
+  constexpr void remove(std::uint8_t child_index, db &db_instance) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_16::static_node_type);
+    auto children_count = this->f.f.children_count.load();
+    assert(child_index < children_count);
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+
+    reclaim_node_ptr_at_scope_exit_type reclamator{children[child_index],
+                                                   db_instance};
+
+    for (unsigned i = child_index + 1; i < children_count; ++i) {
+      keys.byte_array[i - 1] = keys.byte_array[i];
+      children[i - 1] = children[i];
+    }
+
+    --children_count;
+    this->f.f.children_count = children_count;
+
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+  }
+
+  [[nodiscard]] constexpr __attribute__((pure)) find_result find_child(
+      std::byte key_byte) noexcept {
+#ifdef __x86_64
+    const auto replicated_search_key =
+        _mm_set1_epi8(static_cast<char>(key_byte));
+    const auto matching_key_positions =
+        _mm_cmpeq_epi8(replicated_search_key, this->keys.sse);
+    const auto mask = (1U << this->f.f.children_count) - 1;
+    const auto bit_field =
+        static_cast<unsigned>(_mm_movemask_epi8(matching_key_positions)) & mask;
+    if (bit_field != 0) {
+      const auto i = static_cast<unsigned>(__builtin_ctz(bit_field));
+      return std::make_pair(
+          i, static_cast<atomic_policy<node_ptr> *>(&this->children[i]));
+    }
+    return std::make_pair(0xFF, nullptr);
+#else
+#error Needs porting
+#endif
+  }
+
+  constexpr void delete_subtree(db &db_instance) noexcept {
+    const auto children_count = this->f.f.children_count.load();
+    for (std::uint8_t i = 0; i < children_count; ++i)
+      db_instance.delete_subtree(this->children[i]);
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    const auto children_count = this->f.f.children_count.load();
+    os << ", key bytes =";
+    for (std::uint8_t i = 0; i < children_count; ++i)
+      dump_byte(os, this->keys.byte_array[i]);
+    os << ", children:\n";
+    for (std::uint8_t i = 0; i < children_count; ++i)
+      dump_node(os, this->children[i].load());
+  }
+
+ private:
+  __attribute__((pure)) constexpr auto get_sorted_key_array_insert_position(
+      std::byte key_byte) noexcept {
+    const auto children_count = this->f.f.children_count.load();
+
+    assert(children_count < basic_inode_16::capacity);
+    assert(std::is_sorted(keys.byte_array.cbegin(),
+                          keys.byte_array.cbegin() + children_count));
+    assert(std::adjacent_find(keys.byte_array.cbegin(),
+                              keys.byte_array.cbegin() + children_count) >=
+           keys.byte_array.cbegin() + children_count);
+
+#ifdef __x86_64
+    const auto replicated_insert_key =
+        _mm_set1_epi8(static_cast<char>(key_byte));
+    const auto lesser_key_positions =
+        _mm_cmple_epu8(replicated_insert_key, keys.sse);
+    const auto mask = (1U << children_count) - 1;
+    const auto bit_field =
+        static_cast<unsigned>(_mm_movemask_epi8(lesser_key_positions)) & mask;
+    const auto result = static_cast<std::uint8_t>(
+        (bit_field != 0) ? __builtin_ctz(bit_field) : children_count);
+#else
+    const auto result = static_cast<std::uint8_t>(
+        std::lower_bound(keys.byte_array.cbegin(),
+                         keys.byte_array.cbegin() + children_count_ccopy,
+                         key_byte) -
+        keys.byte_array.cbegin());
+#endif
+
+    assert(result == children_count || keys.byte_array[result] != key_byte);
+    return result;
+  }
+
+ protected:
+  union {
+    std::array<atomic_policy<std::byte>, basic_inode_16::capacity> byte_array;
+    __m128i sse;
+  } keys;
+  std::array<atomic_policy<node_ptr>, basic_inode_16::capacity> children;
+
+ private:
+  static constexpr std::uint8_t empty_child = 0xFF;
+
+  template <class>
+  friend class basic_inode_4;
+  template <class>
+  friend class basic_inode_48;
+};
+
+template <class ArtPolicy>
+using basic_inode_48_parent = basic_inode<
+    ArtPolicy, 17, 48, node_type::I48, typename ArtPolicy::inode16_type,
+    typename ArtPolicy::inode256_type, typename ArtPolicy::inode48_type>;
+
+template <class ArtPolicy>
+class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
+  using inode16_type = typename ArtPolicy::inode16_type;
+  using inode48_type = typename ArtPolicy::inode48_type;
+  using inode256_type = typename ArtPolicy::inode256_type;
+  template <typename T>
+  using atomic_policy = typename ArtPolicy::template atomic_policy<T>;
+  using node_ptr = typename ArtPolicy::node_ptr;
+  using reclaim_node_ptr_at_scope_exit_type =
+      typename ArtPolicy::reclaim_node_ptr_at_scope_exit_type;
+  using parent_type = basic_inode_48_parent<ArtPolicy>;
+
+ public:
+  using db_leaf_unique_ptr = typename ArtPolicy::db_leaf_unique_ptr;
+  using db = typename ArtPolicy::db;
+
+  constexpr basic_inode_48(std::unique_ptr<inode16_type> source_node,
+                           db_leaf_unique_ptr child, tree_depth depth) noexcept
+      : parent_type{*source_node} {
+    auto *const __restrict__ source_node_ptr = source_node.get();
+    auto *const __restrict__ child_ptr = child.release();
+
+    // TODO(laurynas): initialize at declaration
+    // Cannot use memset without C++20 atomic_ref, but even then check whether
+    // this compiles to memset already
+    std::fill(this->child_indexes.begin(), this->child_indexes.end(),
+              empty_child);
+
+    // TODO(laurynas): consider AVX512 scatter?
+    std::uint8_t i = 0;
+    for (; i < inode16_type::capacity; ++i) {
+      const auto existing_key_byte = source_node_ptr->keys.byte_array[i].load();
+      this->child_indexes[static_cast<std::uint8_t>(existing_key_byte)] = i;
+    }
+    for (i = 0; i < inode16_type::capacity; ++i) {
+      this->children.pointer_array[i] = source_node_ptr->children[i];
+    }
+
+    const auto key_byte = static_cast<std::uint8_t>(
+        basic_inode_48::leaf_type::key(child_ptr)[depth]);
+    assert(this->child_indexes[key_byte] == empty_child);
+    this->child_indexes[key_byte] = i;
+    this->children.pointer_array[i] = child_ptr;
+    for (i = this->f.f.children_count; i < basic_inode_48::capacity; i++) {
+      this->children.pointer_array[i] = node_ptr{nullptr};
+    }
+  }
+
+  // The warning disable might go away once C++20 std::atomic_ref is used
+  DISABLE_GCC_WARNING("-Wclass-memaccess")
+  constexpr basic_inode_48(std::unique_ptr<inode256_type> source_node,
+                           std::uint8_t child_to_delete,
+                           db &db_instance) noexcept
+      : parent_type{*source_node} {
+    auto *const __restrict__ source_node_ptr = source_node.get();
+    reclaim_node_ptr_at_scope_exit_type reclaim_on_scope_exit{
+        source_node_ptr->children[child_to_delete].load(), db_instance};
+    source_node_ptr->children[child_to_delete] = nullptr;
+
+    std::memset(&child_indexes[0], empty_child, 256);
+
+    std::uint8_t next_child = 0;
+    for (unsigned child_i = 0; child_i < 256; child_i++) {
+      const auto child_ptr = source_node_ptr->children[child_i].load();
+      if (child_ptr == nullptr) continue;
+
+      this->child_indexes[child_i] = next_child;
+      this->children.pointer_array[next_child] =
+          source_node_ptr->children[child_i].load();
+      ++next_child;
+
+      if (next_child == this->f.f.children_count) break;
+    }
+  }
+  RESTORE_GCC_WARNINGS()
+
+  constexpr void add(db_leaf_unique_ptr child, tree_depth depth) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_48::static_node_type);
+
+    const auto key_byte = static_cast<uint8_t>(
+        basic_inode_48::leaf_type::key(child.get())[depth]);
+    assert(child_indexes[key_byte] == empty_child);
+    unsigned i{0};
+#ifdef __x86_64
+    const auto nullptr_vector = _mm_setzero_si128();
+    while (true) {
+      const auto ptr_vec0 = _mm_load_si128(&children.pointer_vector[i]);
+      const auto ptr_vec1 = _mm_load_si128(&children.pointer_vector[i + 1]);
+      const auto ptr_vec2 = _mm_load_si128(&children.pointer_vector[i + 2]);
+      const auto ptr_vec3 = _mm_load_si128(&children.pointer_vector[i + 3]);
+      const auto vec0_cmp = _mm_cmpeq_epi64(ptr_vec0, nullptr_vector);
+      const auto vec1_cmp = _mm_cmpeq_epi64(ptr_vec1, nullptr_vector);
+      const auto vec2_cmp = _mm_cmpeq_epi64(ptr_vec2, nullptr_vector);
+      const auto vec3_cmp = _mm_cmpeq_epi64(ptr_vec3, nullptr_vector);
+      // OK to treat 64-bit comparison result as 32-bit vector: we need to find
+      // the first 0xFF only.
+      const auto vec01_cmp = _mm_packs_epi32(vec0_cmp, vec1_cmp);
+      const auto vec23_cmp = _mm_packs_epi32(vec2_cmp, vec3_cmp);
+      const auto vec_cmp = _mm_packs_epi32(vec01_cmp, vec23_cmp);
+      const auto cmp_mask =
+          static_cast<std::uint64_t>(_mm_movemask_epi8(vec_cmp));
+      if (cmp_mask != 0) {
+        i = (i << 1U) + (ffs_nonzero(cmp_mask) >> 1U);
+        break;
+      }
+      i += 4;
+    }
+#else  // #ifdef __x86_64
+    node_ptr child_ptr;
+    while (true) {
+      child_ptr = children.pointer_array[i];
+      if (child_ptr == nullptr) break;
+      assert(i < 255);
+      ++i;
+    }
+#endif  // #ifdef __x86_64
+    assert(children.pointer_array[i] == nullptr);
+    child_indexes[key_byte] = gsl::narrow_cast<std::uint8_t>(i);
+    children.pointer_array[i] = child.release();
+    ++this->f.f.children_count;
+  }
+
+  constexpr void remove(std::uint8_t child_index, db &db_instance) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_48::static_node_type);
+
+    remove_child_pointer(child_index, db_instance);
+    children.pointer_array[child_indexes[child_index]] = node_ptr{nullptr};
+    child_indexes[child_index] = empty_child;
+    --this->f.f.children_count;
+  }
+
+  [[nodiscard]] constexpr typename basic_inode_48::find_result find_child(
+      std::byte key_byte) noexcept {
+    if (this->child_indexes[static_cast<std::uint8_t>(key_byte)] !=
+        empty_child) {
+      const auto child_i =
+          this->child_indexes[static_cast<std::uint8_t>(key_byte)].load();
+      return std::make_pair(static_cast<std::uint8_t>(key_byte),
+                            &this->children.pointer_array[child_i]);
+    }
+    return std::make_pair(0xFF, nullptr);
+  }
+
+  constexpr void delete_subtree(db &db_instance) noexcept {
+    const auto children_count USED_IN_DEBUG = this->f.f.children_count.load();
+
+    unsigned actual_children_count = 0;
+    for (unsigned i = 0; i < this->capacity; ++i) {
+      const auto child = this->children.pointer_array[i].load();
+      if (child != nullptr) {
+        ++actual_children_count;
+        db_instance.delete_subtree(child);
+        assert(actual_children_count <= children_count);
+      }
+    }
+    assert(actual_children_count == children_count);
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    const auto children_count USED_IN_DEBUG = this->f.f.children_count.load();
+
+    os << ", key bytes & child indexes\n";
+    unsigned actual_children_count = 0;
+    for (unsigned i = 0; i < 256; i++)
+      if (this->child_indexes[i] != empty_child) {
+        ++actual_children_count;
+        os << " ";
+        dump_byte(os, gsl::narrow_cast<std::byte>(i));
+        os << ", child index = "
+           << static_cast<unsigned>(this->child_indexes[i]) << ": ";
+        assert(this->children.pointer_array[this->child_indexes[i]] != nullptr);
+        dump_node(os,
+                  this->children.pointer_array[this->child_indexes[i]].load());
+        assert(actual_children_count <= children_count);
+      }
+
+    assert(actual_children_count == children_count);
+  }
+
+ private:
+  constexpr void remove_child_pointer(std::uint8_t child_index,
+                                      db &db_instance) noexcept {
+    direct_remove_child_pointer(child_indexes[child_index], db_instance);
+  }
+
+  constexpr void direct_remove_child_pointer(std::uint8_t children_i,
+                                             db &db_instance) noexcept {
+    const auto child_ptr = children.pointer_array[children_i].load();
+
+    assert(children_i != empty_child);
+    assert(child_ptr != nullptr);
+
+    reclaim_node_ptr_at_scope_exit_type reclaim{child_ptr, db_instance};
+  }
+
+  std::array<atomic_policy<std::uint8_t>, 256> child_indexes;
+  union children_union {
+    std::array<atomic_policy<node_ptr>, basic_inode_48::capacity> pointer_array;
+#ifdef __x86_64
+    static_assert(basic_inode_48::capacity % 2 == 0);
+    // To support unrolling without remainder
+    static_assert((basic_inode_48::capacity / 2) % 4 == 0);
+    // No std::array below because it would ignore the alignment attribute
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    __m128i
+        pointer_vector[basic_inode_48::capacity / 2];  // NOLINT(runtime/arrays)
+#endif
+    children_union() {}
+  } children;
+
+  static constexpr std::uint8_t empty_child = 0xFF;
+
+  template <class>
+  friend class basic_inode_16;
+  template <class>
+  friend class basic_inode_256;
+};
+
+template <class ArtPolicy>
+using basic_inode_256_parent =
+    basic_inode<ArtPolicy, 49, 256, node_type::I256,
+                typename ArtPolicy::inode48_type, fake_inode,
+                typename ArtPolicy::inode256_type>;
+
+template <class ArtPolicy>
+class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
+ private:
+  using inode48_type = typename ArtPolicy::inode48_type;
+  using inode256_type = typename ArtPolicy::inode256_type;
+  template <typename T>
+  using atomic_policy = typename ArtPolicy::template atomic_policy<T>;
+  using node_ptr = typename ArtPolicy::node_ptr;
+  using reclaim_node_ptr_at_scope_exit_type =
+      typename ArtPolicy::reclaim_node_ptr_at_scope_exit_type;
+  using parent_type = basic_inode_256_parent<ArtPolicy>;
+
+ public:
+  using db = typename ArtPolicy::db;
+  using db_leaf_unique_ptr = typename ArtPolicy::db_leaf_unique_ptr;
+
+  constexpr basic_inode_256(std::unique_ptr<inode48_type> source_node,
+                            db_leaf_unique_ptr child, tree_depth depth) noexcept
+      : parent_type{*source_node} {
+    unsigned children_copied = 0;
+    unsigned i = 0;
+    while (true) {
+      const auto children_i = source_node->child_indexes[i].load();
+      if (children_i == inode48_type::empty_child) {
+        children[i] = nullptr;
+      } else {
+        children[i] = source_node->children.pointer_array[children_i].load();
+        ++children_copied;
+        if (children_copied == inode48_type::capacity) break;
+      }
+      ++i;
+    }
+
+    ++i;
+    for (; i < basic_inode_256::capacity; ++i) children[i] = nullptr;
+
+    const auto key_byte = static_cast<uint8_t>(
+        basic_inode_256::leaf_type::key(child.get())[depth]);
+    assert(children[key_byte] == nullptr);
+    children[key_byte] = node_ptr{child.release()};
+  }
+
+  constexpr void add(db_leaf_unique_ptr child, tree_depth depth) noexcept {
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_256::static_node_type);
+    assert(!this->is_full());
+
+    const auto key_byte = static_cast<std::uint8_t>(
+        basic_inode_256::leaf_type::key(child.get())[depth]);
+    assert(children[key_byte] == nullptr);
+    children[key_byte] = node_ptr{child.release()};
+    ++this->f.f.children_count;
+  }
+
+  constexpr void remove(std::uint8_t child_index, db &db_instance) noexcept {
+    const auto child_ptr = children[child_index].load();
+
+    assert(reinterpret_cast<node_header *>(this)->type() ==
+           basic_inode_256::static_node_type);
+    assert(child_ptr != nullptr);
+
+    reclaim_node_ptr_at_scope_exit_type reclaim{child_ptr, db_instance};
+
+    children[child_index] = node_ptr{nullptr};
+    --this->f.f.children_count;
+  }
+
+  [[nodiscard]] constexpr typename basic_inode_256::find_result find_child(
+      std::byte key_byte) noexcept {
+    const auto key_int_byte = static_cast<std::uint8_t>(key_byte);
+    if (children[key_int_byte] != nullptr)
+      return std::make_pair(key_int_byte, &children[key_int_byte]);
+    return std::make_pair(0xFF, nullptr);
+  }
+
+  template <typename Function>
+  constexpr void for_each_child(Function func) noexcept(
+      noexcept(func(0, node_ptr{nullptr}))) {
+    const auto children_count USED_IN_DEBUG = this->f.f.children_count.load();
+    std::uint8_t actual_children_count = 0;
+    for (unsigned i = 0; i < 256; ++i) {
+      const auto child_ptr = children[i].load();
+      if (child_ptr != nullptr) {
+        ++actual_children_count;
+        func(i, child_ptr);
+        assert(actual_children_count <= children_count || children_count == 0);
+      }
+    }
+    assert(actual_children_count == children_count);
+  }
+
+  template <typename Function>
+  constexpr void for_each_child(Function func) const
+      noexcept(noexcept(func(0, node_ptr{nullptr}))) {
+    const_cast<basic_inode_256 *>(this)->for_each_child(func);
+  }
+
+  constexpr void delete_subtree(db &db_instance) noexcept {
+    for_each_child([&db_instance](unsigned, node_ptr child) noexcept {
+      db_instance.delete_subtree(child);
+    });
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    os << ", key bytes & children:\n";
+    for_each_child([&](unsigned i, node_ptr child) noexcept {
+      os << ' ';
+      dump_byte(os, gsl::narrow_cast<std::byte>(i));
+      os << ' ';
+      dump_node(os, child);
+    });
+  }
+
+ private:
+  std::array<atomic_policy<node_ptr>, basic_inode_256::capacity> children;
+
+  template <class>
+  friend class basic_inode_48;
+};
+
+}  // namespace unodb::detail
+
+#endif  // UNODB_ART_INTERNAL_IMPL_HPP_

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 Laurynas Biveinis
+# Copyright 2020-2021 Laurynas Biveinis
 
 set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
 set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/20|/100'")
@@ -7,6 +7,7 @@ set(micro_benchmark_node48_quick_arg "--benchmark_filter='/64|/128|/192'")
 set(micro_benchmark_node256_quick_arg "--benchmark_filter='/8|/128|/192'")
 set(micro_benchmark_quick_arg "--benchmark_filter='.*262144|.*51200'")
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
+set(micro_benchmark_olc_quick_arg "--benchmark_filter='/4/70000/'")
 
 add_custom_target(benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_key_prefix
@@ -15,7 +16,8 @@ add_custom_target(benchmarks
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node48
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node256
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex)
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_olc)
 
 add_custom_target(quick_benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV}
@@ -31,7 +33,9 @@ add_custom_target(quick_benchmarks
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg})
+  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
+  ./micro_benchmark_olc ${micro_benchmark_olc_quick_arg})
 
 add_custom_target(valgrind_benchmarks
   COMMAND valgrind --error-exitcode=1 --leak-check=full
@@ -47,7 +51,9 @@ add_custom_target(valgrind_benchmarks
   COMMAND valgrind --error-exitcode=1 --leak-check=full
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg})
+  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
+  COMMAND valgrind --error-exitcode=1 --leak-check=full
+  ./micro_benchmark_olc ${micro_benchmark_olc_quick_arg})
 
 add_library(micro_benchmark_utils STATIC micro_benchmark_utils.cpp
   micro_benchmark_utils.hpp)
@@ -68,10 +74,16 @@ function(ADD_BENCHMARK_TARGET TARGET)
   add_dependencies(valgrind_benchmarks "${TARGET}")
 endfunction()
 
+function(ADD_CONCURRENT_BENCHMARK_TARGET TARGET)
+  add_benchmark_target("${TARGET}")
+  target_sources("${TARGET}" PRIVATE micro_benchmark_concurrency.hpp)
+endfunction()
+
 add_benchmark_target(micro_benchmark_key_prefix)
 add_benchmark_target(micro_benchmark_node4)
 add_benchmark_target(micro_benchmark_node16)
 add_benchmark_target(micro_benchmark_node48)
 add_benchmark_target(micro_benchmark_node256)
 add_benchmark_target(micro_benchmark)
-add_benchmark_target(micro_benchmark_mutex)
+add_concurrent_benchmark_target(micro_benchmark_mutex)
+add_concurrent_benchmark_target(micro_benchmark_olc)

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -1,0 +1,185 @@
+// Copyright 2020-2021 Laurynas Biveinis
+#ifndef UNODB_MICRO_BENCHMARK_CONCURRENCY_HPP_
+#define UNODB_MICRO_BENCHMARK_CONCURRENCY_HPP_
+
+#include "global.hpp"
+
+#include <memory>
+#include <thread>
+
+#include <benchmark/benchmark.h>
+
+#include "art_common.hpp"
+#include "micro_benchmark_utils.hpp"
+
+namespace unodb::benchmark {
+
+// Something small for CI quick checks
+static constexpr auto small_concurrent_tree_size = 70000;
+// Do not OOM on a 16GB Linux test server
+static constexpr auto large_concurrent_tree_size = 5000000;
+
+inline constexpr void concurrency_ranges(::benchmark::internal::Benchmark *b,
+                                         int max_concurrency) {
+  for (auto i = 1; i <= max_concurrency; i *= 2)
+    b->Args({i, small_concurrent_tree_size});
+  for (auto i = 1; i <= max_concurrency; i *= 2)
+    b->Args({i, large_concurrent_tree_size});
+}
+
+inline constexpr void concurrency_ranges16(
+    ::benchmark::internal::Benchmark *b) {
+  concurrency_ranges(b, 16);
+}
+
+inline constexpr void concurrency_ranges32(
+    ::benchmark::internal::Benchmark *b) {
+  concurrency_ranges(b, 32);
+}
+
+template <typename T>
+inline constexpr auto to_counter(T value) {
+  return ::benchmark::Counter{static_cast<double>(value)};
+}
+
+template <class Db, class Thread>
+class concurrent_benchmark {
+ protected:
+  virtual void setup() {}
+
+  virtual void end_workload_in_main_thread() {}
+
+  virtual void teardown() {}
+
+ public:
+  virtual ~concurrent_benchmark() {}
+
+  void parallel_get(::benchmark::State &state) {
+    test_db = std::make_unique<Db>();
+
+    const auto tree_size = static_cast<unodb::key>(state.range(1));
+    for (unodb::key i = 0; i < tree_size; ++i)
+      insert_key(*test_db, i, values[i % values.size()]);
+
+    const auto num_of_threads = static_cast<std::size_t>(state.range(0));
+    const unodb::key length = tree_size / num_of_threads;
+    // FIXME(laurynas): copy-paste
+    std::vector<Thread> threads{num_of_threads - 1};
+
+    for (auto _ : state) {
+      setup();
+
+      for (std::size_t i = 0; i < num_of_threads - 1; ++i) {
+        const unodb::key start = i * length;
+        threads[i] =
+            Thread{parallel_get_worker, std::ref(*test_db), start, length};
+      }
+
+      parallel_get_worker(*test_db, 0, length);
+
+      for (std::size_t i = 0; i < num_of_threads - 1; ++i) {
+        threads[i].join();
+      }
+
+      end_workload_in_main_thread();
+
+      teardown();
+    }
+
+    test_db.reset(nullptr);
+  }
+
+  void parallel_insert_disjoint_ranges(::benchmark::State &state) {
+    const auto num_of_threads = static_cast<std::size_t>(state.range(0));
+    const auto tree_size = static_cast<unodb::key>(state.range(1));
+    const unodb::key length = tree_size / num_of_threads;
+
+    for (auto _ : state) {
+      state.PauseTiming();
+      std::vector<Thread> threads{num_of_threads};
+      test_db = std::make_unique<Db>();
+      setup();
+      state.ResumeTiming();
+
+      for (std::size_t i = 1; i < num_of_threads; ++i) {
+        const unodb::key start = i * length;
+        threads[i] =
+            Thread{parallel_insert_worker, std::ref(*test_db), start, length};
+      }
+
+      parallel_insert_worker(*test_db, 0, length);
+
+      for (std::size_t i = 1; i < num_of_threads; ++i) {
+        threads[i].join();
+      }
+
+      end_workload_in_main_thread();
+
+      state.PauseTiming();
+      destroy_tree(*test_db, state);
+      teardown();
+    }
+
+    test_db.reset(nullptr);
+  }
+
+  void parallel_delete_disjoint_ranges(::benchmark::State &state) {
+    const auto tree_size = static_cast<unodb::key>(state.range(1));
+    const auto num_of_threads = static_cast<std::size_t>(state.range(0));
+    const unodb::key length = tree_size / num_of_threads;
+
+    for (auto _ : state) {
+      state.PauseTiming();
+      std::vector<Thread> threads{num_of_threads};
+      test_db = std::make_unique<Db>();
+      for (unodb::key i = 0; i < tree_size; ++i)
+        insert_key(*test_db, i, values[i % values.size()]);
+      setup();
+      state.ResumeTiming();
+
+      for (std::size_t i = 1; i < num_of_threads; ++i) {
+        const unodb::key start = i * length;
+        threads[i] =
+            Thread{parallel_delete_worker, std::ref(*test_db), start, length};
+      }
+
+      parallel_delete_worker(*test_db, 0, length);
+
+      for (std::size_t i = 1; i < num_of_threads; ++i) {
+        threads[i].join();
+      }
+
+      end_workload_in_main_thread();
+
+      state.PauseTiming();
+      destroy_tree(*test_db, state);
+      teardown();
+    }
+
+    test_db.reset(nullptr);
+  }
+
+ private:
+  static void parallel_get_worker(const Db &test_db, unodb::key start,
+                                  unodb::key length) {
+    for (unodb::key i = start; i < start + length; ++i)
+      get_existing_key(test_db, i);
+  }
+
+  static void parallel_insert_worker(Db &test_db, unodb::key start,
+                                     unodb::key length) {
+    for (unodb::key i = start; i < start + length; ++i)
+      insert_key(test_db, i, values[i % values.size()]);
+  }
+
+  static void parallel_delete_worker(Db &test_db, unodb::key start,
+                                     unodb::key length) {
+    for (unodb::key i = start; i < start + length; ++i) delete_key(test_db, i);
+  }
+
+  std::unique_ptr<Db> test_db;
+};
+
+}  // namespace unodb::benchmark
+
+#endif

--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -1,0 +1,102 @@
+// Copyright 2019-2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include "micro_benchmark_concurrency.hpp"
+#include "micro_benchmark_utils.hpp"
+#include "olc_art.hpp"
+#include "qsbr.hpp"
+
+namespace {
+
+class concurrent_benchmark_olc final
+    : public unodb::benchmark::concurrent_benchmark<unodb::olc_db,
+                                                    unodb::qsbr_thread> {
+ protected:
+  void setup() override {
+    assert_idle_qsbr();
+    unodb::qsbr::instance().reset();
+  }
+
+  void end_workload_in_main_thread() override {
+    unodb::current_thread_reclamator().quiescent_state();
+  }
+
+  void teardown() override {
+    assert_idle_qsbr();
+  }
+
+ private:
+  void assert_idle_qsbr() const {
+    // FIXME(laurynas): copy-paste with expect_idle_qsbr, but not clear how to
+    // fix this
+    assert(unodb::qsbr::instance().single_thread_mode());
+    assert(unodb::qsbr::instance().number_of_threads() == 1);
+    assert(unodb::qsbr::instance().previous_interval_size() == 0);
+    assert(unodb::qsbr::instance().current_interval_size() == 0);
+    assert(unodb::qsbr::instance().get_reserved_thread_capacity() == 1);
+    assert(unodb::qsbr::instance().get_threads_in_previous_epoch() == 1);
+  }
+};
+
+concurrent_benchmark_olc benchmark_fixture;
+
+void parallel_get(benchmark::State &state) {
+  benchmark_fixture.parallel_get(state);
+
+  state.counters["epoch changes"] = unodb::benchmark::to_counter(
+      unodb::qsbr::instance().get_epoch_change_count());
+  state.counters["mean qstates before epoch change"] = benchmark::Counter(
+      unodb::qsbr::instance()
+          .get_mean_quiescent_states_per_thread_between_epoch_changes());
+}
+
+void parallel_insert_disjoint_ranges(benchmark::State &state) {
+  benchmark_fixture.parallel_insert_disjoint_ranges(state);
+
+  state.counters["QSBR callback count max"] = unodb::benchmark::to_counter(
+      unodb::qsbr::instance().get_epoch_callback_count_max());
+  state.counters["callback count variance"] = benchmark::Counter(
+      unodb::qsbr::instance().get_epoch_callback_count_variance());
+  state.counters["epoch changes"] = unodb::benchmark::to_counter(
+      unodb::qsbr::instance().get_epoch_change_count());
+  state.counters["mean qstates before epoch change"] = benchmark::Counter(
+      unodb::qsbr::instance()
+          .get_mean_quiescent_states_per_thread_between_epoch_changes());
+}
+
+void parallel_delete_disjoint_ranges(benchmark::State &state) {
+  benchmark_fixture.parallel_delete_disjoint_ranges(state);
+
+  state.counters["max backlog bytes"] = unodb::benchmark::to_counter(
+      unodb::qsbr::instance().get_max_backlog_bytes());
+  state.counters["mean backlog bytes"] =
+      benchmark::Counter(unodb::qsbr::instance().get_mean_backlog_bytes());
+  state.counters["epoch changes"] = unodb::benchmark::to_counter(
+      unodb::qsbr::instance().get_epoch_change_count());
+  state.counters["mean qstates before epoch change"] = benchmark::Counter(
+      unodb::qsbr::instance()
+          .get_mean_quiescent_states_per_thread_between_epoch_changes());
+}
+
+}  // namespace
+
+BENCHMARK(parallel_get)
+    ->Apply(unodb::benchmark::concurrency_ranges16)
+    ->Unit(benchmark::kMillisecond)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+BENCHMARK(parallel_insert_disjoint_ranges)
+    ->Apply(unodb::benchmark::concurrency_ranges32)
+    ->Unit(benchmark::kMillisecond)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+BENCHMARK(parallel_delete_disjoint_ranges)
+    ->Apply(unodb::benchmark::concurrency_ranges32)
+    ->Unit(benchmark::kMillisecond)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+
+BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Laurynas Biveinis
+// Copyright 2020-2021 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -11,6 +11,7 @@
 
 #include "art.hpp"
 #include "mutex_art.hpp"
+#include "olc_art.hpp"
 
 namespace {
 
@@ -177,7 +178,7 @@ std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
       }
     }
   }
-  cannot_happen();
+  unodb::cannot_happen();
 }
 
 // Asserts
@@ -486,6 +487,8 @@ template void destroy_tree<unodb::db>(unodb::db &,
                                       ::benchmark::State &) noexcept;
 template void destroy_tree<unodb::mutex_db>(unodb::mutex_db &,
                                             ::benchmark::State &) noexcept;
+template void destroy_tree<unodb::olc_db>(unodb::olc_db &,
+                                          ::benchmark::State &) noexcept;
 
 // Benchmarks
 

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Laurynas Biveinis
+// Copyright 2019-2021 Laurynas Biveinis
 #ifndef MICRO_BENCHMARK_HPP_
 #define MICRO_BENCHMARK_HPP_
 
@@ -24,6 +24,7 @@
 namespace unodb {
 class db;
 class mutex_db;
+class olc_db;
 }  // namespace unodb
 
 namespace unodb::benchmark {
@@ -350,6 +351,8 @@ extern template void destroy_tree<unodb::db>(unodb::db &,
                                              ::benchmark::State &) noexcept;
 extern template void destroy_tree<unodb::mutex_db>(
     unodb::mutex_db &, ::benchmark::State &) noexcept;
+extern template void destroy_tree<unodb::olc_db>(unodb::olc_db &,
+                                                 ::benchmark::State &) noexcept;
 
 // Benchmarks
 

--- a/db_test_utils.cpp
+++ b/db_test_utils.cpp
@@ -1,11 +1,13 @@
-// Copyright 2019-2020 Laurynas Biveinis
+// Copyright 2019-2021 Laurynas Biveinis
 
 #include "global.hpp"
 
-#include "test_utils.hpp"
+#include "db_test_utils.hpp"
 
 #include "art.hpp"
 #include "mutex_art.hpp"
+#include "olc_art.hpp"
 
 template class tree_verifier<unodb::db>;
 template class tree_verifier<unodb::mutex_db>;
+template class tree_verifier<unodb::olc_db>;

--- a/db_test_utils.hpp
+++ b/db_test_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_TEST_UTILS_HPP_
-#define UNODB_TEST_UTILS_HPP_
+#ifndef UNODB_DB_TEST_UTILS_HPP_
+#define UNODB_DB_TEST_UTILS_HPP_
 
 #include "global.hpp"
 
@@ -16,6 +16,8 @@
 
 #include "art.hpp"
 #include "mutex_art.hpp"
+#include "olc_art.hpp"
+#include "qsbr.hpp"
 
 constexpr auto test_value_1 = std::array<std::byte, 1>{std::byte{0x00}};
 constexpr auto test_value_2 =
@@ -283,5 +285,8 @@ class tree_verifier final {
 
 extern template class tree_verifier<unodb::db>;
 extern template class tree_verifier<unodb::mutex_db>;
+extern template class tree_verifier<unodb::olc_db>;
 
-#endif  // UNODB_TEST_UTILS_HPP_
+using olc_tree_verifier = tree_verifier<unodb::olc_db>;
+
+#endif  // UNODB_DB_TEST_UTILS_HPP_

--- a/debug_thread_sync.h
+++ b/debug_thread_sync.h
@@ -1,0 +1,47 @@
+// Copyright 2020-2021 Laurynas Biveinis
+#ifndef UNODB_DEBUG_THREAD_SYNC_H_
+#define UNODB_DEBUG_THREAD_SYNC_H_
+
+#include "global.hpp"
+
+#include <cassert>
+#include <condition_variable>
+#include <mutex>
+
+namespace unodb::debug {
+
+class thread_wait final {
+ public:
+  ~thread_wait() noexcept { assert(is_reset()); }
+
+  [[nodiscard]] bool is_reset() const noexcept {
+    std::lock_guard<std::mutex> lock{sync_mutex};
+    return !flag;
+  }
+
+  void notify() {
+    {
+      std::lock_guard<std::mutex> lock{sync_mutex};
+      flag = true;
+    }
+    thread_sync.notify_one();
+  }
+
+  void wait() {
+    std::unique_lock<std::mutex> lock{sync_mutex};
+    // cppcheck-suppress assignBoolToPointer
+    thread_sync.wait(lock, [& flag = flag] { return flag; });
+    flag = false;
+    lock.unlock();
+  }
+
+ private:
+  // Replace with a C++20 latch when that's available
+  std::condition_variable thread_sync;
+  mutable std::mutex sync_mutex;
+  bool flag{false};
+};
+
+}  // namespace unodb::debug
+
+#endif  // UNODB_DEBUG_THREAD_SYNC_H_

--- a/heap.hpp
+++ b/heap.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Laurynas Biveinis
+// Copyright 2020-2021 Laurynas Biveinis
 #ifndef UNODB_HEAP_HPP_
 #define UNODB_HEAP_HPP_
 
@@ -11,6 +11,7 @@
 #ifndef USE_STD_PMR
 #include <boost/container/pmr/global_resource.hpp>
 #include <boost/container/pmr/memory_resource.hpp>
+#include <boost/container/pmr/synchronized_pool_resource.hpp>
 #include <boost/container/pmr/unsynchronized_pool_resource.hpp>
 #endif
 
@@ -45,6 +46,7 @@ namespace unodb::detail {
 using pmr_pool = std::pmr::memory_resource;
 using pmr_pool_options = std::pmr::pool_options;
 inline const auto &pmr_new_delete_resource = std::pmr::new_delete_resource;
+using pmr_synchronized_pool_resource = std::pmr::synchronized_pool_resource;
 using pmr_unsynchronized_pool_resource = std::pmr::unsynchronized_pool_resource;
 
 #else
@@ -53,6 +55,8 @@ using pmr_pool = boost::container::pmr::memory_resource;
 using pmr_pool_options = boost::container::pmr::pool_options;
 inline const auto &pmr_new_delete_resource =
     boost::container::pmr::new_delete_resource;
+using pmr_synchronized_pool_resource =
+    boost::container::pmr::synchronized_pool_resource;
 using pmr_unsynchronized_pool_resource =
     boost::container::pmr::unsynchronized_pool_resource;
 

--- a/not_atomic.hpp
+++ b/not_atomic.hpp
@@ -1,0 +1,60 @@
+// Copyright 2019-2021 Laurynas Biveinis
+#ifndef NOT_ATOMIC_HPP_
+#define NOT_ATOMIC_HPP_
+
+#include "global.hpp"
+
+#include <cstddef>
+#include <type_traits>
+
+namespace unodb {
+
+// A template wrapper providing access to T with std::atomic-like interface
+// (like relaxed_atomic<T>), which is not actually atomic. It enables having a
+// common templatized non-atomic and relaxed atomic implementation.
+template <typename T>
+class not_atomic final {
+ public:
+  constexpr not_atomic() noexcept = default;
+  // cppcheck-suppress noExplicitConstructor
+  constexpr not_atomic(T value_) noexcept : value{value_} {}
+  constexpr not_atomic(const not_atomic<T> &) = default;
+  constexpr not_atomic(not_atomic<T> &&) = default;
+
+  // Regular C++ assignment operators return ref to this, std::atomic returns
+  // the assigned value, we return nothing as we never chain assignments.
+  constexpr void operator=(T new_value) noexcept { value = new_value; }
+
+  constexpr void operator=(not_atomic<T> new_value) noexcept {
+    value = new_value;
+  }
+
+  constexpr void operator++() noexcept { ++value; }
+
+  constexpr void operator--() noexcept { --value; }
+
+  constexpr T operator--(int) noexcept { return value--; }
+
+  template <typename T_ = T,
+            typename = std::enable_if_t<!std::is_integral_v<T_>>>
+  [[nodiscard]] constexpr auto operator==(std::nullptr_t) const noexcept {
+    return value == nullptr;
+  }
+
+  template <typename T_ = T,
+            typename = std::enable_if_t<!std::is_integral_v<T_>>>
+  [[nodiscard]] constexpr auto operator!=(std::nullptr_t) const noexcept {
+    return value != nullptr;
+  }
+
+  constexpr operator T() const noexcept { return value; }
+
+  constexpr T load() const noexcept { return value; }
+
+ private:
+  T value;
+};
+
+}  // namespace unodb
+
+#endif  // NOT_ATOMIC_HPP_

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -1,0 +1,1129 @@
+// Copyright 2019-2021 Laurynas Biveinis
+
+#include "art_internal.hpp"
+#include "global.hpp"
+
+#include "olc_art.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+#include <gsl/gsl_util>
+
+#include "art_internal_impl.hpp"
+#include "optimistic_lock.hpp"
+#include "qsbr.hpp"
+
+namespace unodb::detail {
+
+static void olc_node_header_static_asserts();
+
+struct olc_node_header final {
+  constexpr explicit olc_node_header(node_type type_) : m_header{type_} {}
+
+  [[nodiscard]] constexpr auto type() const noexcept { return m_header.type(); }
+
+  [[nodiscard]] constexpr optimistic_lock &lock() const noexcept {
+    return m_lock;
+  }
+
+  void reinit_in_inode() noexcept { new (&m_lock) optimistic_lock; }
+
+ private:
+  // Composition and not inheritance so that std::is_standard_layout holds
+  const node_header m_header;
+  mutable optimistic_lock m_lock;
+
+  friend void olc_node_header_static_asserts();
+};
+
+// LCOV_EXCL_START
+DISABLE_WARNING("-Wunused-function")
+static void olc_node_header_static_asserts() {
+#ifdef NDEBUG
+  static_assert(sizeof(olc_node_header) == 16);
+#else
+  static_assert(sizeof(olc_node_header) == 32);
+#endif
+  static_assert(std::is_standard_layout_v<olc_node_header>);
+  static_assert(offsetof(unodb::detail::olc_node_header, m_lock) == 8);
+}
+RESTORE_WARNINGS()
+// LCOV_EXCL_STOP
+
+template <class Header, class Db>
+class db_leaf_qsbr_deleter {
+ public:
+  static_assert(std::is_trivially_destructible_v<basic_leaf<Header>>);
+
+  // cppcheck-suppress constParameter
+  constexpr explicit db_leaf_qsbr_deleter(Db &db_) noexcept
+      : db_instance{db_} {}
+
+  void operator()(raw_leaf_ptr to_delete) const noexcept {
+    const auto leaf_size = basic_leaf<Header>::size(to_delete);
+
+    unodb::qsbr::instance().on_next_epoch_pool_deallocate(
+        get_leaf_node_pool(), to_delete, leaf_size,
+        alignment_for_new<Header>());
+
+    db_instance.decrement_leaf_count(leaf_size);
+  }
+
+ private:
+  Db &db_instance;
+};
+
+}  // namespace unodb::detail
+
+namespace {
+
+template <class INode>
+struct inode_pool_getter {
+  [[nodiscard]] static inline auto &get() {
+    static unodb::detail::pmr_synchronized_pool_resource inode_pool{
+        unodb::detail::get_inode_pool_options<INode>()};
+    return inode_pool;
+  }
+};
+
+using olc_art_policy = unodb::detail::basic_art_policy<
+    unodb::olc_db, unodb::relaxed_atomic, unodb::detail::olc_node_ptr,
+    unodb::detail::db_leaf_qsbr_deleter, inode_pool_getter>;
+
+using olc_db_leaf_unique_ptr = olc_art_policy::db_leaf_unique_ptr;
+
+using leaf = olc_art_policy::leaf_type;
+
+using olc_inode_base = unodb::detail::basic_inode_impl<olc_art_policy>;
+
+using delete_db_node_ptr_at_scope_exit =
+    olc_art_policy::delete_db_node_ptr_at_scope_exit;
+
+[[nodiscard]] inline constexpr auto &node_ptr_lock(
+    const unodb::detail::olc_node_ptr &node) noexcept {
+  return node.header->lock();
+}
+
+template <class INode>
+[[nodiscard]] inline constexpr auto &lock(const INode &inode) noexcept {
+  return inode.get_header().lock();
+}
+
+template <class INode>
+void qsbr_delete(void *to_delete) {
+  static_assert(std::is_trivially_destructible_v<INode>);
+  unodb::qsbr::instance().on_next_epoch_pool_deallocate(
+      inode_pool_getter<INode>::get(), to_delete, sizeof(INode),
+      unodb::detail::alignment_for_new<INode>());
+}
+
+// FIXME(laurynas): belongs to optimistic_lock.hpp
+template <class T>
+std::remove_reference_t<T> &&obsolete_and_move(
+    T &&t, unodb::unique_write_lock_obsoleting_guard &&guard) noexcept {
+  assert(guard.guards(lock(*t)));
+
+  // My first attempt was to pass guard by value and let it destruct at the end
+  // of this scope, but due to copy elision (?) the destructor got called way
+  // too late, after the owner node was destructed.
+  guard.commit();
+
+  return static_cast<std::remove_reference_t<T> &&>(t);
+}
+
+inline auto obsolete_child_by_index(
+    std::uint8_t child,
+    unodb::unique_write_lock_obsoleting_guard &&guard) noexcept {
+  guard.commit();
+
+  return child;
+}
+
+}  // namespace
+
+namespace unodb::detail {
+
+class olc_inode : public olc_inode_base {};
+
+class olc_inode_4 final : public basic_inode_4<olc_art_policy> {
+ public:
+  constexpr olc_inode_4(detail::art_key k1, detail::art_key shifted_k2,
+                        detail::tree_depth depth, olc_node_ptr child1,
+                        olc_db_leaf_unique_ptr &&child2) noexcept
+      : basic_inode_4<olc_art_policy>{k1, shifted_k2, depth, child1,
+                                      std::move(child2)} {
+    assert(node_ptr_lock(child1).is_write_locked());
+  }
+
+  constexpr olc_inode_4(olc_node_ptr source_node, unsigned len,
+                        detail::tree_depth depth,
+                        olc_db_leaf_unique_ptr &&child1) noexcept
+      : basic_inode_4<olc_art_policy>{source_node, len, depth,
+                                      std::move(child1)} {
+    assert(node_ptr_lock(source_node).is_write_locked());
+  }
+
+  // FIXME(laurynas): hide guards in unique_ptr deleters?
+  olc_inode_4(std::unique_ptr<olc_inode_16> &&source_node,
+              unique_write_lock_obsoleting_guard &&node_obsoleting_guard,
+              std::uint8_t child_to_delete,
+              unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+              olc_db &db_instance) noexcept;
+
+  [[nodiscard]] static std::unique_ptr<olc_inode_4> create(
+      std::unique_ptr<olc_inode_16> &&source_node,
+      unique_write_lock_obsoleting_guard &&node_obsoleting_guard,
+      std::uint8_t child_to_delete,
+      unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+      olc_db &db_instance);
+
+  // Create a new node with two given child nodes
+  [[nodiscard]] static auto create(detail::art_key k1,
+                                   detail::art_key shifted_k2,
+                                   detail::tree_depth depth,
+                                   olc_node_ptr child1,
+                                   olc_db_leaf_unique_ptr &&child2) {
+    assert(node_ptr_lock(child1).is_write_locked());
+
+    return basic_inode_4::create(k1, shifted_k2, depth, child1,
+                                 std::move(child2));
+  }
+
+  // Create a new node, split the key prefix of an existing node, and make the
+  // new node contain that existing node and a given new node which caused
+  // this key prefix split.
+  [[nodiscard]] static auto create(olc_node_ptr source_node, unsigned len,
+                                   detail::tree_depth depth,
+                                   olc_db_leaf_unique_ptr &&child1) {
+    assert(node_ptr_lock(source_node).is_write_locked());
+
+    return basic_inode_4::create(source_node, len, depth, std::move(child1));
+  }
+
+  static void operator delete(void *to_delete) {
+    qsbr_delete<olc_inode_4>(to_delete);
+  }
+
+  void add(olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_4::add(std::move(child), depth);
+  }
+
+  void remove(std::uint8_t child_index, olc_db &db_instance) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_4::remove(child_index, db_instance);
+  }
+
+  void add_two_to_empty(std::byte key1, olc_node_ptr child1, std::byte key2,
+                        olc_db_leaf_unique_ptr &&child2) noexcept {
+    assert(node_ptr_lock(child1).is_write_locked());
+
+    basic_inode_4::add_two_to_empty(key1, child1, key2, std::move(child2));
+  }
+
+  auto leave_last_child(std::uint8_t child_to_delete,
+                        olc_db &db_instance) noexcept {
+    assert(lock(*this).is_obsoleted_by_this_thread());
+    assert(node_ptr_lock(children[child_to_delete].load())
+               .is_obsoleted_by_this_thread());
+
+    return basic_inode_4::leave_last_child(child_to_delete, db_instance);
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    os << ", ";
+    lock(*this).dump(os);
+    basic_inode_4::dump(os);
+  }
+};
+
+// 48 == sizeof(inode_4)
+#ifdef NDEBUG
+static_assert(sizeof(olc_inode_4) == 48 + 16);
+#else
+static_assert(sizeof(olc_inode_4) == 48 + 32);
+#endif
+
+class olc_inode_16 final : public basic_inode_16<olc_art_policy> {
+ public:
+  olc_inode_16(
+      std::unique_ptr<olc_inode_4> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept
+      : basic_inode_16<olc_art_policy>{
+            obsolete_and_move(source_node,
+                              std::move(source_node_obsoleting_guard)),
+            std::move(child), depth} {
+    assert(!source_node_obsoleting_guard.active());
+  }
+
+  olc_inode_16(
+      std::unique_ptr<olc_inode_48> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      std::uint8_t child_to_delete,
+      unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+      olc_db &db_instance) noexcept;
+
+  // FIXME(laurynas): if cannot hide the guards in unique_ptr, move superclass
+  // create methods to db::
+  [[nodiscard]] static auto create(
+      std::unique_ptr<olc_inode_4> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) {
+    assert(source_node_obsoleting_guard.guards(lock(*source_node)));
+
+    return std::make_unique<olc_inode_16>(
+        std::move(source_node), std::move(source_node_obsoleting_guard),
+        std::move(child), depth);
+  }
+
+  [[nodiscard]] static std::unique_ptr<olc_inode_16> create(
+      std::unique_ptr<olc_inode_48> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      std::uint8_t child_to_delete,
+      unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+      olc_db &db_instance);
+
+  static void operator delete(void *to_delete) {
+    qsbr_delete<olc_inode_16>(to_delete);
+  }
+
+  void add(olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_16::add(std::move(child), depth);
+  }
+
+  void remove(std::uint8_t child_index, olc_db &db_instance) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_16::remove(child_index, db_instance);
+  }
+
+  [[nodiscard]] find_result find_child(std::byte key_byte) noexcept {
+#ifdef UNODB_THREAD_SANITIZER
+    const auto children_count_copy = this->f.f.children_count.load();
+    for (unsigned i = 0; i < children_count_copy; ++i)
+      if (keys.byte_array[i] == key_byte)
+        return std::make_pair(i, &children[i]);
+    return std::make_pair(0xFF, nullptr);
+#elif defined(__x86_64)
+    return basic_inode_16::find_child(key_byte);
+#else
+#error Needs porting
+#endif
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    os << ", ";
+    lock(*this).dump(os);
+    basic_inode_16::dump(os);
+  }
+};
+
+// 160 == sizeof(inode_16)
+#ifdef NDEBUG
+static_assert(sizeof(olc_inode_16) == 160 + 16);
+#else
+static_assert(sizeof(olc_inode_16) == 160 + 32);
+#endif
+
+olc_inode_4::olc_inode_4(
+    std::unique_ptr<olc_inode_16> &&source_node,
+    unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+    std::uint8_t child_to_delete,
+    unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+    // cppcheck-suppress constParameter
+    olc_db &db_instance) noexcept
+    : basic_inode_4<olc_art_policy>{
+          obsolete_and_move(source_node,
+                            std::move(source_node_obsoleting_guard)),
+          obsolete_child_by_index(child_to_delete,
+                                  std::move(child_obsoleting_guard)),
+          db_instance} {
+  assert(!source_node_obsoleting_guard.active());
+  assert(!child_obsoleting_guard.active());
+}
+
+[[nodiscard]] inline std::unique_ptr<olc_inode_4> olc_inode_4::create(
+    std::unique_ptr<olc_inode_16> &&source_node,
+    unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+    std::uint8_t child_to_delete,
+    unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+    olc_db &db_instance) {
+  assert(source_node_obsoleting_guard.guards(lock(*source_node)));
+  assert(child_obsoleting_guard.active());
+
+  return std::make_unique<olc_inode_4>(
+      std::move(source_node), std::move(source_node_obsoleting_guard),
+      child_to_delete, std::move(child_obsoleting_guard), db_instance);
+}
+
+class olc_inode_48 final : public basic_inode_48<olc_art_policy> {
+ public:
+  olc_inode_48(
+      std::unique_ptr<olc_inode_16> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept
+      : basic_inode_48<olc_art_policy>{
+            obsolete_and_move(source_node,
+                              std::move(source_node_obsoleting_guard)),
+            std::move(child), depth} {
+    assert(!source_node_obsoleting_guard.active());
+  }
+
+  [[nodiscard]] static auto create(
+      std::unique_ptr<olc_inode_16> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) {
+    assert(source_node_obsoleting_guard.guards(lock(*source_node)));
+
+    return std::make_unique<olc_inode_48>(
+        std::move(source_node), std::move(source_node_obsoleting_guard),
+        std::move(child), depth);
+  }
+
+  olc_inode_48(
+      std::unique_ptr<olc_inode_256> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      std::uint8_t child_to_delete,
+      unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+      olc_db &db_instance) noexcept;
+
+  [[nodiscard]] static std::unique_ptr<olc_inode_48> create(
+      std::unique_ptr<olc_inode_256> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      std::uint8_t child_to_delete,
+      unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+      olc_db &db_instance);
+
+  static void operator delete(void *to_delete) {
+    qsbr_delete<olc_inode_48>(to_delete);
+  }
+
+  void add(olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_48::add(std::move(child), depth);
+  }
+
+  void remove(std::uint8_t child_index, olc_db &db_instance) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_48::remove(child_index, db_instance);
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    os << ", ";
+    lock(*this).dump(os);
+    basic_inode_48::dump(os);
+  }
+};
+
+// 656 == sizeof(inode_48)
+#ifdef NDEBUG
+static_assert(sizeof(olc_inode_48) == 656 + 16);
+#else
+static_assert(sizeof(olc_inode_48) == 656 + 32);
+#endif
+
+[[nodiscard]] inline std::unique_ptr<olc_inode_16> olc_inode_16::create(
+    std::unique_ptr<olc_inode_48> &&source_node,
+    unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+    std::uint8_t child_to_delete,
+    unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+    olc_db &db_instance) {
+  assert(source_node_obsoleting_guard.guards(lock(*source_node)));
+  // TODO(laurynas): consider asserting that the child guard guards the right
+  // lock.
+  assert(child_obsoleting_guard.active());
+
+  return std::make_unique<olc_inode_16>(
+      std::move(source_node), std::move(source_node_obsoleting_guard),
+      child_to_delete, std::move(child_obsoleting_guard), db_instance);
+}
+
+olc_inode_16::olc_inode_16(
+    std::unique_ptr<olc_inode_48> &&source_node,
+    unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+    std::uint8_t child_to_delete,
+    unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+    // cppcheck-suppress constParameter
+    olc_db &db_instance) noexcept
+    : basic_inode_16<olc_art_policy>{
+          obsolete_and_move(source_node,
+                            std::move(source_node_obsoleting_guard)),
+          obsolete_child_by_index(child_to_delete,
+                                  std::move(child_obsoleting_guard)),
+          db_instance} {
+  assert(!source_node_obsoleting_guard.active());
+  assert(!child_obsoleting_guard.active());
+}
+
+class olc_inode_256 final : public basic_inode_256<olc_art_policy> {
+ public:
+  olc_inode_256(
+      std::unique_ptr<olc_inode_48> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept
+      : basic_inode_256<olc_art_policy>{
+            obsolete_and_move(source_node,
+                              std::move(source_node_obsoleting_guard)),
+            std::move(child), depth} {
+    assert(!source_node_obsoleting_guard.active());
+  }
+
+  [[nodiscard]] static auto create(
+      std::unique_ptr<olc_inode_48> &&source_node,
+      unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+      olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) {
+    assert(source_node_obsoleting_guard.guards(lock(*source_node)));
+
+    return std::make_unique<olc_inode_256>(
+        std::move(source_node), std::move(source_node_obsoleting_guard),
+        std::move(child), depth);
+  }
+
+  static void operator delete(void *to_delete) {
+    qsbr_delete<olc_inode_256>(to_delete);
+  }
+
+  void add(olc_db_leaf_unique_ptr &&child, detail::tree_depth depth) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_256::add(std::move(child), depth);
+  }
+
+  void remove(std::uint8_t child_index, olc_db &db_instance) noexcept {
+    assert(lock(*this).is_write_locked());
+
+    basic_inode_256::remove(child_index, db_instance);
+  }
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    os << ", ";
+    lock(*this).dump(os);
+    basic_inode_256::dump(os);
+  }
+};
+
+// 2064 == sizeof(inode_256)
+#ifdef NDEBUG
+static_assert(sizeof(olc_inode_256) == 2064 + 8);
+#else
+static_assert(sizeof(olc_inode_256) == 2064 + 24);
+#endif
+
+[[nodiscard]] inline std::unique_ptr<olc_inode_48> olc_inode_48::create(
+    std::unique_ptr<olc_inode_256> &&source_node,
+    unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+    std::uint8_t child_to_delete,
+    unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+    olc_db &db_instance) {
+  assert(source_node_obsoleting_guard.guards(lock(*source_node)));
+  assert(child_obsoleting_guard.active());
+
+  return std::make_unique<olc_inode_48>(
+      std::move(source_node), std::move(source_node_obsoleting_guard),
+      child_to_delete, std::move(child_obsoleting_guard), db_instance);
+}
+
+olc_inode_48::olc_inode_48(
+    std::unique_ptr<olc_inode_256> &&source_node,
+    unique_write_lock_obsoleting_guard &&source_node_obsoleting_guard,
+    std::uint8_t child_to_delete,
+    unique_write_lock_obsoleting_guard &&child_obsoleting_guard,
+    // cppcheck-suppress constParameter
+    olc_db &db_instance) noexcept
+    : basic_inode_48<olc_art_policy>{
+          obsolete_and_move(source_node,
+                            std::move(source_node_obsoleting_guard)),
+          obsolete_child_by_index(child_to_delete,
+                                  std::move(child_obsoleting_guard)),
+          db_instance} {
+  assert(!source_node_obsoleting_guard.active());
+  assert(!child_obsoleting_guard.active());
+}
+
+}  // namespace unodb::detail
+
+namespace unodb {
+
+olc_db::~olc_db() noexcept {
+  assert(qsbr::instance().single_thread_mode());
+
+  delete_root_subtree();
+}
+
+get_result olc_db::get(key search_key) const noexcept {
+  quiescent_state_on_scope_exit qsbr_after_get{};
+  try_get_result_type result;
+  const detail::art_key bin_comparable_key{search_key};
+  do {
+    result = try_get(bin_comparable_key);
+    // TODO(laurynas): upgrade to write locks to prevent starving after a
+    // certain number of failures?
+  } while (!result);
+
+  return *result;
+}
+
+olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
+  auto *parent_lock = &root_pointer_lock;
+  auto optional_parent_version = parent_lock->try_read_lock();
+  if (unlikely(!optional_parent_version)) return {};
+
+  auto parent_version = *optional_parent_version;
+  auto node{root.load()};
+
+  if (unlikely(!parent_lock->check(parent_version))) return {};
+
+  if (unlikely(node.header == nullptr)) {
+    if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+    return std::make_optional<get_result>(std::nullopt);
+  }
+
+  auto remaining_key{k};
+
+  while (true) {
+    auto &node_lock = node_ptr_lock(node);
+    const auto optional_version = node_lock.try_read_lock();
+    if (unlikely(!optional_version)) return {};
+
+    const auto version = *optional_version;
+
+    if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+
+    const auto node_type = node.type();
+
+    if (node_type == detail::node_type::LEAF) {
+      if (leaf::matches(node.leaf, k)) {
+        const auto value = leaf::value(node.leaf);
+        if (unlikely(!node_lock.try_read_unlock(version))) return {};
+        return value;
+      }
+      if (unlikely(!node_lock.try_read_unlock(version))) return {};
+      return std::make_optional<get_result>(std::nullopt);
+    }
+
+    const auto key_prefix_length = node.internal->key_prefix_length();
+    const auto shared_key_prefix_length =
+        node.internal->get_shared_key_prefix_length(remaining_key);
+
+    if (shared_key_prefix_length < key_prefix_length) {
+      if (unlikely(!node_lock.try_read_unlock(version))) return {};
+      return std::make_optional<get_result>(std::nullopt);
+    }
+
+    if (unlikely(!node_lock.check(version))) return {};
+
+    assert(shared_key_prefix_length == key_prefix_length);
+
+    remaining_key.shift_right(key_prefix_length);
+
+    auto *const child_loc =
+        node.internal->find_child(node_type, remaining_key[0]).second;
+
+    if (child_loc == nullptr) {
+      if (unlikely(!node_lock.try_read_unlock(version))) return {};
+      return std::make_optional<get_result>(std::nullopt);
+    }
+
+    const auto child = child_loc->load();
+
+    if (unlikely(!node_lock.check(version))) return {};
+
+    parent_lock = &node_lock;
+    parent_version = version;
+    node = child;
+    remaining_key.shift_right(1);
+  }
+}
+
+bool olc_db::insert(key insert_key, value_view v) {
+  quiescent_state_on_scope_exit qsbr_after_insert{};
+
+  const auto bin_comparable_key = detail::art_key{insert_key};
+
+  try_update_result_type result;
+  do {
+    result = try_insert(bin_comparable_key, v);
+  } while (!result);
+
+  return *result;
+}
+
+olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
+                                                  value_view v) {
+  auto *parent_lock = &root_pointer_lock;
+  auto optional_parent_version = parent_lock->try_read_lock();
+  if (unlikely(!optional_parent_version)) return {};
+
+  auto parent_version = *optional_parent_version;
+  auto *node_loc{&root};
+  auto node{root.load()};
+
+  if (unlikely(!parent_lock->check(parent_version))) return {};
+
+  if (unlikely(node.header == nullptr)) {
+    auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
+
+    if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
+      return {};
+    optimistic_write_lock_guard unlock_on_exit{*parent_lock};
+
+    root = leaf.release();
+    return true;
+  }
+
+  detail::tree_depth depth{};
+  auto remaining_key{k};
+
+  while (true) {
+    auto &node_lock = node_ptr_lock(node);
+    const auto optional_version = node_lock.try_read_lock();
+    if (unlikely(!optional_version)) return {};
+    const auto version = *optional_version;
+
+    const auto node_type = node.type();
+
+    if (node_type == detail::node_type::LEAF) {
+      const auto existing_key = leaf::key(node.leaf);
+      if (unlikely(k == existing_key)) {
+        if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+        if (unlikely(!node_lock.try_read_unlock(version))) return {};
+
+        return false;
+      }
+
+      auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
+
+      if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
+        return {};
+      optimistic_write_lock_guard unlock_on_exit{*parent_lock};
+
+      if (unlikely(!node_lock.try_upgrade_to_write_lock(version))) return {};
+      optimistic_write_lock_guard unlock_on_exit2{node_lock};
+
+      increase_memory_use(sizeof(detail::olc_inode_4));
+      // TODO(laurynas): consider creating new lower version and replacing
+      // contents, to enable replacing parent write unlock with parent unlock
+      auto new_node = detail::olc_inode_4::create(existing_key, remaining_key,
+                                                  depth, node, std::move(leaf));
+      *node_loc = new_node.release();
+      ++inode4_count;
+      ++created_inode4_count;
+      return true;
+    }
+
+    assert(node_type != detail::node_type::LEAF);
+    assert(depth < detail::art_key::size);
+
+    const auto key_prefix_length = node.internal->key_prefix_length();
+    const auto shared_prefix_length =
+        node.internal->get_shared_key_prefix_length(remaining_key);
+
+    if (unlikely(!node_lock.check(version))) return {};
+
+    if (shared_prefix_length < key_prefix_length) {
+      auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
+
+      if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
+        return {};
+      optimistic_write_lock_guard unlock_on_exit{*parent_lock};
+
+      if (unlikely(!node_lock.try_upgrade_to_write_lock(version))) return {};
+      optimistic_write_lock_guard unlock_on_exit2{node_lock};
+
+      increase_memory_use(sizeof(detail::olc_inode_4));
+      auto new_node = detail::olc_inode_4::create(node, shared_prefix_length,
+                                                  depth, std::move(leaf));
+      *node_loc = new_node.release();
+      ++inode4_count;
+      ++created_inode4_count;
+      ++key_prefix_splits;
+      return true;
+    }
+
+    assert(shared_prefix_length == key_prefix_length);
+    depth += key_prefix_length;
+    remaining_key.shift_right(key_prefix_length);
+
+    auto *const child_loc =
+        node.internal->find_child(node_type, remaining_key[0]).second;
+
+    if (child_loc == nullptr) {
+      if (unlikely(!node_lock.check(version))) return {};
+      if (unlikely(!parent_lock->check(parent_version))) return {};
+
+      auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
+
+      const auto node_is_full = node.internal->is_full();
+
+      if (likely(!node_is_full)) {
+        if (unlikely(!node_lock.try_upgrade_to_write_lock(version))) return {};
+        optimistic_write_lock_guard unlock_on_exit{node_lock};
+
+        if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+
+        node.internal->add(std::move(leaf), depth);
+
+        return true;
+      }
+
+      assert(node_is_full);
+
+      if (!unlikely(parent_lock->try_upgrade_to_write_lock(parent_version)))
+        return {};
+      optimistic_write_lock_guard unlock_on_exit{*parent_lock};
+
+      if (!unlikely(node_lock.try_upgrade_to_write_lock(version))) return {};
+      unique_write_lock_obsoleting_guard obsolete_node_on_exit{node_lock};
+
+      if (node_type == detail::node_type::I4) {
+        // TODO(laurynas): shorten the critical section by moving allocation
+        // before it?
+        increase_memory_use(sizeof(detail::olc_inode_16) -
+                            sizeof(detail::olc_inode_4));
+        std::unique_ptr<detail::olc_inode_4> current_node{node.node_4};
+        auto larger_node = detail::olc_inode_16::create(
+            std::move(current_node), std::move(obsolete_node_on_exit),
+            std::move(leaf), depth);
+        *node_loc = larger_node.release();
+
+        --inode4_count;
+        ++inode16_count;
+        ++inode4_to_inode16_count;
+
+      } else if (node_type == detail::node_type::I16) {
+        increase_memory_use(sizeof(detail::olc_inode_48) -
+                            sizeof(detail::olc_inode_16));
+        std::unique_ptr<detail::olc_inode_16> current_node{node.node_16};
+        auto larger_node = detail::olc_inode_48::create(
+            std::move(current_node), std::move(obsolete_node_on_exit),
+            std::move(leaf), depth);
+        *node_loc = larger_node.release();
+
+        --inode16_count;
+        ++inode48_count;
+        ++inode16_to_inode48_count;
+
+      } else {
+        increase_memory_use(sizeof(detail::olc_inode_256) -
+                            sizeof(detail::olc_inode_48));
+        assert(node_type == detail::node_type::I48);
+        std::unique_ptr<detail::olc_inode_48> current_node{node.node_48};
+        auto larger_node = detail::olc_inode_256::create(
+            std::move(current_node), std::move(obsolete_node_on_exit),
+            std::move(leaf), depth);
+        *node_loc = larger_node.release();
+
+        --inode48_count;
+        ++inode256_count;
+        ++inode48_to_inode256_count;
+      }
+
+      assert(!obsolete_node_on_exit.active());
+
+      return true;
+    }
+
+    assert(child_loc != nullptr);
+
+    const auto child = child_loc->load();
+
+    if (unlikely(!node_lock.check(version))) return {};
+    if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+
+    parent_lock = &node_lock;
+    parent_version = version;
+    node = child;
+    node_loc = child_loc;
+    ++depth;
+    remaining_key.shift_right(1);
+  }
+}
+
+bool olc_db::remove(key remove_key) {
+  quiescent_state_on_scope_exit qsbr_after_remove{};
+
+  const auto bin_comparable_key = detail::art_key{remove_key};
+
+  try_update_result_type result;
+  do {
+    result = try_remove(bin_comparable_key);
+  } while (!result);
+
+  return *result;
+}
+
+olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
+  auto *parent_lock = &root_pointer_lock;
+  auto optional_parent_version = parent_lock->try_read_lock();
+  if (unlikely(!optional_parent_version)) return {};
+  auto parent_version = *optional_parent_version;
+
+  auto *node_loc{&root};
+  auto node{root.load()};
+
+  if (unlikely(!parent_lock->check(parent_version))) return {};
+
+  if (unlikely(node == nullptr)) return false;
+
+  auto *node_lock = &node_ptr_lock(node);
+  auto optional_version = node_lock->try_read_lock();
+  if (unlikely(!optional_version)) return {};
+  auto version = *optional_version;
+
+  auto node_type = node.type();
+
+  if (unlikely(!node_lock->check(version))) return {};
+
+  if (node_type == detail::node_type::LEAF) {
+    if (leaf::matches(node.leaf, k)) {
+      if (unlikely(
+              !root_pointer_lock.try_upgrade_to_write_lock(parent_version)))
+        return {};
+
+      optimistic_write_lock_guard unlock_on_exit{root_pointer_lock};
+      if (unlikely(!node_lock->try_upgrade_to_write_lock(version))) return {};
+
+      node_lock->write_unlock_and_obsolete();
+
+      const auto reclaim_root_leaf_on_scope_exit{
+          olc_art_policy::make_db_reclaimable_leaf_ptr(node.leaf, *this)};
+      root = nullptr;
+      return true;
+    }
+
+    if (unlikely(!node_lock->try_read_unlock(version))) return {};
+
+    return false;
+  }
+
+  detail::tree_depth depth{};
+  auto remaining_key{k};
+
+  while (true) {
+    assert(node_type != detail::node_type::LEAF);
+    assert(depth < detail::art_key::size);
+
+    const auto key_prefix_length = node.internal->key_prefix_length();
+    const auto shared_prefix_length =
+        node.internal->get_shared_key_prefix_length(remaining_key);
+
+    if (shared_prefix_length < key_prefix_length) {
+      if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+      if (unlikely(!node_lock->try_read_unlock(version))) return {};
+
+      return false;
+    }
+
+    if (unlikely(!node_lock->check(version))) return {};
+
+    assert(shared_prefix_length == key_prefix_length);
+    depth += key_prefix_length;
+    remaining_key.shift_right(key_prefix_length);
+
+    // FIXME(laurynas): child_loc, child_lock too similar
+    auto [child_i, child_loc] =
+        node.internal->find_child(node_type, remaining_key[0]);
+
+    const auto is_node_min_size = node.internal->is_min_size();
+
+    if (child_loc == nullptr) {
+      if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+      if (unlikely(!node_lock->try_read_unlock(version))) return {};
+
+      return false;
+    }
+
+    auto child = child_loc->load();
+
+    if (unlikely(!node_lock->check(version))) return {};
+
+    auto &child_lock = node_ptr_lock(child);
+    const auto optional_child_version = child_lock.try_read_lock();
+    if (unlikely(!optional_child_version)) return {};
+    const auto child_version = *optional_child_version;
+
+    const auto child_type = child.type();
+
+    if (child_type == detail::node_type::LEAF) {
+      if (!leaf::matches(child.leaf, k)) {
+        if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
+        if (unlikely(!node_lock->try_read_unlock(version))) return {};
+        if (unlikely(!child_lock.try_read_unlock(child_version))) return {};
+
+        return false;
+      }
+
+      if (likely(!is_node_min_size)) {
+        // TODO(laurynas): decrease_memory_use outside the critical section
+        if (unlikely(!node_lock->try_upgrade_to_write_lock(version))) return {};
+        optimistic_write_lock_guard unlock_on_exit{*node_lock};
+
+        if (unlikely(!child_lock.try_upgrade_to_write_lock(child_version)))
+          return {};
+        child_lock.write_unlock_and_obsolete();
+
+        node.internal->remove(child_i, *this);
+
+        return true;
+      }
+
+      assert(is_node_min_size);
+
+      if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
+        return {};
+      optimistic_write_lock_guard unlock_on_exit{*parent_lock};
+
+      if (unlikely(!node_lock->try_upgrade_to_write_lock(version))) return {};
+      unique_write_lock_obsoleting_guard obsolete_node_on_exit{*node_lock};
+
+      if (unlikely(!child_lock.try_upgrade_to_write_lock(child_version))) {
+        obsolete_node_on_exit.abort();
+        return {};
+      }
+      unique_write_lock_obsoleting_guard obsolete_child_on_exit{child_lock};
+
+      // TODO(laurynas): exception safety, OOM specifically
+      if (node_type == detail::node_type::I4) {
+        obsolete_node_on_exit.commit();
+        obsolete_child_on_exit.commit();
+        std::unique_ptr<detail::olc_inode_4> current_node{node.node_4};
+        *node_loc = current_node->leave_last_child(child_i, *this);
+
+        decrease_memory_use(sizeof(detail::olc_inode_4));
+        --inode4_count;
+        ++deleted_inode4_count;
+
+      } else if (node_type == detail::node_type::I16) {
+        std::unique_ptr<detail::olc_inode_16> current_node{node.node_16};
+        auto new_node{detail::olc_inode_4::create(
+            std::move(current_node), std::move(obsolete_node_on_exit), child_i,
+            std::move(obsolete_child_on_exit), *this)};
+        *node_loc = new_node.release();
+
+        decrease_memory_use(sizeof(detail::olc_inode_16) -
+                            sizeof(detail::olc_inode_4));
+        --inode16_count;
+        ++inode4_count;
+        ++inode16_to_inode4_count;
+
+      } else if (node_type == detail::node_type::I48) {
+        std::unique_ptr<detail::olc_inode_48> current_node{node.node_48};
+        auto new_node{detail::olc_inode_16::create(
+            std::move(current_node), std::move(obsolete_node_on_exit), child_i,
+            std::move(obsolete_child_on_exit), *this)};
+        *node_loc = new_node.release();
+
+        decrease_memory_use(sizeof(detail::olc_inode_48) -
+                            sizeof(detail::olc_inode_16));
+        --inode48_count;
+        ++inode16_count;
+        ++inode48_to_inode16_count;
+
+      } else {
+        assert(node_type == detail::node_type::I256);
+        std::unique_ptr<detail::olc_inode_256> current_node{node.node_256};
+        auto new_node{detail::olc_inode_48::create(
+            std::move(current_node), std::move(obsolete_node_on_exit), child_i,
+            std::move(obsolete_child_on_exit), *this)};
+        *node_loc = new_node.release();
+
+        decrease_memory_use(sizeof(detail::olc_inode_256) -
+                            sizeof(detail::olc_inode_48));
+        --inode256_count;
+        ++inode48_count;
+        ++inode256_to_inode48_count;
+      }
+
+      assert(!obsolete_node_on_exit.active());
+      assert(!obsolete_child_on_exit.active());
+
+      return true;
+    }
+
+    assert(child_type != detail::node_type::LEAF);
+
+    parent_lock = node_lock;
+    parent_version = version;
+
+    node = child;
+    node_loc = child_loc;
+    node_lock = &child_lock;
+    version = child_version;
+    node_type = child_type;
+
+    ++depth;
+    remaining_key.shift_right(1);
+  }
+}
+
+void olc_db::delete_subtree(detail::olc_node_ptr node) noexcept {
+  delete_db_node_ptr_at_scope_exit delete_on_scope_exit{node, *this};
+  delete_on_scope_exit.delete_subtree();
+}
+
+void olc_db::delete_root_subtree() noexcept {
+  assert(qsbr::instance().single_thread_mode());
+
+  delete_subtree(root);
+  // It is possible to reset the counter to zero instead of decrementing it for
+  // each leaf, but not sure the savings will be significant.
+  assert(leaf_count == 0);
+}
+
+void olc_db::clear() {
+  assert(qsbr::instance().single_thread_mode());
+
+  delete_root_subtree();
+
+  root = nullptr;
+  current_memory_use.store(0, std::memory_order_relaxed);
+
+  inode4_count = 0;
+  inode16_count = 0;
+  inode48_count = 0;
+  inode256_count = 0;
+}
+
+#if defined(__GNUC__) && (__GNUC__ >= 9)
+DISABLE_GCC_WARNING("-Wsuggest-attribute=cold")
+#endif
+
+void olc_db::increase_memory_use(std::size_t delta) {
+  if (delta == 0) return;
+
+  current_memory_use.fetch_add(delta, std::memory_order_relaxed);
+}
+
+#if defined(__GNUC__) && (__GNUC__ >= 9)
+RESTORE_GCC_WARNINGS()
+#endif
+
+void olc_db::decrease_memory_use(std::size_t delta) noexcept {
+  if (delta == 0) return;
+
+  assert(delta <= current_memory_use.load(std::memory_order_relaxed));
+  current_memory_use.fetch_sub(delta, std::memory_order_relaxed);
+}
+
+void olc_db::dump(std::ostream &os) const {
+  os << "olc_db dump, currently used = " << get_current_memory_use() << '\n';
+  detail::dump_node(os, root.load());
+}
+
+}  // namespace unodb

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1,0 +1,233 @@
+// Copyright 2019-2021 Laurynas Biveinis
+#ifndef UNODB_OLC_ART_HPP_
+#define UNODB_OLC_ART_HPP_
+
+#include "global.hpp"  // IWYU pragma: keep
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <optional>
+
+#include "art_common.hpp"
+#include "art_internal.hpp"
+#include "optimistic_lock.hpp"
+
+namespace unodb {
+
+namespace detail {
+
+template <class>
+class basic_inode_4;
+
+template <class>
+class basic_inode_16;
+
+template <class>
+class basic_inode_48;
+
+template <class>
+class basic_inode_256;
+
+struct olc_node_header;
+
+class olc_inode;
+
+class olc_inode_4;
+class olc_inode_16;
+class olc_inode_48;
+class olc_inode_256;
+
+using olc_inode_defs =
+    basic_inode_def<olc_inode_4, olc_inode_16, olc_inode_48, olc_inode_256>;
+
+using olc_node_ptr = basic_node_ptr<olc_node_header, olc_inode, olc_inode_defs>;
+
+template <class, class>
+class db_leaf_qsbr_deleter;
+
+template <class Header, class Db>
+auto make_db_leaf_ptr(art_key, value_view, Db &);
+
+}  // namespace detail
+
+// A concurrent Adaptive Radix Tree that is synchronized using optimistic lock
+// coupling. At any time, at most two directly-related tree nodes can be
+// write-locked by the insert algorithm and three by the delete algorithm. The
+// lock used is optimistic lock (see optimistic_lock.hpp), where only writers
+// lock and readers access nodes optimistically with node version checks. For
+// deleted node reclamation, Quiescent State-Based Reclamation is used.
+class olc_db final {
+ public:
+  // Creation and destruction
+  constexpr explicit olc_db() noexcept {}
+
+  ~olc_db() noexcept;
+
+  // Querying
+  [[nodiscard]] get_result get(key search_key) const noexcept;
+
+  [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
+
+  // Modifying
+  // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
+  [[nodiscard]] bool insert(key insert_key, value_view v);
+
+  [[nodiscard]] bool remove(key remove_key);
+
+  // Only legal in single-threaded context, as destructor
+  void clear();
+
+  // Stats
+
+  // Return current memory use by tree nodes in bytes
+  [[nodiscard]] auto get_current_memory_use() const noexcept {
+    return current_memory_use.load(std::memory_order_relaxed);
+  }
+
+  [[nodiscard]] auto get_leaf_count() const noexcept {
+    return leaf_count.load();
+  }
+
+  [[nodiscard]] auto get_inode4_count() const noexcept {
+    return inode4_count.load();
+  }
+
+  [[nodiscard]] auto get_inode16_count() const noexcept {
+    return inode16_count.load();
+  }
+
+  [[nodiscard]] auto get_inode48_count() const noexcept {
+    return inode48_count.load();
+  }
+
+  [[nodiscard]] auto get_inode256_count() const noexcept {
+    return inode256_count.load();
+  }
+
+  [[nodiscard]] auto get_created_inode4_count() const noexcept {
+    return created_inode4_count.load();
+  }
+
+  [[nodiscard]] auto get_inode4_to_inode16_count() const noexcept {
+    return inode4_to_inode16_count.load();
+  }
+
+  [[nodiscard]] auto get_inode16_to_inode48_count() const noexcept {
+    return inode16_to_inode48_count.load();
+  }
+
+  [[nodiscard]] auto get_inode48_to_inode256_count() const noexcept {
+    return inode48_to_inode256_count.load();
+  }
+
+  [[nodiscard]] auto get_deleted_inode4_count() const noexcept {
+    return deleted_inode4_count.load();
+  }
+
+  [[nodiscard]] auto get_inode16_to_inode4_count() const noexcept {
+    return inode16_to_inode4_count.load();
+  }
+
+  [[nodiscard]] auto get_inode48_to_inode16_count() const noexcept {
+    return inode48_to_inode16_count.load();
+  }
+
+  [[nodiscard]] auto get_inode256_to_inode48_count() const noexcept {
+    return inode256_to_inode48_count.load();
+  }
+
+  [[nodiscard]] auto get_key_prefix_splits() const noexcept {
+    return key_prefix_splits.load();
+  }
+
+  // Debugging
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const;
+
+ private:
+  // If get_result is not present, the search was interrupted. Yes, this
+  // resolves to std::optional<std::optional<value_view>>, but IMHO both
+  // levels of std::optional are clear here
+  using try_get_result_type = std::optional<get_result>;
+
+  using try_update_result_type = std::optional<bool>;
+
+  [[nodiscard]] try_get_result_type try_get(detail::art_key k) const noexcept;
+
+  [[nodiscard]] try_update_result_type try_insert(detail::art_key k,
+                                                  value_view v);
+
+  [[nodiscard]] try_update_result_type try_remove(detail::art_key k);
+
+  void delete_subtree(detail::olc_node_ptr) noexcept;
+
+  void delete_root_subtree() noexcept;
+
+  void increase_memory_use(std::size_t delta);
+  void decrease_memory_use(std::size_t delta) noexcept;
+
+  void decrement_leaf_count(std::size_t leaf_size) noexcept {
+    decrease_memory_use(leaf_size);
+
+    const auto USED_IN_DEBUG old_leaf_count = leaf_count--;
+    assert(old_leaf_count > 0);
+  }
+
+  mutable optimistic_lock root_pointer_lock;
+
+  relaxed_atomic<detail::olc_node_ptr> root{nullptr};
+
+  // Current logically allocated memory that is not scheduled to be reclaimed.
+  // The total memory currently allocated is this plus the QSBR deallocation
+  // backlog (qsbr::previous_interval_total_dealloc_size +
+  // qsbr::current_interval_total_dealloc_size).
+  std::atomic<std::size_t> current_memory_use{0};
+
+  relaxed_atomic<std::uint64_t> leaf_count{0};
+  relaxed_atomic<std::uint64_t> inode4_count{0};
+  relaxed_atomic<std::uint64_t> inode16_count{0};
+  relaxed_atomic<std::uint64_t> inode48_count{0};
+  relaxed_atomic<std::uint64_t> inode256_count{0};
+
+  relaxed_atomic<std::uint64_t> created_inode4_count{0};
+  relaxed_atomic<std::uint64_t> inode4_to_inode16_count{0};
+  relaxed_atomic<std::uint64_t> inode16_to_inode48_count{0};
+  relaxed_atomic<std::uint64_t> inode48_to_inode256_count{0};
+
+  relaxed_atomic<std::uint64_t> deleted_inode4_count{0};
+  relaxed_atomic<std::uint64_t> inode16_to_inode4_count{0};
+  relaxed_atomic<std::uint64_t> inode48_to_inode16_count{0};
+  relaxed_atomic<std::uint64_t> inode256_to_inode48_count{0};
+
+  relaxed_atomic<std::uint64_t> key_prefix_splits{0};
+
+  friend auto detail::make_db_leaf_ptr<detail::olc_node_header, olc_db>(
+      detail::art_key, value_view, olc_db &);
+
+  template <class>
+  friend struct detail::basic_leaf;
+
+  template <class, class>
+  friend class detail::basic_db_leaf_deleter;
+
+  template <class, class>
+  friend class detail::db_leaf_qsbr_deleter;
+
+  template <class>
+  friend class detail::basic_inode_4;
+
+  template <class>
+  friend class detail::basic_inode_16;
+
+  template <class>
+  friend class detail::basic_inode_48;
+
+  template <class>
+  friend class detail::basic_inode_256;
+
+};
+
+}  // namespace unodb
+
+#endif  // UNODB_OLC_ART_HPP_

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -1,0 +1,397 @@
+// Copyright (C) 2019-2021 Laurynas Biveinis
+#ifndef OPTIMISTIC_LOCK_HPP_
+#define OPTIMISTIC_LOCK_HPP_
+
+#include "global.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#ifdef __x86_64
+#include <emmintrin.h>
+#endif
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <thread>
+#include <type_traits>
+
+namespace unodb {
+
+// Optimistic lock as described in V. Leis, F. Schneiber, A. Kemper and T.
+// Neumann, "The ART of Practical Synchronization," 2016 Proceedings of the 12th
+// International Workshop on Data Management on New Hardware(DaMoN), pages
+// 3:1--3:8, 2016. They also seem to be very similar to Linux kernel sequential
+// locks, with the addition of the obsolete state. Memory ordering is
+// implementing following Boehm's 2012 paper "Can seqlocks get along with
+// programming language memory models?"
+
+// A lock is a single machine word, which encodes locked-unlocked state,
+// obsolete state, and version number. Locking for write atomically sets the
+// locked state and bumps the version number. Locking for read saves the version
+// number at the time, and "unlocking" for read checks whether the lock version
+// did not advance during the reader's critical section, which has the
+// constraint that no pointers may be followed while in there nor any other data
+// can be interpreted in a way that may potentially cause faults. Effectively
+// this means that reader critical section should copy the data it's interested
+// in, and, after unlock (or version check if further actions are needed in a
+// longer reader critical section), the data might be used only if the version
+// number has not advanced. Otherwise an algorithm restart is necessary. In the
+// current implementation, it is possible for a reader to be starved
+// indefinitely.
+
+// A lock in obsolete state marks data which is on the deallocation backlog to
+// be freed once all the thread epochs have advanced. All algorithms must
+// restart upon encountering a lock in obsolete state.
+
+// All bool-returning try_ functions return true on success and false on
+// lock version change, which indicates the need to restart
+class optimistic_lock final {
+ public:
+  class version_type final {
+   public:
+    using version_number_type = std::uint64_t;
+
+    constexpr version_type(version_number_type version_,
+                           USED_IN_DEBUG const optimistic_lock *owner_) noexcept
+        : version {
+      version_
+    }
+#ifndef NDEBUG
+    , owner { owner_ }
+#endif
+    {}
+
+    constexpr version_type(const version_type &other) noexcept : version {
+      other.version
+    }
+#ifndef NDEBUG
+    , owner { other.owner }
+#endif
+    {}
+
+    constexpr version_type &operator=(version_type other) noexcept {
+      version = other.version;
+#ifndef NDEBUG
+      owner = other.owner;
+#endif
+      return *this;
+    }
+
+    [[nodiscard]] constexpr operator version_number_type() const noexcept {
+      return version;
+    }
+
+    [[nodiscard]] constexpr operator version_number_type &() noexcept {
+      return version;
+    }
+
+    constexpr void assert_owner(
+        USED_IN_DEBUG const optimistic_lock *owner_) const noexcept {
+#ifndef NDEBUG
+      assert(owner_ == owner);
+#endif
+    }
+
+   private:
+    version_number_type version;
+#ifndef NDEBUG
+    const optimistic_lock *owner;
+#endif
+  };
+
+#ifdef NDEBUG
+  static_assert(
+      sizeof(version_type) == sizeof(std::uint64_t),
+      "class version_type must have no overhead over std::uint64_t in "
+      "release build ");
+  static_assert(sizeof(version_type) == 8);
+#else
+  static_assert(sizeof(version_type) == 16);
+#endif
+
+  optimistic_lock() noexcept = default;
+
+  optimistic_lock(const optimistic_lock &) = delete;
+  optimistic_lock(optimistic_lock &&) = delete;
+
+  optimistic_lock & operator = (const optimistic_lock &) = delete;
+  optimistic_lock & operator = (optimistic_lock &&) = delete;
+
+  // If QSBR starts running destructors for objects being deallocated, add one
+  // here that asserts read_lock_count == 0
+  ~optimistic_lock() = default;
+
+  [[nodiscard]] std::optional<version_type> try_read_lock() const noexcept {
+    const auto current_version = await_node_unlocked();
+    if (unlikely(is_obsolete(current_version))) return {};
+    inc_read_lock_count();
+    return std::optional<version_type>{std::in_place, current_version, this};
+  }
+
+  [[nodiscard]] bool check(const version_type locked_version) const noexcept {
+    assert(read_lock_count.load(std::memory_order_relaxed) > 0);
+    locked_version.assert_owner(this);
+
+    std::atomic_thread_fence(std::memory_order_acquire);
+    return likely(locked_version == version.load());
+  }
+
+  [[nodiscard]] bool try_read_unlock(
+      const version_type locked_version) const noexcept {
+    const auto result{check(locked_version)};
+    dec_read_lock_count();
+    return result;
+  }
+
+  [[nodiscard]] bool try_upgrade_to_write_lock(
+      version_type locked_version) noexcept {
+    locked_version.assert_owner(this);
+
+    const auto result{likely(version.compare_exchange_strong(
+        locked_version, set_locked_bit(locked_version),
+        std::memory_order_acquire))};
+    dec_read_lock_count();
+    return result;
+  }
+
+  void write_unlock() noexcept {
+    assert(is_write_locked());
+
+    version.fetch_add(2, std::memory_order_release);
+  }
+
+  void write_unlock_and_obsolete() noexcept {
+    assert(is_write_locked());
+
+    version.fetch_add(3, std::memory_order_release);
+#ifndef NDEBUG
+    obsoleter_thread = std::this_thread::get_id();
+#endif
+  }
+
+#ifndef NDEBUG
+  [[nodiscard]] bool is_obsoleted_by_this_thread() const noexcept {
+    return is_obsolete(version.load(std::memory_order_acquire)) &&
+           std::this_thread::get_id() == obsoleter_thread;
+  }
+
+  [[nodiscard]] bool is_write_locked() const noexcept {
+    return is_write_locked(version.load(std::memory_order_acquire));
+  }
+#endif
+
+  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+    const auto dump_version = version.load();
+    os << "lock: version = 0x" << std::hex << std::setfill('0') << std::setw(8)
+       << dump_version << std::dec;
+    if (is_write_locked(dump_version)) os << " (write locked)";
+    if (is_obsolete(dump_version)) os << " (obsoleted)";
+#ifndef NDEBUG
+    os << " current read lock count = " << read_lock_count;
+#endif
+  }
+
+ private:
+  [[nodiscard]] static constexpr bool is_write_locked(
+      version_type::version_number_type version) noexcept {
+    return version & 2;
+  }
+
+  [[nodiscard]] version_type::version_number_type await_node_unlocked()
+      const noexcept {
+    version_type::version_number_type current_version =
+        version.load(std::memory_order_acquire);
+    while (is_write_locked(current_version)) {
+#ifdef UNODB_THREAD_SANITIZER
+      std::this_thread::yield();
+#elif defined(__x86_64)
+      // Dear reader, please don't make fun of this just yet
+      _mm_pause();
+#else
+#error Needs porting
+#endif
+      current_version = version.load(std::memory_order_acquire);
+    }
+    return current_version;
+  }
+
+  [[nodiscard]] static constexpr version_type::version_number_type
+  set_locked_bit(const version_type version) noexcept {
+    assert(!is_write_locked(version));
+    return version + 2;
+  }
+
+  [[nodiscard]] static constexpr bool is_obsolete(
+      version_type::version_number_type version) noexcept {
+    return version & 1;
+  }
+
+  std::atomic<version_type::version_number_type> version{0};
+
+  static_assert(decltype(version)::is_always_lock_free,
+                "Must use always lock-free atomics");
+
+#ifndef NDEBUG
+  mutable std::atomic<std::int64_t> read_lock_count{0};
+  std::thread::id obsoleter_thread{};
+#endif
+
+  void inc_read_lock_count() const noexcept {
+#ifndef NDEBUG
+    read_lock_count.fetch_add(1, std::memory_order_relaxed);
+#endif
+  }
+
+  void dec_read_lock_count() const noexcept {
+#ifndef NDEBUG
+    const auto old_value =
+        read_lock_count.fetch_sub(1, std::memory_order_relaxed);
+    assert(old_value > 0);
+#endif
+  }
+};
+
+static_assert(std::is_standard_layout_v<optimistic_lock>);
+
+#ifdef NDEBUG
+static_assert(sizeof(optimistic_lock) == sizeof(optimistic_lock::version_type));
+static_assert(sizeof(optimistic_lock) == 8);
+#else
+static_assert(sizeof(optimistic_lock) == 24);
+#endif
+
+class optimistic_write_lock_guard final {
+ public:
+  explicit constexpr optimistic_write_lock_guard(optimistic_lock &lock_)
+      : lock{lock_} {
+    assert(lock.is_write_locked());
+  }
+
+  ~optimistic_write_lock_guard() { lock.write_unlock(); }
+
+ private:
+  optimistic_lock &lock;
+
+  optimistic_write_lock_guard() = delete;
+  optimistic_write_lock_guard(const optimistic_write_lock_guard &) = delete;
+  optimistic_write_lock_guard(optimistic_write_lock_guard &&) = delete;
+  optimistic_write_lock_guard &operator=(const optimistic_write_lock_guard &) =
+      delete;
+  optimistic_write_lock_guard &operator=(optimistic_write_lock_guard &&) =
+      delete;
+};
+
+class unique_write_lock_obsoleting_guard final {
+ public:
+  explicit unique_write_lock_obsoleting_guard(optimistic_lock &lock_) noexcept
+      : lock{&lock_}, exceptions_at_ctor{std::uncaught_exceptions()} {
+    assert(lock->is_write_locked());
+  }
+
+  unique_write_lock_obsoleting_guard(
+      unique_write_lock_obsoleting_guard &&other) noexcept
+      : lock{other.lock}, exceptions_at_ctor{other.exceptions_at_ctor} {
+    other.lock = nullptr;
+  }
+
+  ~unique_write_lock_obsoleting_guard() {
+    if (lock == nullptr) return;
+    // FIXME(laurynas): remove uncaught_exceptions() calls and require commit()
+    // to be called in the success paths (which is what the user code has to do
+    // anyway).
+    if (likely(exceptions_at_ctor == std::uncaught_exceptions()))
+      lock->write_unlock_and_obsolete();
+    else
+      lock->write_unlock();
+  }
+
+  void commit() {
+    assert(active());
+
+    lock->write_unlock_and_obsolete();
+    lock = nullptr;
+  }
+
+  void abort() {
+    assert(active());
+
+    lock->write_unlock();
+    lock = nullptr;
+  }
+
+#ifndef NDEBUG
+  bool active() const noexcept { return lock != nullptr; }
+
+  bool guards(const optimistic_lock &lock_) const noexcept {
+    return lock == &lock_;
+  }
+#endif
+
+ private:
+  optimistic_lock *lock;
+  const int exceptions_at_ctor;
+
+  unique_write_lock_obsoleting_guard() = delete;
+  unique_write_lock_obsoleting_guard(
+      const unique_write_lock_obsoleting_guard &) = delete;
+  unique_write_lock_obsoleting_guard &operator=(
+      const unique_write_lock_obsoleting_guard &) = delete;
+  unique_write_lock_obsoleting_guard &operator=(
+      unique_write_lock_obsoleting_guard &&) = delete;
+};
+
+template <typename T>
+class relaxed_atomic final {
+ public:
+  constexpr relaxed_atomic() noexcept = default;
+
+  explicit constexpr relaxed_atomic(T value_) noexcept : value{value_} {}
+
+  // Regular C++ assignment operators return ref to this, std::atomic returns
+  // the assigned value, we return nothing as we never chain assignments.
+  void operator=(T new_value) noexcept {
+    value.store(new_value, std::memory_order_relaxed);
+  }
+
+  void operator=(const relaxed_atomic<T> &new_value) noexcept {
+    value.store(new_value.load(), std::memory_order_relaxed);
+  }
+
+  void operator++() noexcept { value.fetch_add(1, std::memory_order_relaxed); }
+
+  void operator--() noexcept { value.fetch_sub(1, std::memory_order_relaxed); }
+
+  T operator--(int) noexcept {
+    return value.fetch_sub(1, std::memory_order_relaxed);
+  }
+
+  template <typename T_ = T,
+            typename = std::enable_if_t<!std::is_integral_v<T_>>>
+  [[nodiscard]] auto operator==(std::nullptr_t) const noexcept {
+    return load() == nullptr;
+  }
+
+  template <typename T_ = T,
+            typename = std::enable_if_t<!std::is_integral_v<T_>>>
+  [[nodiscard]] auto operator!=(std::nullptr_t) const noexcept {
+    return load() != nullptr;
+  }
+
+  operator T() const noexcept { return load(); }
+
+  T load() const noexcept { return value.load(std::memory_order_relaxed); }
+
+ private:
+  std::atomic<T> value;
+
+  static_assert(std::atomic<T>::is_always_lock_free,
+                "Must use always lock-free atomics");
+};
+
+}  // namespace unodb
+
+#endif  // OPTIMISTIC_LOCK_HPP_

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -1,0 +1,263 @@
+// Copyright (C) 2019-2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+#include <utility>
+
+#include "heap.hpp"
+#include "qsbr.hpp"
+
+namespace {
+
+__attribute__((constructor)) void run_tls_ctor_in_main_thread() {
+  unodb::construct_current_thread_reclamator();
+}
+
+}  // namespace
+
+namespace unodb {
+
+void qsbr::prepare_new_thread() {
+  std::lock_guard<std::mutex> guard{qsbr_mutex};
+  prepare_new_thread_locked();
+}
+
+void qsbr::register_prepared_thread(std::thread::id thread_id) noexcept {
+  std::lock_guard<std::mutex> guard{qsbr_mutex};
+  register_prepared_thread_locked(thread_id);
+}
+
+void qsbr::register_new_thread(std::thread::id thread_id) {
+  std::lock_guard<std::mutex> guard{qsbr_mutex};
+  // TODO(laurynas): both of these calls share the critical section, simpler
+  // implementation possible
+  prepare_new_thread_locked();
+  register_prepared_thread_locked(thread_id);
+}
+
+void qsbr::unregister_thread(std::thread::id thread_id) {
+  deferred_requests_type requests_to_deallocate;
+  {
+    std::lock_guard<std::mutex> guard{qsbr_mutex};
+
+#ifndef NDEBUG
+    thread_count_changed_in_current_epoch = true;
+#endif
+
+    // TODO(laurynas): return iterator to save the find call below
+    // A thread being unregistered must be quiescent
+    requests_to_deallocate = quiescent_state_locked(thread_id);
+
+    const auto thread_state = threads.find(thread_id);
+    assert(thread_state != threads.end());
+    if (unlikely(thread_state->second == 0)) {
+      // The thread being unregistered become quiescent and that allowed an
+      // epoch change, which marked this thread as not-quiescent again, and
+      // included it in threads_in_previous_epoch
+      --threads_in_previous_epoch;
+    }
+    threads.erase(thread_state);
+    --reserved_thread_capacity;
+
+    if (unlikely(threads.empty())) {
+      threads_in_previous_epoch = 0;
+    } else if (unlikely(single_thread_mode_locked())) {
+      // Deallocate previous epoch requests immediately as the sole current
+      // thread cannot be holding any live pointers to them. We cannot do the
+      // same for the current epoch requests as they might come from a
+      // just-stopped thread with the current thread holding live pointers.
+      // However, any new deallocation requests from this point on can be
+      // executed immediately.
+      epoch_callback_stats(previous_interval_deallocation_requests.size());
+      deallocation_size_stats(
+          previous_interval_total_dealloc_size.load(std::memory_order_relaxed));
+      previous_interval_total_dealloc_size.store(0, std::memory_order_relaxed);
+      // FIXME(laurynas): unit test for requests_to_deallocate[0].size() > 0
+      // at this point.
+      // FIXME(laurynas): replace with a third member of deferred_requests_type
+      std::move(std::begin(previous_interval_deallocation_requests),
+                std::end(previous_interval_deallocation_requests),
+                std::back_inserter(requests_to_deallocate[0]));
+      previous_interval_deallocation_requests.clear();
+    }
+
+    assert_invariants();
+  }
+
+  deallocate_requests(requests_to_deallocate[0]);
+  deallocate_requests(requests_to_deallocate[1]);
+}
+
+void qsbr::reset() noexcept {
+  std::lock_guard<std::mutex> guard{qsbr_mutex};
+
+  assert_invariants();
+
+  deallocation_size_stats = {};
+  epoch_callback_stats = {};
+  quiescent_states_per_thread_between_epoch_change_stats = {};
+  epoch_change_count = 0;
+}
+
+void qsbr::dump(std::ostream &out) const {
+  // TODO(laurynas): locking? anyone using it all?
+  out << "QSBR status:\n";
+  out << "Previous interval pending deallocation requests: "
+      << previous_interval_deallocation_requests.size() << '\n';
+  out << "Previous interval pending deallocation bytes: "
+      << previous_interval_total_dealloc_size.load(std::memory_order_relaxed);
+  out << "Current interval pending deallocation requests: "
+      << current_interval_deallocation_requests.size() << '\n';
+  out << "Current interval pending deallocation bytes: "
+      << current_interval_total_dealloc_size.load(std::memory_order_relaxed);
+  out << "Number of tracked threads: " << threads.size() << '\n';
+  for (const auto &thread_info : threads) {
+    out << "Thread key: " << thread_info.first
+        << ", quiescent: " << thread_info.second << '\n';
+  }
+  out << "Number of threads in the previous epoch = "
+      << threads_in_previous_epoch << '\n';
+}
+
+void qsbr::prepare_new_thread_locked() {
+  assert_invariants();
+
+  ++reserved_thread_capacity;
+  assert(reserved_thread_capacity > threads.size());
+
+  threads.reserve(reserved_thread_capacity);
+}
+
+void qsbr::register_prepared_thread_locked(std::thread::id thread_id) noexcept {
+  // No need to reserve space for the first (or the last, depending on the
+  // workload) thread
+  if (unlikely(reserved_thread_capacity == 0)) reserved_thread_capacity = 1;
+
+#ifndef NDEBUG
+  thread_count_changed_in_current_epoch = true;
+  assert_invariants();
+  assert(reserved_thread_capacity > threads.size());
+#endif
+
+  try {
+    const auto USED_IN_DEBUG[itr, insert_ok] =
+        threads.insert({thread_id, false});
+    assert(insert_ok);
+    // LCOV_EXCL_START
+  } catch (std::exception &e) {
+    std::cerr
+        << "Impossible happened: QSBR thread vector insert threw exception: "
+        << e.what() << ", aborting!\n";
+#ifdef NDEBUG
+    std::abort();
+#else
+    cannot_happen();
+#endif
+  } catch (...) {
+    std::cerr << "Impossible happened: QSBR thread vector insert threw unknown "
+                 "exception, aborting!\n";
+#ifdef NDEBUG
+    std::abort();
+#else
+    cannot_happen();
+#endif
+    // LCOV_EXCL_STOP
+  }
+
+  ++threads_in_previous_epoch;
+}
+
+qsbr::deferred_requests_type qsbr::quiescent_state_locked(
+    std::thread::id thread_id) noexcept {
+  assert_invariants();
+
+  auto thread_state = threads.find(thread_id);
+  assert(thread_state != threads.end());
+
+  ++thread_state->second;
+  if (thread_state->second > 1) {
+    assert_invariants();
+    return deferred_requests_type{};
+  }
+
+  --threads_in_previous_epoch;
+
+  deferred_requests_type result = (threads_in_previous_epoch == 0)
+                                      ? change_epoch()
+                                      : deferred_requests_type{};
+
+  assert_invariants();
+
+  return result;
+}
+
+qsbr::deferred_requests_type qsbr::change_epoch() noexcept {
+  ++epoch_change_count;
+
+  deallocation_size_stats(
+      current_interval_total_dealloc_size.load(std::memory_order_relaxed));
+  epoch_callback_stats(previous_interval_deallocation_requests.size());
+
+  deferred_requests_type result;
+  result[0] = std::move(previous_interval_deallocation_requests);
+
+  if (likely(!single_thread_mode_locked())) {
+    previous_interval_deallocation_requests =
+        std::move(current_interval_deallocation_requests);
+    previous_interval_total_dealloc_size.store(
+        current_interval_total_dealloc_size.load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
+  } else {
+    previous_interval_deallocation_requests.clear();
+    result[1] = std::move(current_interval_deallocation_requests);
+  }
+  current_interval_deallocation_requests.clear();
+  current_interval_total_dealloc_size.store(0, std::memory_order_relaxed);
+
+#ifndef NDEBUG
+  thread_count_changed_in_previous_epoch =
+      thread_count_changed_in_current_epoch;
+  thread_count_changed_in_current_epoch = false;
+#endif
+
+  for (auto &itr : threads) {
+    quiescent_states_per_thread_between_epoch_change_stats(itr.second);
+    itr.second = 0;
+  }
+
+  threads_in_previous_epoch = threads.size();
+  return result;
+}
+
+void qsbr::assert_invariants() const noexcept {
+#ifndef NDEBUG
+  assert(reserved_thread_capacity >= threads.size());
+
+  if (single_thread_mode_locked()) {
+    assert(previous_interval_deallocation_requests.empty());
+    assert(previous_interval_total_dealloc_size.load(
+               std::memory_order_relaxed) == 0);
+  }
+  // TODO(laurynas): can this be simplified after the thread registration
+  // quiescent state fix?
+  if (!thread_count_changed_in_current_epoch &&
+      !thread_count_changed_in_previous_epoch) {
+    const auto actual_threads_in_previous_epoch = std::count_if(
+        threads.cbegin(), threads.cend(),
+        [](decltype(threads)::value_type value) { return value.second == 0; });
+    if (static_cast<std::size_t>(actual_threads_in_previous_epoch) !=
+        threads_in_previous_epoch) {
+      assert(static_cast<std::size_t>(actual_threads_in_previous_epoch) ==
+             threads_in_previous_epoch);
+    }
+  }
+#endif
+}
+
+}  // namespace unodb

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1,0 +1,386 @@
+// Copyright (C) 2019-2021 Laurynas Biveinis
+#ifndef UNODB_QSBR_HPP_
+#define UNODB_QSBR_HPP_
+
+#include "global.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/variance.hpp>
+
+#include "debug_thread_sync.h"
+#include "heap.hpp"
+
+namespace unodb {
+
+// Quiescent-state based reclamation (QSBR) memory reclamation scheme. Instead
+// of freeing memory directly, threads register pending deallocation requests to
+// be executed later. Further, each thread notifies when it's not holding any
+// pointers to the shared data structure (is quiescent with respect to that
+// structure). All the threads having passed through a quiescent state
+// constitute a quiescent period, and an epoch change happens at its boundary.
+// At that point all the pending deallocation requests queued before the
+// start of the just-finished quiescent period can be safely executed.
+
+// The implementation borrows some of the basic ideas from
+// https://preshing.com/20160726/using-quiescent-states-to-reclaim-memory/
+
+// If C++ standartisation proposal by A. D. Robison "Policy-based design for
+// safe destruction in concurrent containers" ever gets anywhere, consider
+// changing to its interface, like Stamp-it paper does.
+class qsbr;
+
+class qsbr_per_thread final {
+ public:
+  qsbr_per_thread() noexcept;
+
+  ~qsbr_per_thread() { pause(); }
+
+  void quiescent_state() noexcept;
+
+  void pause();
+
+  void resume();
+
+ private:
+  std::thread::id thread_id;
+
+#ifndef NDEBUG
+  bool is_paused{true};
+#endif
+};
+
+[[nodiscard]] inline qsbr_per_thread &current_thread_reclamator() {
+  thread_local static qsbr_per_thread current_thread_reclamator_instance;
+  return current_thread_reclamator_instance;
+}
+
+inline void construct_current_thread_reclamator() {
+  // An ODR-use ensures that the constructor gets called
+  (void)current_thread_reclamator();
+}
+
+namespace boost_acc = boost::accumulators;
+
+class qsbr final {
+ public:
+  [[nodiscard]] static auto &instance() noexcept {
+    static qsbr instance;
+    return instance;
+  }
+
+  qsbr(const qsbr &) = delete;
+  qsbr(qsbr &&) = delete;
+  qsbr &operator=(const qsbr &) = delete;
+  qsbr &operator=(qsbr &&) = delete;
+
+  void on_next_epoch_pool_deallocate(
+      detail::pmr_pool &pool, void *pointer, std::size_t size,
+      std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
+    assert(alignment >= __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+
+    bool deallocate_immediately = false;
+    {
+      std::lock_guard<std::mutex> guard{qsbr_mutex};
+      if (unlikely(single_thread_mode_locked()))
+        deallocate_immediately = true;
+      else {
+        // TODO(laurynas): out of critical section?
+        current_interval_total_dealloc_size.fetch_add(
+            size, std::memory_order_relaxed);
+        current_interval_deallocation_requests.emplace_back(pool, pointer, size,
+                                                            alignment);
+      }
+      assert_invariants();
+    }
+    if (deallocate_immediately)
+      detail::pmr_deallocate(pool, pointer, size, alignment);
+  }
+
+  void quiescent_state(std::thread::id thread_id) noexcept {
+    deferred_requests_type to_deallocate;
+    {
+      // TODO(laurynas): can call with locked mutex too
+      std::lock_guard<std::mutex> guard{qsbr_mutex};
+
+      to_deallocate = quiescent_state_locked(thread_id);
+    }
+    deallocate_requests(to_deallocate[0]);
+    deallocate_requests(to_deallocate[1]);
+  }
+
+  void prepare_new_thread();
+  void register_prepared_thread(std::thread::id thread_id) noexcept;
+
+  void register_new_thread(std::thread::id thread_id);
+
+  void unregister_thread(std::thread::id thread_id);
+
+  void reset() noexcept;
+
+  __attribute__((cold, noinline)) void dump(std::ostream &out) const;
+
+  [[nodiscard]] auto get_epoch_callback_count_max() const noexcept {
+    // TODO(laurynas): std::max against current_interval_callbacks.size(), but
+    // that would require mutex
+    return boost_acc::max(epoch_callback_stats);
+  }
+
+  [[nodiscard]] auto get_epoch_callback_count_variance() noexcept {
+    return boost_acc::variance(epoch_callback_stats);
+  }
+
+  [[nodiscard]] auto
+  get_mean_quiescent_states_per_thread_between_epoch_changes() const noexcept {
+    return boost_acc::mean(
+        quiescent_states_per_thread_between_epoch_change_stats);
+  }
+
+  [[nodiscard]] constexpr std::size_t get_epoch_change_count() const noexcept {
+    return epoch_change_count;
+  }
+
+  [[nodiscard]] auto get_max_backlog_bytes() const noexcept {
+    return boost_acc::max(deallocation_size_stats);
+  }
+
+  [[nodiscard]] auto get_mean_backlog_bytes() const noexcept {
+    return boost_acc::mean(deallocation_size_stats);
+  }
+
+  // FIXME(laurynas): cleanup! But I cannot pull gtest EXPECT here
+  // Made public for tests
+  [[nodiscard]] auto single_thread_mode() const noexcept {
+    std::lock_guard<std::mutex> guard{qsbr_mutex};
+    return single_thread_mode_locked();
+  }
+
+  [[nodiscard]] auto number_of_threads() const noexcept {
+    std::lock_guard<std::mutex> guard{qsbr_mutex};
+    return threads.size();
+  }
+
+  [[nodiscard]] auto previous_interval_size() const noexcept {
+    return previous_interval_deallocation_requests.size();
+  }
+
+  [[nodiscard]] auto current_interval_size() const noexcept {
+    return current_interval_deallocation_requests.size();
+  }
+
+  [[nodiscard]] auto get_reserved_thread_capacity() const noexcept {
+    return reserved_thread_capacity;
+  }
+
+  [[nodiscard]] auto get_threads_in_previous_epoch() const noexcept {
+    return threads_in_previous_epoch;
+  }
+
+ private:
+  struct deallocation_request {
+    // If memory usage becomes an issue, replace pool references with
+    // pre-registered pools with tagged pointers
+    detail::pmr_pool &pool;
+    void *const pointer;
+    const std::size_t size;
+    const std::size_t alignment;
+
+    // cppcheck-suppress constParameter
+    constexpr deallocation_request(detail::pmr_pool &pool_, void *pointer_,
+                                   std::size_t size_,
+                                   std::size_t alignment_) noexcept
+        : pool{pool_}, pointer{pointer_}, size{size_}, alignment{alignment_} {}
+
+    void deallocate() const {
+      // TODO(laurynas): count deallocation request instances, assert 0 in QSBR
+      // dtor
+      detail::pmr_deallocate(pool, pointer, size, alignment);
+    }
+  };
+
+  using deferred_requests_type =
+      std::array<std::vector<deallocation_request>, 2>;
+
+  static void deallocate_requests(
+      const std::vector<deallocation_request> &requests) {
+    for (const auto &dealloc_request : requests) {
+      dealloc_request.deallocate();
+    }
+  }
+
+  qsbr() noexcept {}
+
+  ~qsbr() noexcept {
+    assert(threads.size() == 0);
+    assert(previous_interval_deallocation_requests.size() == 0);
+    assert(current_interval_deallocation_requests.size() == 0);
+    assert(reserved_thread_capacity == 0);
+    assert(threads_in_previous_epoch == 0);
+  }
+
+  [[nodiscard]] bool single_thread_mode_locked() const noexcept {
+    return threads.size() < 2;
+  }
+
+  void prepare_new_thread_locked();
+  void register_prepared_thread_locked(std::thread::id thread_id) noexcept;
+
+  [[nodiscard]] deferred_requests_type quiescent_state_locked(
+      std::thread::id thread_id) noexcept;
+
+  [[nodiscard]] deferred_requests_type change_epoch() noexcept;
+
+  void assert_invariants() const noexcept;
+
+  std::vector<deallocation_request> previous_interval_deallocation_requests;
+  std::vector<deallocation_request> current_interval_deallocation_requests;
+
+  // All the registered threads. The value indicates how many times a thread was
+  // marked quiescent in the current epoch
+  std::unordered_map<std::thread::id, std::uint64_t> threads;
+
+  std::size_t reserved_thread_capacity{1};
+
+  // TODO(laurynas): absolute scalability bottleneck
+  mutable std::mutex qsbr_mutex;
+
+  std::size_t threads_in_previous_epoch{0};
+
+#ifndef NDEBUG
+  bool thread_count_changed_in_current_epoch{false};
+  bool thread_count_changed_in_previous_epoch{false};
+#endif
+
+  std::atomic<std::uint64_t> previous_interval_total_dealloc_size{};
+  std::atomic<std::uint64_t> current_interval_total_dealloc_size{};
+
+  // TODO(laurynas): more interesting callback stats?
+  boost_acc::accumulator_set<
+      std::size_t,
+      boost_acc::stats<boost_acc::tag::max, boost_acc::tag::variance>>
+      epoch_callback_stats;
+
+  boost_acc::accumulator_set<
+      std::uint64_t,
+      boost_acc::stats<boost_acc::tag::max, boost_acc::tag::variance>>
+      deallocation_size_stats;
+
+  boost_acc::accumulator_set<std::uint64_t,
+                             boost_acc::stats<boost_acc::tag::mean>>
+      quiescent_states_per_thread_between_epoch_change_stats;
+
+  std::uint64_t epoch_change_count{0};
+};
+
+inline qsbr_per_thread::qsbr_per_thread() noexcept
+    : thread_id{std::this_thread::get_id()} {
+  assert(is_paused);
+  qsbr::instance().register_prepared_thread(thread_id);
+#ifndef NDEBUG
+  is_paused = false;
+#endif
+}
+
+inline void qsbr_per_thread::quiescent_state() noexcept {
+  qsbr::instance().quiescent_state(thread_id);
+}
+
+inline void qsbr_per_thread::pause() {
+  assert(!is_paused);
+  qsbr::instance().unregister_thread(thread_id);
+#ifndef NDEBUG
+  is_paused = true;
+#endif
+}
+
+inline void qsbr_per_thread::resume() {
+  assert(is_paused);
+  qsbr::instance().register_new_thread(thread_id);
+#ifndef NDEBUG
+  is_paused = false;
+#endif
+}
+
+struct quiescent_state_on_scope_exit final {
+  quiescent_state_on_scope_exit() = default;
+
+  quiescent_state_on_scope_exit(const quiescent_state_on_scope_exit &) = delete;
+  quiescent_state_on_scope_exit(quiescent_state_on_scope_exit &&) = delete;
+  quiescent_state_on_scope_exit &operator=(
+      const quiescent_state_on_scope_exit &) = delete;
+  quiescent_state_on_scope_exit &operator=(quiescent_state_on_scope_exit &&) =
+      delete;
+
+  ~quiescent_state_on_scope_exit() noexcept {
+    current_thread_reclamator().quiescent_state();
+  }
+};
+
+// Replace with C++20 std::remove_cvref once it's available
+template <typename T>
+struct remove_cvref {
+  using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
+
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+// All the QSBR users must use qsbr_thread instead of std::thread so that
+// a thread-local current_thread_reclamator instance gets properly constructed
+class qsbr_thread : public std::thread {
+ public:
+  qsbr_thread() noexcept : std::thread{} {}
+  qsbr_thread(qsbr_thread &&other) noexcept
+      : std::thread{std::move(static_cast<std::thread &&>(other))} {}
+  qsbr_thread(const qsbr_thread &) = delete;
+
+  qsbr_thread &operator=(qsbr_thread &&other) noexcept {
+    thread::operator=(std::move(static_cast<std::thread &&>(other)));
+    return *this;
+  }
+
+  template <typename Function, typename... Args,
+            class = std::enable_if_t<
+                !std::is_same_v<remove_cvref_t<Function>, qsbr_thread>>>
+  explicit qsbr_thread(Function &&f, Args &&...args) noexcept
+      : std::thread{(qsbr::instance().prepare_new_thread(),
+                     [](auto &&f2, auto &&...args2) noexcept {
+                       construct_current_thread_reclamator();
+                       f2(std::forward<Args>(args2)...);
+                     }),
+                    std::forward<Function>(f), std::forward<Args>(args)...} {}
+
+#ifndef NDEBUG
+  template <typename Function, typename... Args,
+            class = std::enable_if_t<
+                !std::is_same_v<remove_cvref_t<Function>, qsbr_thread>>>
+  qsbr_thread(debug::thread_wait &notify_point, debug::thread_wait &wait_point,
+              Function &&f, Args &&...args) noexcept
+      : std::thread{((void)qsbr::instance().prepare_new_thread(),
+                     (void)notify_point.notify(), (void)wait_point.wait(),
+                     [](auto &&f2, auto &&...args2) noexcept {
+                       construct_current_thread_reclamator();
+                       f2(std::forward<Args>(args2)...);
+                     }),
+                    std::forward<Function>(f), std::forward<Args>(args)...} {}
+#endif  // NDEBUG
+};
+
+}  // namespace unodb
+
+#endif  // UNODB_QSBR_HPP_

--- a/qsbr_test_utils.cpp
+++ b/qsbr_test_utils.cpp
@@ -1,0 +1,18 @@
+// Copyright 2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "qsbr_test_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include "qsbr.hpp"
+
+void expect_idle_qsbr() {
+  EXPECT_TRUE(unodb::qsbr::instance().single_thread_mode());
+  EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+  EXPECT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
+  EXPECT_EQ(unodb::qsbr::instance().current_interval_size(), 0);
+  EXPECT_EQ(unodb::qsbr::instance().get_reserved_thread_capacity(), 1);
+  EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 1);
+}

--- a/qsbr_test_utils.hpp
+++ b/qsbr_test_utils.hpp
@@ -1,0 +1,13 @@
+// Copyright 2021 Laurynas Biveinis
+#ifndef UNODB_QSBR_TEST_UTILS_HPP_
+#define UNODB_QSBR_TEST_UTILS_HPP_
+
+#include "global.hpp"
+
+#include <gtest/gtest.h>
+
+#include "qsbr.hpp"
+
+void expect_idle_qsbr();
+
+#endif  // UNODB_QSBR_TEST_UTILS_HPP_

--- a/test_art_mutex_concurrency.cpp
+++ b/test_art_mutex_concurrency.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Laurynas Biveinis
+// Copyright 2019-2021 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -7,8 +7,8 @@
 
 #include <gtest/gtest.h>
 
+#include "db_test_utils.hpp"
 #include "mutex_art.hpp"
-#include "test_utils.hpp"
 
 namespace {
 

--- a/test_olc_art_concurrency.cpp
+++ b/test_olc_art_concurrency.cpp
@@ -1,0 +1,151 @@
+// Copyright 2019-2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <random>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "art.hpp"
+#include "db_test_utils.hpp"
+#include "qsbr.hpp"
+#include "qsbr_test_utils.hpp"
+
+namespace {
+
+class ARTOptimisticLockCoupling : public ::testing::Test {
+ protected:
+  ARTOptimisticLockCoupling() noexcept { expect_idle_qsbr(); }
+
+  ~ARTOptimisticLockCoupling() noexcept override { expect_idle_qsbr(); }
+
+  olc_tree_verifier verifier{true};
+};
+
+template <unsigned ThreadCount, unsigned OpsPerThread, typename TestFn>
+void parallel_test(TestFn test_function, olc_tree_verifier &verifier) {
+  unodb::current_thread_reclamator().pause();
+  std::array<unodb::qsbr_thread, ThreadCount> threads;
+  for (std::size_t i = 0; i < ThreadCount; ++i) {
+    threads[i] = unodb::qsbr_thread{test_function, &verifier, i, OpsPerThread};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+  unodb::current_thread_reclamator().resume();
+}
+
+void key_range_op_thread(olc_tree_verifier *verifier, std::size_t thread_i,
+                         unsigned op_count) {
+  unodb::key key = thread_i / 3 * 3;
+  for (unsigned i = 0; i < op_count; ++i) {
+    switch (thread_i % 3) {
+      case 0: /* insert */
+        verifier->try_insert(key, test_value_1);
+        break;
+      case 1: /* remove */
+        verifier->try_remove(key);
+        break;
+      case 2: /* get */
+        verifier->try_get(key);
+        break;
+    }
+    key++;
+  }
+}
+
+template <unsigned ThreadCount, unsigned OpCount>
+void key_range_op_test(olc_tree_verifier &verifier) {
+  static_assert(ThreadCount >= 3);
+
+  unodb::current_thread_reclamator().pause();
+  std::array<unodb::qsbr_thread, ThreadCount> threads;
+  for (std::size_t i = 0; i < ThreadCount; ++i) {
+    threads[i] = unodb::qsbr_thread{key_range_op_thread, &verifier, i, OpCount};
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+  unodb::current_thread_reclamator().resume();
+}
+
+void parallel_insert_thread(olc_tree_verifier *verifier, std::size_t thread_i,
+                            unsigned count) {
+  verifier->insert_preinserted_key_range(thread_i * count, count);
+}
+
+TEST_F(ARTOptimisticLockCoupling, ParallelInsertOneTree) {
+  constexpr auto num_of_threads = 4;
+  constexpr auto total_keys = 1024;
+  verifier.preinsert_key_range_to_verifier_only(0, total_keys);
+  parallel_test<num_of_threads, total_keys / num_of_threads>(
+      parallel_insert_thread, verifier);
+  // FIXME(laurynas): move to the fixture class
+  verifier.check_present_values();
+}
+
+void parallel_remove_thread(olc_tree_verifier *verifier, std::size_t thread_i,
+                            unsigned count) {
+  const auto start_key = thread_i * count;
+  for (std::size_t i = 0; i < count; ++i) {
+    verifier->remove(start_key + i, true);
+  }
+}
+
+TEST_F(ARTOptimisticLockCoupling, ParallelTearDownOneTree) {
+  constexpr auto num_of_threads = 8;
+  constexpr auto total_keys = 2048;
+  verifier.insert_key_range(0, total_keys, true);
+  parallel_test<num_of_threads, total_keys / num_of_threads>(
+      parallel_remove_thread, verifier);
+  verifier.assert_empty();
+}
+
+TEST_F(ARTOptimisticLockCoupling, Node4ParallelOps) {
+  verifier.insert_key_range(0, 3, true);
+  key_range_op_test<9, 6>(verifier);
+}
+
+TEST_F(ARTOptimisticLockCoupling, Node16ParallelOps) {
+  verifier.insert_key_range(0, 10, true);
+  key_range_op_test<9, 12>(verifier);
+}
+
+TEST_F(ARTOptimisticLockCoupling, Node48ParallelOps) {
+  verifier.insert_key_range(0, 32, true);
+  key_range_op_test<9, 32>(verifier);
+}
+
+TEST_F(ARTOptimisticLockCoupling, Node256ParallelOps) {
+  verifier.insert_key_range(0, 152, true);
+  key_range_op_test<9, 208>(verifier);
+}
+
+void random_op_thread(olc_tree_verifier *verifier, std::size_t thread_i,
+                      unsigned op_count) {
+  std::random_device rd;
+  std::mt19937 gen{rd()};
+  std::geometric_distribution<unodb::key> key_generator{0.5};
+  for (unsigned i = 0; i < op_count; ++i) {
+    const auto key{key_generator(gen)};
+    switch (thread_i % 3) {
+      case 0: /* insert */
+        verifier->try_insert(key, test_value_2);
+        break;
+      case 1: /* remove */
+        verifier->try_remove(key);
+        break;
+      case 2: /* get */
+        verifier->try_get(key);
+        break;
+    }
+  }
+}
+
+TEST_F(ARTOptimisticLockCoupling, ParallelRandomInsertDeleteGet) {
+  verifier.insert_key_range(0, 2048, true);
+  parallel_test<4 * 3, 10000>(random_op_thread, verifier);
+}
+
+}  // namespace

--- a/test_qsbr.cpp
+++ b/test_qsbr.cpp
@@ -1,0 +1,694 @@
+// Copyright 2020-2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include <condition_variable>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+#include "debug_thread_sync.h"
+#include "heap.hpp"
+#include "qsbr.hpp"
+#include "qsbr_test_utils.hpp"
+
+namespace {
+
+class mock_pool : public unodb::detail::pmr_pool {
+ public:
+  using unodb::detail::pmr_pool::pmr_pool;
+
+  ~mock_pool() override { EXPECT_TRUE(empty()); }
+
+  [[nodiscard]] bool empty() const noexcept { return allocations.empty(); }
+
+  DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
+  [[nodiscard]] auto is_allocated(void *ptr) const {
+    return allocations.find(reinterpret_cast<std::uintptr_t>(ptr)) !=
+           allocations.cend();
+  }
+  RESTORE_GCC_WARNINGS()
+
+  [[nodiscard]] void *do_allocate(std::size_t, std::size_t) override {
+    const auto pointer_val = next_pointer++;
+    allocations.emplace(pointer_val);
+    return reinterpret_cast<void *>(pointer_val);
+  }
+
+  void do_deallocate(void *ptr, std::size_t, std::size_t) override {
+    const auto elems_removed =
+        allocations.erase(reinterpret_cast<std::uintptr_t>(ptr));
+    EXPECT_EQ(elems_removed, 1);
+  }
+
+  // LCOV_EXCL_START
+  [[nodiscard]] bool do_is_equal(
+      const unodb::detail::pmr_pool &other) const noexcept override {
+    const auto *other_as_mock_pool = dynamic_cast<const mock_pool *>(&other);
+    return (other_as_mock_pool != nullptr) && (this == other_as_mock_pool);
+  }
+  // LCOV_EXCL_STOP
+
+ private:
+  std::unordered_set<std::uintptr_t> allocations{};
+
+  std::uintptr_t next_pointer{1};
+};
+
+class QSBR : public ::testing::Test {
+ protected:
+  QSBR() noexcept { expect_idle_qsbr(); }
+
+  ~QSBR() noexcept override { expect_idle_qsbr(); }
+
+  // Epochs
+
+  void mark_epoch() noexcept {
+    last_epoch_num = unodb::qsbr::instance().get_epoch_change_count();
+  }
+
+  void check_epoch_advanced() {
+    const auto current_epoch = unodb::qsbr::instance().get_epoch_change_count();
+    EXPECT_EQ(last_epoch_num + 1, current_epoch);
+    last_epoch_num = current_epoch;
+  }
+
+  void check_epoch_same() const {
+    const auto current_epoch = unodb::qsbr::instance().get_epoch_change_count();
+    EXPECT_EQ(last_epoch_num, current_epoch);
+  }
+
+  std::size_t last_epoch_num{std::numeric_limits<std::size_t>::max()};
+
+  // Allocation and deallocation
+
+  [[nodiscard]] void *mock_allocate() {
+    std::lock_guard guard{mock_allocator_mutex};
+    return allocator.allocate(1);
+  }
+
+  void mock_qsbr_deallocate(void *ptr) {
+    std::lock_guard guard{mock_allocator_mutex};
+    unodb::qsbr::instance().on_next_epoch_pool_deallocate(allocator, ptr, 1);
+  }
+
+  [[nodiscard]] bool mock_is_allocated(void *ptr) {
+    std::lock_guard guard{mock_allocator_mutex};
+    return allocator.is_allocated(ptr);
+  }
+
+  unodb::debug::thread_wait thread_sync_1;
+  unodb::debug::thread_wait thread_sync_2;
+
+ private:
+  mock_pool allocator;
+  std::mutex mock_allocator_mutex;
+};
+
+TEST_F(QSBR, SingleThreadPauseResume) {
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, TwoThreads) {
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+  unodb::qsbr_thread second_thread(
+      [] { EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 2); });
+  second_thread.join();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, TwoThreadsSecondPaused) {
+  unodb::qsbr_thread second_thread([] {
+    EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 2);
+    unodb::current_thread_reclamator().pause();
+    EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+    unodb::current_thread_reclamator().resume();
+    EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 2);
+  });
+  second_thread.join();
+}
+
+TEST_F(QSBR, TwoThreadsFirstPaused) {
+  unodb::qsbr_thread second_thread([this] {
+    EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 2);
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+  thread_sync_2.notify();
+  second_thread.join();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, TwoThreadsBothPaused) {
+  unodb::qsbr_thread second_thread([this] {
+    EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 2);
+    thread_sync_1.notify();
+    unodb::current_thread_reclamator().pause();
+    thread_sync_2.wait();
+    EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+    unodb::current_thread_reclamator().resume();
+  });
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().pause();
+  thread_sync_2.notify();
+  second_thread.join();
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, TwoThreadsSequential) {
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::qsbr_thread second_thread(
+      [] { ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1); });
+  second_thread.join();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, TwoThreadsDefaultCtor) {
+  unodb::current_thread_reclamator().pause();
+  unodb::qsbr_thread second_thread{};
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  second_thread = unodb::qsbr_thread{
+      [] { ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1); }};
+  second_thread.join();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::current_thread_reclamator().resume();
+}
+
+#ifndef NDEBUG
+
+TEST_F(QSBR, ThreeThreadsInterleavedCtor) {
+  std::thread second_thread_launcher([this] {
+    unodb::qsbr_thread second_thread(thread_sync_1, thread_sync_2, [] {});
+    second_thread.join();
+  });
+
+  thread_sync_1.wait();
+  unodb::qsbr_thread third_thread([this] { thread_sync_2.notify(); });
+  second_thread_launcher.join();
+  third_thread.join();
+}
+
+TEST_F(QSBR, TwoThreadsInterleavedCtorDtor) {
+  std::thread second_thread_launcher([this] {
+    unodb::qsbr_thread second_thread(thread_sync_1, thread_sync_2, [] {
+      ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+    });
+    second_thread.join();
+  });
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  thread_sync_2.notify();
+  second_thread_launcher.join();
+  unodb::current_thread_reclamator().resume();
+}
+
+#endif  // NDEBUG
+
+TEST_F(QSBR, SecondThreadAddedWhileFirstPaused) {
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+
+  unodb::qsbr_thread second_thread(
+      [] { ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1); });
+  second_thread.join();
+
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, SecondThreadAddedWhileFirstPausedBothRun) {
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+
+  unodb::qsbr_thread second_thread([this] {
+    ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 2);
+  thread_sync_2.notify();
+  second_thread.join();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, ThreeThreadsInitialPaused) {
+  unodb::current_thread_reclamator().pause();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::qsbr_thread second_thread([this] {
+    ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+  thread_sync_1.wait();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+  unodb::qsbr_thread third_thread([this] {
+    ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 2);
+    thread_sync_2.notify();
+  });
+  second_thread.join();
+  third_thread.join();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 0);
+  unodb::current_thread_reclamator().resume();
+  ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
+}
+
+TEST_F(QSBR, SingleThreadOneAllocation) {
+  auto *ptr = mock_allocate();
+  ASSERT_TRUE(mock_is_allocated(ptr));
+  mock_qsbr_deallocate(ptr);
+  ASSERT_FALSE(mock_is_allocated(ptr));
+}
+
+TEST_F(QSBR, SingleThreadAllocationAndEpochChange) {
+  auto *ptr = mock_allocate();
+  ASSERT_TRUE(mock_is_allocated(ptr));
+  mock_qsbr_deallocate(ptr);
+  ASSERT_FALSE(mock_is_allocated(ptr));
+
+  mark_epoch();
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  check_epoch_advanced();
+
+  ASSERT_FALSE(mock_is_allocated(ptr));
+  ptr = mock_allocate();
+  ASSERT_TRUE(mock_is_allocated(ptr));
+  mock_qsbr_deallocate(ptr);
+  ASSERT_FALSE(mock_is_allocated(ptr));
+}
+
+TEST_F(QSBR, TwoThreadEpochChangesSecondStartsQuiescent) {
+  mark_epoch();
+
+  unodb::qsbr_thread second_thread([this] {
+    unodb::current_thread_reclamator().quiescent_state();
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+
+  thread_sync_1.wait();
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  check_epoch_advanced();
+
+  thread_sync_2.notify();
+  second_thread.join();
+}
+
+TEST_F(QSBR, TwoThreadEpochChanges) {
+  mark_epoch();
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  check_epoch_advanced();
+
+  unodb::qsbr_thread second_thread([this] {
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+    unodb::current_thread_reclamator().quiescent_state();
+    thread_sync_1.notify();
+  });
+
+  thread_sync_1.wait();
+
+  check_epoch_same();
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  check_epoch_same();
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  check_epoch_advanced();
+
+  second_thread.join();
+}
+
+TEST_F(QSBR, TwoThreadAllocations) {
+  auto *ptr = mock_allocate();
+
+  unodb::qsbr_thread second_thread([this] {
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    unodb::current_thread_reclamator().quiescent_state();
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    unodb::current_thread_reclamator().quiescent_state();
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+
+  thread_sync_1.wait();
+  mock_qsbr_deallocate(ptr);
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  unodb::current_thread_reclamator().quiescent_state();
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  ASSERT_FALSE(mock_is_allocated(ptr));
+
+  thread_sync_2.notify();
+  second_thread.join();
+}
+
+TEST_F(QSBR, TwoThreadAllocationsQuitWithoutQuiescentState) {
+  auto *ptr = mock_allocate();
+
+  unodb::qsbr_thread second_thread([this] {
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+    thread_sync_1.notify();
+  });
+
+  thread_sync_1.wait();
+  mock_qsbr_deallocate(ptr);
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  unodb::current_thread_reclamator().quiescent_state();
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  second_thread.join();
+  ASSERT_FALSE(mock_is_allocated(ptr));
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_FALSE(mock_is_allocated(ptr));
+}
+
+TEST_F(QSBR, SecondThreadAllocatingWhileFirstPaused) {
+  unodb::current_thread_reclamator().pause();
+
+  unodb::qsbr_thread second_thread([this] {
+    auto *ptr = mock_allocate();
+    mock_qsbr_deallocate(ptr);
+    ASSERT_FALSE(mock_is_allocated(ptr));
+
+    ptr = mock_allocate();
+
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    mock_qsbr_deallocate(ptr);
+    ASSERT_TRUE(mock_is_allocated(ptr));
+
+    unodb::current_thread_reclamator().quiescent_state();
+
+    ASSERT_TRUE(mock_is_allocated(ptr));
+
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    unodb::current_thread_reclamator().quiescent_state();
+
+    ASSERT_TRUE(mock_is_allocated(ptr));
+
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    ASSERT_FALSE(mock_is_allocated(ptr));
+  });
+
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().resume();
+  thread_sync_2.notify();
+
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().quiescent_state();
+  thread_sync_2.notify();
+
+  thread_sync_1.wait();
+  unodb::current_thread_reclamator().quiescent_state();
+  thread_sync_2.notify();
+
+  second_thread.join();
+}
+
+TEST_F(QSBR, SecondThreadQuittingWithoutQuiescentState) {
+  auto *ptr = mock_allocate();
+
+  unodb::qsbr_thread second_thread([this] {
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+
+  thread_sync_1.wait();
+  mock_qsbr_deallocate(ptr);
+
+  unodb::current_thread_reclamator().quiescent_state();
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  thread_sync_2.notify();
+  second_thread.join();
+
+  ASSERT_FALSE(mock_is_allocated(ptr));
+}
+
+TEST_F(QSBR, SecondThreadQuittingWithoutQuiescentStateBefore1stThreadQState) {
+  auto *ptr = mock_allocate();
+
+  unodb::qsbr_thread second_thread([this] {
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  });
+
+  thread_sync_1.wait();
+  mock_qsbr_deallocate(ptr);
+
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  thread_sync_2.notify();
+  second_thread.join();
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_FALSE(mock_is_allocated(ptr));
+}
+
+TEST_F(QSBR, TwoThreadsConsecutiveEpochAllocations) {
+  mark_epoch();
+  auto *ptr_1_1 = mock_allocate();
+
+  unodb::qsbr_thread second_thread([this] {
+    auto *ptr_2_1 = mock_allocate();
+
+    mock_qsbr_deallocate(ptr_2_1);
+    unodb::current_thread_reclamator().quiescent_state();
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    ASSERT_TRUE(mock_is_allocated(ptr_2_1));
+    auto *ptr_2_2 = mock_allocate();
+    mock_qsbr_deallocate(ptr_2_2);
+    unodb::current_thread_reclamator().quiescent_state();
+
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    ASSERT_FALSE(mock_is_allocated(ptr_2_1));
+    ASSERT_TRUE(mock_is_allocated(ptr_2_2));
+    unodb::current_thread_reclamator().quiescent_state();
+
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    ASSERT_FALSE(mock_is_allocated(ptr_2_2));
+  });
+
+  thread_sync_1.wait();
+  mock_qsbr_deallocate(ptr_1_1);
+  unodb::current_thread_reclamator().quiescent_state();
+
+  check_epoch_advanced();
+
+  ASSERT_TRUE(mock_is_allocated(ptr_1_1));
+  auto *ptr_1_2 = mock_allocate();
+  mock_qsbr_deallocate(ptr_1_2);
+  unodb::current_thread_reclamator().quiescent_state();
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  check_epoch_advanced();
+
+  ASSERT_FALSE(mock_is_allocated(ptr_1_1));
+  ASSERT_TRUE(mock_is_allocated(ptr_1_2));
+  unodb::current_thread_reclamator().quiescent_state();
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  check_epoch_advanced();
+
+  ASSERT_FALSE(mock_is_allocated(ptr_1_2));
+
+  thread_sync_2.notify();
+  second_thread.join();
+}
+
+TEST_F(QSBR, TwoThreadsImmediateTwoEpochDeallocationOnOneQuitting) {
+  mark_epoch();
+  auto *ptr = mock_allocate();
+
+  unodb::qsbr_thread second_thread{[this] {
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+
+    unodb::current_thread_reclamator().quiescent_state();
+
+    thread_sync_1.notify();
+    thread_sync_2.wait();
+  }};
+
+  thread_sync_1.wait();
+  mock_qsbr_deallocate(ptr);
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  thread_sync_2.notify();
+  thread_sync_1.wait();
+
+  check_epoch_advanced();
+  ASSERT_TRUE(mock_is_allocated(ptr));
+
+  auto *ptr2 = mock_allocate();
+  mock_qsbr_deallocate(ptr2);
+  ASSERT_TRUE(mock_is_allocated(ptr2));
+
+  thread_sync_2.notify();
+  second_thread.join();
+
+  ASSERT_FALSE(mock_is_allocated(ptr));
+  ASSERT_TRUE(mock_is_allocated(ptr2));
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_FALSE(mock_is_allocated(ptr2));
+}
+
+TEST_F(QSBR, TwoThreadsAllocatingInTwoEpochsAndPausing) {
+  mark_epoch();
+
+  auto *ptr_1_1 = mock_allocate();
+
+  unodb::qsbr_thread second_thread{[this] {
+    auto *ptr_2_1 = mock_allocate();
+    thread_sync_1.notify();  // 1 ->
+    thread_sync_2.wait();    // 2 <-
+
+    mock_qsbr_deallocate(ptr_2_1);
+    unodb::current_thread_reclamator().quiescent_state();
+
+    thread_sync_1.notify();  // 3 ->
+    thread_sync_2.wait();    // 4 <-
+
+    ASSERT_TRUE(mock_is_allocated(ptr_2_1));
+    auto *ptr_2_2 = mock_allocate();
+    mock_qsbr_deallocate(ptr_2_2);
+    ASSERT_TRUE(mock_is_allocated(ptr_2_2));
+
+    thread_sync_1.notify();  // 5 ->
+    thread_sync_2.wait();    // 6 <-
+
+    unodb::current_thread_reclamator().pause();
+
+    thread_sync_1.notify();  // 7 ->
+
+    ASSERT_FALSE(mock_is_allocated(ptr_2_1));
+    ASSERT_FALSE(mock_is_allocated(ptr_2_2));
+
+    unodb::current_thread_reclamator().resume();
+  }};
+
+  thread_sync_1.wait();  // 1 <-
+
+  mock_qsbr_deallocate(ptr_1_1);
+  unodb::current_thread_reclamator().quiescent_state();
+
+  thread_sync_2.notify();  // 2 ->
+  thread_sync_1.wait();    // 3 <-
+
+  check_epoch_advanced();
+
+  thread_sync_2.notify();  // 4 ->
+  thread_sync_1.wait();    // 5 <-
+
+  ASSERT_TRUE(mock_is_allocated(ptr_1_1));
+  auto *ptr_1_2 = mock_allocate();
+  mock_qsbr_deallocate(ptr_1_2);
+  ASSERT_TRUE(mock_is_allocated(ptr_1_2));
+
+  unodb::current_thread_reclamator().pause();
+
+  thread_sync_2.notify();  // 6 ->
+  thread_sync_1.wait();    // 7 <-
+
+  ASSERT_FALSE(mock_is_allocated(ptr_1_1));
+  ASSERT_FALSE(mock_is_allocated(ptr_1_2));
+  second_thread.join();
+
+  unodb::current_thread_reclamator().resume();
+}
+
+TEST_F(QSBR, TwoThreadsDeallocateBeforeQuittingPointerStaysLive) {
+  void *test_ptr = mock_allocate();
+
+  unodb::qsbr_thread second_thread{
+      [this, test_ptr] { mock_qsbr_deallocate(test_ptr); }};
+  second_thread.join();
+
+  ASSERT_TRUE(mock_is_allocated(test_ptr));
+
+  unodb::current_thread_reclamator().quiescent_state();
+
+  ASSERT_FALSE(mock_is_allocated(test_ptr));
+}
+
+// TODO(laurynas): stat tests
+// TODO(laurynas): quiescent_state_on_scope_exit tests?
+// TODO(laurynas): qsbr::reset test?
+// TODO(laurynas): qsbr::dump test
+
+}  // namespace


### PR DESCRIPTION
The implementation follows OLC ART as described in "The ART of Practical
Synchronization" paper. For memory reclamation, QSBR was chosen, but the current
implementation is extremely ineffective due to a global mutex there.

The existing ART implementation was refactored to the absolutist DRY level, so
that most internal and leaf node code ended up being shared, implemented by
heavy C++ templating of things. The shared code is in a new file
art_internal_impl.hpp with a helper not_atomic.hpp.

Add correctness tests and some benchmarks. For concurrency benchmarks, factor
out common fixture for mutex_db and olc_db into micro_benchmark_concurrency.hpp.

Rename test_utils.hpp and .cpp to db_test_utils, to differentiate between DB and
QSBR tests due to the latter not needing DB-specific test utilities.