### PR TITLE
Move clang-tidy configuration to .clang-tidy files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,14 @@
+# The following are disabled because:
+# -clang-analyzer-cplusplus.Move: moved-from object states are asserted
+# -cppcoreguidelines-avoid-c-arrays: duplicated by modernize-avoid-c-arrays
+# -cppcoreguidelines-macro-usage: does not respect __LINE__ in macro definition
+# -cppcoreguidelines-pro-bounds-pointer-arithmetic: because leaf nodes are
+#   std::byte arrays
+# -cppcoreguidelines-pro-type-const-cast: because VALGRIND_MALLOCLIKE_BLOCK
+#   expands a to C-style cast, and we have -Wold-style-cast anyway
+# -hicpp-avoid-c-arrays: duplicated by modernize-avoid-c-arrays
+# -hicpp-no-assembler: Valgrind client requests
+# -modernize-use-equals-default: until foo() noexcept = default is accepted by
+#   clang
+Checks: '*,-bugprone-use-after-move,-clang-diagnostic-error,-clang-analyzer-cplusplus.Move,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-cppcoreguidelines-macro-usage,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-union-access,-fuchsia-default-arguments,-fuchsia-default-arguments-calls,-fuchsia-overloaded-operator,-google-readability-braces-around-statements,-google-runtime-references,-hicpp-avoid-c-arrays,-hicpp-braces-around-statements,-hicpp-invalid-access-moved,-hicpp-member-init,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-no-assembler,-hicpp-use-equals-default,-llvm-include-order,-llvmlibc*,-misc-no-recursion,-misc-non-private-member-variables-in-classes,-modernize-use-equals-default,-modernize-use-trailing-return-type,-portability-simd-intrinsics,-readability-braces-around-statements,-readability-named-parameter,-readability-magic-numbers'
+WarningsAsErrors: '*'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,56 +258,7 @@ else()
     message(STATUS "clang-tidy not found")
   else()
     message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-    string(CONCAT CLANG_TIDY_DISABLED
-      "-bugprone-use-after-move,"
-      "-clang-diagnostic-error,"
-      # Moved-from object states are asserted
-      "-clang-analyzer-cplusplus.Move,"
-      # Duplicated by modernize-avoid-c-arrays
-      "-cppcoreguidelines-avoid-c-arrays,"
-      "-cppcoreguidelines-avoid-magic-numbers,"
-      "-cppcoreguidelines-init-variables,"
-      "-cppcoreguidelines-macro-usage," # Until it respects __LINE__ in macro definition
-      "-cppcoreguidelines-non-private-member-variables-in-classes,"
-      "-cppcoreguidelines-pro-bounds-array-to-pointer-decay,"
-      "-cppcoreguidelines-pro-bounds-constant-array-index,"
-      # Because leaf nodes are std::byte arrays
-      "-cppcoreguidelines-pro-bounds-pointer-arithmetic,"
-      # Because VALGRIND_MALLOCLIKE_BLOCK expands to C-style cast, and we have
-      # -Wold-style-cast anyway
-      "-cppcoreguidelines-pro-type-const-cast,"
-      "-cppcoreguidelines-pro-type-cstyle-cast,"
-      "-cppcoreguidelines-pro-type-member-init,"
-      "-cppcoreguidelines-pro-type-reinterpret-cast,"
-      "-cppcoreguidelines-pro-type-static-cast-downcast,"
-      "-cppcoreguidelines-pro-type-union-access,"
-      "-fuchsia-default-arguments,"
-      "-fuchsia-default-arguments-calls,"
-      "-fuchsia-overloaded-operator,"
-      "-google-readability-braces-around-statements,"
-      "-google-runtime-references,"
-      # Duplicated by modernize-avoid-c-arrays
-      "-hicpp-avoid-c-arrays,"
-      "-hicpp-braces-around-statements,"
-      "-hicpp-invalid-access-moved,"
-      "-hicpp-member-init,"
-      "-hicpp-named-parameter,"
-      "-hicpp-no-array-decay,"
-      "-hicpp-no-assembler," # Valgrind client requests
-      "-hicpp-use-equals-default,"
-      "-llvm-include-order,"
-      "-llvmlibc*,"
-      "-misc-no-recursion,"
-      "-misc-non-private-member-variables-in-classes,"
-      "-modernize-use-equals-default," # Until foo() noexcept = default is accepted by clang
-      "-modernize-use-trailing-return-type,"
-      "-portability-simd-intrinsics,"
-      "-readability-braces-around-statements,"
-      "-readability-named-parameter,"
-      "-readability-magic-numbers")
-    set(DO_CLANG_TIDY_COMMON "${CLANG_TIDY_EXE}" "-p=${CMAKE_BINARY_DIR}"
-      "-warnings-as-errors=*")
-    set(DO_CLANG_TIDY ${DO_CLANG_TIDY_COMMON} "-checks=*,${CLANG_TIDY_DISABLED}")
+    set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-p=${CMAKE_BINARY_DIR}")
   endif()
 endif()
 

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,3 @@
+InheritParentConfig: true
+# Google Test forces to disable the following
+Checks: '-cert-err58-cpp,-cppcoreguidelines-avoid-goto,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-special-member-functions,-fuchsia-statically-constructed-objects,-hicpp-avoid-goto,-hicpp-special-member-functions'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,27 +47,14 @@ if(DEEPSTATE_HPP_PATH)
 endif()
 
 if(DO_CLANG_TIDY)
-  # Google Test forces to disable the following
-  string(CONCAT CLANG_TIDY_DISABLED_FOR_TESTS
-    "${CLANG_TIDY_DISABLED},"
-    "-cert-err58-cpp,"
-    "-cppcoreguidelines-avoid-goto,"
-    "-cppcoreguidelines-avoid-non-const-global-variables,"
-    "-cppcoreguidelines-owning-memory,"
-    "-cppcoreguidelines-special-member-functions,"
-    "-fuchsia-statically-constructed-objects,"
-    "-hicpp-avoid-goto,"
-    "-hicpp-special-member-functions,")
-  set(DO_CLANG_TIDY_TEST ${DO_CLANG_TIDY_COMMON}
-    "-checks=*,${CLANG_TIDY_DISABLED_FOR_TESTS}")
+  # TODO(laurynas): introduce subdir, move this to own .clang-tidy
   string(CONCAT CLANG_TIDY_DISABLED_FOR_DEEPSTATE
-    "${CLANG_TIDY_DISABLED},"
     "-cert-err58-cpp,"
     "-cppcoreguidelines-avoid-non-const-global-variables," # TEST() macros
     "-fuchsia-statically-constructed-objects,"
     "-readability-implicit-bool-conversion") # DeepState_Bool returning int
-  set(DO_CLANG_TIDY_DEEPSTATE ${DO_CLANG_TIDY_COMMON}
-    "-checks=*,${CLANG_TIDY_DISABLED_FOR_DEEPSTATE}")
+  set(DO_CLANG_TIDY_DEEPSTATE ${DO_CLANG_TIDY}
+    "-checks=${CLANG_TIDY_DISABLED_FOR_DEEPSTATE}")
 endif()
 
 function(ADD_COVERAGE_TARGET)
@@ -97,13 +84,13 @@ endfunction()
 add_library(db_test_utils STATIC db_test_utils.hpp db_test_utils.cpp)
 common_target_properties(db_test_utils)
 target_link_libraries(db_test_utils PRIVATE unodb gtest_main)
-set_clang_tidy_options(db_test_utils "${DO_CLANG_TIDY_TEST}")
+set_clang_tidy_options(db_test_utils "${DO_CLANG_TIDY}")
 
 # FIXME(laurynas): unduplicate
 add_library(qsbr_test_utils STATIC qsbr_test_utils.hpp qsbr_test_utils.cpp)
 common_target_properties(qsbr_test_utils)
 target_link_libraries(qsbr_test_utils PRIVATE unodb_qsbr gtest_main)
-set_clang_tidy_options(qsbr_test_utils "${DO_CLANG_TIDY_TEST}")
+set_clang_tidy_options(qsbr_test_utils "${DO_CLANG_TIDY}")
 
 # FIXME(laurynas): merge with add_db_test_target, pass which test utils libs
 # to link with
@@ -111,7 +98,7 @@ function(ADD_TEST_TARGET TARGET)
   add_executable("${TARGET}" "${TARGET}.cpp")
   common_target_properties("${TARGET}")
   target_link_libraries("${TARGET}" PRIVATE unodb_qsbr gtest_main)
-  set_clang_tidy_options("${TARGET}" "${DO_CLANG_TIDY_TEST}")
+  set_clang_tidy_options("${TARGET}" "${DO_CLANG_TIDY}")
   add_test(NAME "${TARGET}" COMMAND "${TARGET}")
   if(SANITIZE_ADDRESS OR SANITIZE_THREAD OR SANITIZE_UB)
     set_property(TEST ${TARGET} APPEND PROPERTY ENVIRONMENT "${SANITIZER_ENV}")


### PR DESCRIPTION
This reduces CMake files, and might enable online clang-tidy checking too later.