### PR TITLE
Update Google Test to HEAD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,21 +351,19 @@ else()
       "-readability-magic-numbers")
     set(DO_CLANG_TIDY_COMMON "${CLANG_TIDY_EXE}" "-p=${CMAKE_BINARY_DIR}"
       "-warnings-as-errors=*")
-    set(DO_CLANG_TIDY ${DO_CLANG_TIDY_COMMON} "-checks=*,${CLANG_TIDY_DISABLED}")
+    set(DO_CLANG_TIDY ${DO_CLANG_TIDY_COMMON}
+      "-checks=*,${CLANG_TIDY_DISABLED}")
+    # Google Test forces to disable the following
     string(CONCAT CLANG_TIDY_DISABLED_FOR_TESTS
       "${CLANG_TIDY_DISABLED},"
-      "-build-include-order,"
       "-cert-err58-cpp,"
       "-cppcoreguidelines-avoid-goto,"
-      "-cppcoreguidelines-avoid-non-const-global-variables," # TEST() macros
+      "-cppcoreguidelines-avoid-non-const-global-variables,"
       "-cppcoreguidelines-owning-memory,"
-      "-cppcoreguidelines-pro-type-vararg," # GTest uses varargs
       "-cppcoreguidelines-special-member-functions,"
       "-fuchsia-statically-constructed-objects,"
-      "-google-runtime-references,"
       "-hicpp-avoid-goto,"
-      "-hicpp-special-member-functions,"
-      "-hicpp-vararg") # GTest uses varargs
+      "-hicpp-special-member-functions")
     set(DO_CLANG_TIDY_TEST ${DO_CLANG_TIDY_COMMON}
       "-checks=*,${CLANG_TIDY_DISABLED_FOR_TESTS}")
     string(CONCAT CLANG_TIDY_DISABLED_FOR_DEEPSTATE

--- a/gtest_utils.hpp
+++ b/gtest_utils.hpp
@@ -13,9 +13,9 @@
 // TYPED_TEST_CASE(ARTCorrectnessTest, ARTTypes);
 //                                             ^
 // is not a bug: https://github.com/google/googletest/issues/2271
-#define UNODB_TYPED_TEST_CASE(Suite, Types)                    \
+#define UNODB_TYPED_TEST_SUITE(Suite, Types)                   \
   DISABLE_CLANG_WARNING("-Wgnu-zero-variadic-macro-arguments") \
-  TYPED_TEST_CASE(Suite, Types);                               \
+  TYPED_TEST_SUITE(Suite, Types);                              \
   RESTORE_CLANG_WARNINGS()
 
 // Because Google thinks

--- a/test_art.cpp
+++ b/test_art.cpp
@@ -25,7 +25,7 @@ class ARTCorrectnessTest : public ::testing::Test {
 
 using ARTTypes = ::testing::Types<unodb::db, unodb::mutex_db, unodb::olc_db>;
 
-UNODB_TYPED_TEST_CASE(ARTCorrectnessTest, ARTTypes)
+UNODB_TYPED_TEST_SUITE(ARTCorrectnessTest, ARTTypes)
 
 UNODB_START_TYPED_TESTS()
 

--- a/test_art_concurrency.cpp
+++ b/test_art_concurrency.cpp
@@ -123,7 +123,7 @@ class ARTConcurrencyTest : public ::testing::Test {
 
 using ConcurrentARTTypes = ::testing::Types<unodb::mutex_db, unodb::olc_db>;
 
-UNODB_TYPED_TEST_CASE(ARTConcurrencyTest, ConcurrentARTTypes)
+UNODB_TYPED_TEST_SUITE(ARTConcurrencyTest, ConcurrentARTTypes)
 
 UNODB_START_TYPED_TESTS()
 


### PR DESCRIPTION
This should get rid of a CMake warning in
1.10 (https://github.com/google/googletest/issues/3040), and the project YOLOs
with "Live at Head" anyway.