### PR TITLE
Cleanup key and binary-comparable key dumping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,9 +484,9 @@ if(DO_CLANG_TIDY)
 endif()
 target_link_libraries(unodb_qsbr PUBLIC Threads::Threads)
 
-add_library(unodb art.cpp art.hpp art_common.hpp mutex_art.hpp
+add_library(unodb art.cpp art.hpp art_common.cpp art_common.hpp mutex_art.hpp
   optimistic_lock.hpp art_internal_impl.hpp olc_art.hpp olc_art.cpp
-  art_internal.hpp)
+  art_internal.cpp art_internal.hpp)
 common_target_properties(unodb)
 target_link_libraries(unodb PUBLIC unodb_qsbr)
 target_include_directories(unodb PUBLIC ".")

--- a/art_common.cpp
+++ b/art_common.cpp
@@ -1,0 +1,17 @@
+// Copyright 2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "art_common.hpp"
+
+#include <iomanip>
+#include <iostream>
+
+namespace unodb::detail {
+
+__attribute__((cold, noinline)) void dump_key(std::ostream &os, unodb::key k) {
+  os << "key: 0x" << std::hex << std::setfill('0') << std::setw(sizeof(k)) << k
+     << std::dec;
+}
+
+}  // namespace unodb::detail

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -1,10 +1,11 @@
-// Copyright 2019 Laurynas Biveinis
+// Copyright 2019-2021 Laurynas Biveinis
 #ifndef UNODB_ART_COMMON_HPP_
 #define UNODB_ART_COMMON_HPP_
 
 #include "global.hpp"
 
 #include <cstdint>
+#include <iosfwd>
 #include <optional>
 
 #include <gsl/span>
@@ -13,6 +14,12 @@ namespace unodb {
 
 // Key type for public API
 using key = std::uint64_t;
+
+namespace detail {
+
+__attribute__((cold, noinline)) void dump_key(std::ostream &os, key k);
+
+}  // namespace detail
 
 // Value type for public API. Values are passed as non-owning pointers to
 // memory with associated length (gsl::span). The memory is copied upon

--- a/art_internal.cpp
+++ b/art_internal.cpp
@@ -1,0 +1,26 @@
+// Copyright 2021 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "art_internal.hpp"
+
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+
+namespace unodb::detail {
+
+__attribute__((cold, noinline)) void dump_byte(std::ostream &os,
+                                               std::byte byte) {
+  os << ' ' << std::hex << std::setfill('0') << std::setw(2)
+     << static_cast<unsigned>(byte) << std::dec;
+}
+
+__attribute__((cold, noinline)) std::ostream &operator<<(std::ostream &os,
+                                                         art_key key) {
+  os << "binary-comparable key:";
+  for (std::size_t i = 0; i < sizeof(key); ++i) dump_byte(os, key[i]);
+  return os;
+}
+
+}  // namespace unodb::detail

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <iosfwd>
 #include <memory>
 #include <type_traits>
 
@@ -83,6 +84,12 @@ struct basic_art_key final {
 };
 
 using art_key = basic_art_key<unodb::key>;
+
+__attribute__((cold, noinline)) void dump_byte(std::ostream &os,
+                                               std::byte byte);
+
+__attribute__((cold, noinline)) std::ostream &operator<<(std::ostream &os,
+                                                         art_key key);
 
 // This corresponds to the "single value leaf" type in the ART paper. Since we
 // have only one kind of leaf nodes, we call them simply "leaf" nodes. Should we

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -9,7 +9,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <iomanip>
 #include <iostream>
 #include <stdexcept>
 
@@ -30,17 +29,6 @@ class olc_db;
 }  // namespace unodb
 
 namespace unodb::detail {
-
-__attribute__((cold, noinline)) inline void dump_byte(std::ostream &os,
-                                                      std::byte byte) {
-  os << ' ' << std::hex << std::setfill('0') << std::setw(2)
-     << static_cast<unsigned>(byte) << std::dec;
-}
-
-__attribute__((cold, noinline)) inline void dump_key(std::ostream &os,
-                                                     art_key key) {
-  for (std::size_t i = 0; i < sizeof(key); i++) dump_byte(os, key[i]);
-}
 
 // For internal node pools, approximate requesting ~2MB blocks from backing
 // storage (when ported to Linux, ask for 2MB huge pages directly)
@@ -219,9 +207,7 @@ auto make_db_leaf_ptr(art_key k, value_view v, Db &db) {
 
 template <class Header>
 void basic_leaf<Header>::dump(std::ostream &os, raw_leaf_ptr leaf) {
-  os << "LEAF: key:";
-  dump_key(os, key(leaf));
-  os << ", value size: " << value_size(leaf) << '\n';
+  os << "LEAF: " << key(leaf) << ", value size: " << value_size(leaf) << '\n';
 }
 
 // Implementation of things declared in art_internal.hpp

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -44,20 +44,6 @@ inline auto &get_prng() {
   return gen;
 }
 
-// Asserts
-
-namespace detail {
-
-#ifndef NDEBUG
-
-inline void print_key(std::ostream &out, unodb::key k) {
-  out << "0x" << std::hex << k << std::dec;
-}
-
-#endif  // #ifndef NDEBUG
-
-}  // namespace detail
-
 // Inserts
 
 template <class Db>
@@ -65,8 +51,8 @@ void insert_key(Db &db, unodb::key k, unodb::value_view v) {
   const auto result USED_IN_DEBUG = db.insert(k, v);
 #ifndef NDEBUG
   if (!result) {
-    std::cerr << "Failed to insert key ";
-    detail::print_key(std::cerr, k);
+    std::cerr << "Failed to insert ";
+    detail::dump_key(std::cerr, k);
     std::cerr << "\nCurrent tree:";
     db.dump(std::cerr);
     assert(result);
@@ -82,8 +68,8 @@ void delete_key(Db &db, unodb::key k) {
   const auto result USED_IN_DEBUG = db.remove(k);
 #ifndef NDEBUG
   if (!result) {
-    std::cerr << "Failed to delete existing key ";
-    detail::print_key(std::cerr, k);
+    std::cerr << "Failed to delete existing ";
+    detail::dump_key(std::cerr, k);
     std::cerr << "\nTree:";
     db.dump(std::cerr);
     assert(result);
@@ -100,8 +86,8 @@ void get_existing_key(const Db &db, unodb::key k) {
   const auto result = db.get(k);
 #ifndef NDEBUG
   if (!result) {
-    std::cerr << "Failed to get existing key ";
-    detail::print_key(std::cerr, k);
+    std::cerr << "Failed to get existing ";
+    detail::dump_key(std::cerr, k);
     std::cerr << "\nTree:";
     db.dump(std::cerr);
     assert(result);

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -680,7 +680,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
     auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
 
     if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
-      return {};
+      return {};  // LCOV_EXCL_LINE
     optimistic_write_lock_guard unlock_on_exit{*parent_lock};
 
     root = leaf.release();
@@ -710,7 +710,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
       auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
 
       if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
-        return {};
+        return {};  // LCOV_EXCL_LINE
       optimistic_write_lock_guard unlock_on_exit{*parent_lock};
 
       if (unlikely(!node_lock.try_upgrade_to_write_lock(version))) return {};
@@ -740,7 +740,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
       auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
 
       if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
-        return {};
+        return {};  // LCOV_EXCL_LINE
       optimistic_write_lock_guard unlock_on_exit{*parent_lock};
 
       if (unlikely(!node_lock.try_upgrade_to_write_lock(version))) return {};
@@ -785,7 +785,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
       assert(node_is_full);
 
       if (!unlikely(parent_lock->try_upgrade_to_write_lock(parent_version)))
-        return {};
+        return {};  // LCOV_EXCL_LINE
       optimistic_write_lock_guard unlock_on_exit{*parent_lock};
 
       if (!unlikely(node_lock.try_upgrade_to_write_lock(version))) return {};
@@ -894,7 +894,7 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
     if (leaf::matches(node.leaf, k)) {
       if (unlikely(
               !root_pointer_lock.try_upgrade_to_write_lock(parent_version)))
-        return {};
+        return {};  // LCOV_EXCL_LINE
 
       optimistic_write_lock_guard unlock_on_exit{root_pointer_lock};
       if (unlikely(!node_lock->try_upgrade_to_write_lock(version))) return {};
@@ -975,7 +975,7 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
         optimistic_write_lock_guard unlock_on_exit{*node_lock};
 
         if (unlikely(!child_lock.try_upgrade_to_write_lock(child_version)))
-          return {};
+          return {};  // LCOV_EXCL_LINE
         child_lock.write_unlock_and_obsolete();
 
         node.internal->remove(child_i, *this);
@@ -986,15 +986,17 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
       assert(is_node_min_size);
 
       if (unlikely(!parent_lock->try_upgrade_to_write_lock(parent_version)))
-        return {};
+        return {};  // LCOV_EXCL_LINE
       optimistic_write_lock_guard unlock_on_exit{*parent_lock};
 
       if (unlikely(!node_lock->try_upgrade_to_write_lock(version))) return {};
       unique_write_lock_obsoleting_guard obsolete_node_on_exit{*node_lock};
 
       if (unlikely(!child_lock.try_upgrade_to_write_lock(child_version))) {
+        // LCOV_EXCL_START
         obsolete_node_on_exit.abort();
         return {};
+        // LCOV_EXCL_STOP
       }
       unique_write_lock_obsoleting_guard obsolete_child_on_exit{child_lock};
 


### PR DESCRIPTION
- Introduce two new source files: art_common.cpp and art_internal.cpp for
  art_common.hpp and art_internal.hpp declarations respectively
- Introduce key dumping utility unodb::detail::dump_key(std::ostream &,
  unodb::key)
- Move dump_byte and dump_key from art_internal_impl.hpp to
  art_internal.hpp|cpp. At the same time convert dump_key to std::ostream
  &operator<<(std::ostream &, art_key)
- Make key dumpers print that they dump either a key, either a bin-comparable
  key, remove various "key: " prefixes from their callers
- Remove print_key from micro_benchmark_utils.hpp, use dump_key instead.
- Make db_test_utils.hpp:assert_result_eq use the key dumper, at the same time
  improve it and ASSERT_VALUE_FOR_KEY to use __FILE__ part of source location
  too. Previously it only used __LINE__ as it always was used from a single
  source file, which is no longer the case.