### PR TITLE
Remove RMW atomics from optimistic lock-protected write critical sect…

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -10,7 +10,7 @@
 #include <utility>
 
 #include "art_internal_impl.hpp"
-#include "not_atomic.hpp"
+#include "critical_section_unprotected.hpp"
 
 namespace {
 
@@ -24,7 +24,7 @@ struct inode_pool_getter {
 };
 
 using art_policy = unodb::detail::basic_art_policy<
-    unodb::db, unodb::not_atomic, unodb::detail::node_ptr,
+    unodb::db, unodb::critical_section_unprotected, unodb::detail::node_ptr,
     unodb::detail::basic_db_leaf_deleter, inode_pool_getter>;
 
 using inode_base = unodb::detail::basic_inode_impl<art_policy>;

--- a/art.hpp
+++ b/art.hpp
@@ -148,6 +148,11 @@ class db final {
     current_memory_use -= delta;
   }
 
+  constexpr void increment_leaf_count(std::size_t leaf_size) noexcept {
+    increase_memory_use(leaf_size);
+    ++leaf_count;
+  }
+
   constexpr void decrement_leaf_count(std::size_t leaf_size) noexcept {
     decrease_memory_use(leaf_size);
 
@@ -178,7 +183,8 @@ class db final {
   std::uint64_t key_prefix_splits{0};
 
   friend auto detail::make_db_leaf_ptr<detail::node_header, db>(detail::art_key,
-                                                         value_view, db &);
+                                                                value_view,
+                                                                db &);
 
   template <class, class>
   friend class detail::basic_db_leaf_deleter;

--- a/critical_section_unprotected.hpp
+++ b/critical_section_unprotected.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef NOT_ATOMIC_HPP_
-#define NOT_ATOMIC_HPP_
+#ifndef CRITICAL_SECTION_UNPROTECTED_HPP_
+#define CRITICAL_SECTION_UNPROTECTED_HPP_
 
 #include "global.hpp"
 
@@ -9,23 +9,25 @@
 
 namespace unodb {
 
-// A template wrapper providing access to T with std::atomic-like interface
-// (like relaxed_atomic<T>), which is not actually atomic. It enables having a
-// common templatized non-atomic and relaxed atomic implementation.
+// Provide access to T with critical_section_protected<T>-like interface, except
+// that loads and stores are direct instead of relaxed atomic. It enables having
+// a common templatized implementation of single-threaded and OLC node
+// algorithms.
 template <typename T>
-class not_atomic final {
+class critical_section_unprotected final {
  public:
-  constexpr not_atomic() noexcept = default;
+  constexpr critical_section_unprotected() noexcept = default;
   // cppcheck-suppress noExplicitConstructor
-  constexpr not_atomic(T value_) noexcept : value{value_} {}
-  constexpr not_atomic(const not_atomic<T> &) = default;
-  constexpr not_atomic(not_atomic<T> &&) = default;
+  constexpr critical_section_unprotected(T value_) noexcept : value{value_} {}
+  constexpr critical_section_unprotected(
+      const critical_section_unprotected<T> &) = default;
+  constexpr critical_section_unprotected(critical_section_unprotected<T> &&) =
+      default;
 
-  // Regular C++ assignment operators return ref to this, std::atomic returns
-  // the assigned value, we return nothing as we never chain assignments.
+  // Return nothing as we never chain assignments for now.
   constexpr void operator=(T new_value) noexcept { value = new_value; }
 
-  constexpr void operator=(not_atomic<T> new_value) noexcept {
+  constexpr void operator=(critical_section_unprotected<T> new_value) noexcept {
     value = new_value;
   }
 
@@ -57,4 +59,4 @@ class not_atomic final {
 
 }  // namespace unodb
 
-#endif  // NOT_ATOMIC_HPP_
+#endif  // CRITICAL_SECTION_UNPROTECTED_HPP_


### PR DESCRIPTION
…ions

Previously, OL-protected data used relaxed_atomic wrapper which was std::atomic
with std::memory_order_relaxed defaults. Which resulted in "++x" to an actual
atomic increment whereas load, non-atomic increment, store is fine. Making this
change meant that relaxed_atomic was no longer std::atomic with
std::memory_order_relaxed default. Thus, with RMW atomics removed, rename
relaxed_atomic to critical_section_protected, not_atomic to
critical_section_unprotected, and revert other relaxed_atomic uses to regular
std::atomic. At the same time rename AtomicPolicy template argument of
basic_art_policy to CriticalSectionPolicy, and its field atomic_policy to
critical_section_policy.

Perf changes roughly from 9% slowdown (parallel get large tree eight threads) to
32% speedup (parallel delete large tree four threads).