### PR TITLE
Tweak codecov.io configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+
+codecov:
+  require_to_ci_pass: false
+  notify:
+    wait_for_ci: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,6 +343,7 @@ jobs:
       - name: Upload coverage data
         uses: codecov/codecov-action@v1
         with:
+          flags: ${{matrix.BUILD_TYPE}}
           fail_ci_if_error: true
           directory: ${{github.workspace}}/build
           functionalities: gcov


### PR DESCRIPTION
- Require coverage to increase at PRs
- Show coverage before CI completes, and regardless if it fails
- Separate Debug and Release configuration coverage