### PR TITLE
Convert cannot_happen() function to a CANNOT_HAPPEN() macro and inclu…

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -293,7 +293,7 @@ struct basic_reclaim_db_node_ptr_at_scope_exit final {
         return;
       }
     }
-    cannot_happen();  // LCOV_EXCL_LINE
+    CANNOT_HAPPEN();  // LCOV_EXCL_LINE
   }
 
   void delete_subtree() noexcept {
@@ -516,7 +516,7 @@ class basic_inode_impl {
         break;
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
     os << "# children = "
@@ -538,7 +538,7 @@ class basic_inode_impl {
         break;
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
   }
@@ -562,7 +562,7 @@ class basic_inode_impl {
         break;
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
   }
@@ -585,7 +585,7 @@ class basic_inode_impl {
         break;
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
   }
@@ -602,7 +602,7 @@ class basic_inode_impl {
         return static_cast<inode256_type *>(this)->delete_subtree(db_instance);
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
   }
@@ -628,9 +628,9 @@ class basic_inode_impl {
         return static_cast<inode256_type *>(this)->find_child(key_byte);
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
     }
-    cannot_happen();
+    CANNOT_HAPPEN();
     // LCOV_EXCL_STOP
   }
 
@@ -646,9 +646,9 @@ class basic_inode_impl {
         return static_cast<const inode256_type *>(this)->is_full();
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
     }
-    cannot_happen();
+    CANNOT_HAPPEN();
     // LCOV_EXCL_STOP
   }
 
@@ -664,9 +664,9 @@ class basic_inode_impl {
         return static_cast<const inode256_type *>(this)->is_min_size();
         // LCOV_EXCL_START
       case node_type::LEAF:
-        cannot_happen();
+        CANNOT_HAPPEN();
     }
-    cannot_happen();
+    CANNOT_HAPPEN();
     // LCOV_EXCL_STOP
   }
 
@@ -674,12 +674,12 @@ class basic_inode_impl {
   // define their own new and delete operators using node pools
   [[nodiscard]] __attribute__((cold, noinline)) static void *operator new(
       std::size_t) {
-    cannot_happen();
+    CANNOT_HAPPEN();
   }
 
   DISABLE_CLANG_WARNING("-Wmissing-noreturn")
   __attribute__((cold, noinline)) static void operator delete(void *) {
-    cannot_happen();
+    CANNOT_HAPPEN();
   }
   RESTORE_CLANG_WARNINGS()
 

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -252,7 +252,7 @@ std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
       }
     }
   }
-  unodb::cannot_happen();
+  CANNOT_HAPPEN();
 }
 
 }  // namespace detail

--- a/global.hpp
+++ b/global.hpp
@@ -77,16 +77,29 @@
 #define USE_STD_PMR
 #endif
 
-#include <cassert>
+#ifndef NDEBUG
+#include <cstdlib>
+#include <iostream>
+#endif
 
 // LCOV_EXCL_START
-namespace unodb {
-inline __attribute__((noreturn)) void cannot_happen() {
-  assert(0);
+namespace unodb::detail {
+
+inline __attribute__((noreturn)) void cannot_happen(
+    const char *file USED_IN_DEBUG, int line USED_IN_DEBUG,
+    const char *func USED_IN_DEBUG) {
+#ifndef NDEBUG
+  std::cerr << "Execution reached an unreachable point at " << file << ':'
+            << line << ": " << func << '\n';
+  std::abort();
+#endif
   __builtin_unreachable();
 }
 // LCOV_EXCL_STOP
 
-}  // namespace unodb
+}  // namespace unodb::detail
+
+#define CANNOT_HAPPEN()                                         \
+  unodb::detail::cannot_happen(__FILE__, __LINE__, __func__)
 
 #endif  // UNODB_GLOBAL_HPP_

--- a/heap.hpp
+++ b/heap.hpp
@@ -4,6 +4,7 @@
 
 #include "global.hpp"
 
+#include <cassert>
 #ifdef USE_STD_PMR
 #include <memory_resource>
 #endif

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -157,7 +157,7 @@ void qsbr::register_prepared_thread_locked(std::thread::id thread_id) noexcept {
 #ifdef NDEBUG
     std::abort();
 #else
-    cannot_happen();
+    CANNOT_HAPPEN();
 #endif
   } catch (...) {
     std::cerr << "Impossible happened: QSBR thread vector insert threw unknown "
@@ -165,7 +165,7 @@ void qsbr::register_prepared_thread_locked(std::thread::id thread_id) noexcept {
 #ifdef NDEBUG
     std::abort();
 #else
-    cannot_happen();
+    CANNOT_HAPPEN();
 #endif
     // LCOV_EXCL_STOP
   }


### PR DESCRIPTION
…de source location

Currently, cannot_happen() failures print

13154: test_olc_art_concurrency: /home/travis/build/laurynas-biveinis/unodb/global.hpp:85: void unodb::cannot_happen(): Assertion `0' failed.

without information which of the cannot_happen() callers failed. Address this by
making cannot_happen() function internal and taking source location information,
and introduce CANNOT_HAPPEN macro to pass the usual __FILE__, __LINE__, and
__func__ to it.

As a bonus, this limits header pollution in global.hpp to debug builds only.