### PR TITLE
Use C++ attribute syntax instead of GNU compiler syntax

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -132,7 +132,7 @@ class db final {
   }
 
   // Debugging
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const;
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const;
 
  private:
   void delete_subtree(detail::node_ptr) noexcept;

--- a/art_common.cpp
+++ b/art_common.cpp
@@ -9,7 +9,7 @@
 
 namespace unodb::detail {
 
-__attribute__((cold, noinline)) void dump_key(std::ostream &os, unodb::key k) {
+[[gnu::cold, gnu::noinline]] void dump_key(std::ostream &os, unodb::key k) {
   os << "key: 0x" << std::hex << std::setfill('0') << std::setw(sizeof(k)) << k
      << std::dec;
 }

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -18,7 +18,7 @@ using key = std::uint64_t;
 
 namespace detail {
 
-__attribute__((cold, noinline)) void dump_key(std::ostream &os, key k);
+[[gnu::cold, gnu::noinline]] void dump_key(std::ostream &os, key k);
 
 }  // namespace detail
 

--- a/art_internal.cpp
+++ b/art_internal.cpp
@@ -10,14 +10,13 @@
 
 namespace unodb::detail {
 
-__attribute__((cold, noinline)) void dump_byte(std::ostream &os,
-                                               std::byte byte) {
+[[gnu::cold, gnu::noinline]] void dump_byte(std::ostream &os, std::byte byte) {
   os << ' ' << std::hex << std::setfill('0') << std::setw(2)
      << static_cast<unsigned>(byte) << std::dec;
 }
 
-__attribute__((cold, noinline)) std::ostream &operator<<(std::ostream &os,
-                                                         art_key key) {
+[[gnu::cold, gnu::noinline]] std::ostream &operator<<(std::ostream &os,
+                                                      art_key key) {
   os << "binary-comparable key:";
   for (std::size_t i = 0; i < sizeof(key); ++i) dump_byte(os, key[i]);
   return os;

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -59,7 +59,7 @@ struct basic_art_key final {
     return std::memcmp(&key, &key2.key, size);
   }
 
-  [[nodiscard]] __attribute__((pure)) constexpr auto operator[](
+  [[nodiscard, gnu::pure]] constexpr auto operator[](
       std::size_t index) const noexcept {
     assert(index < size);
     return (reinterpret_cast<const std::byte *>(&key))[index];
@@ -85,11 +85,10 @@ struct basic_art_key final {
 
 using art_key = basic_art_key<unodb::key>;
 
-__attribute__((cold, noinline)) void dump_byte(std::ostream &os,
-                                               std::byte byte);
+[[gnu::cold, gnu::noinline]] void dump_byte(std::ostream &os, std::byte byte);
 
-__attribute__((cold, noinline)) std::ostream &operator<<(std::ostream &os,
-                                                         art_key key);
+[[gnu::cold, gnu::noinline]] std::ostream &operator<<(std::ostream &os,
+                                                      art_key key);
 
 // This corresponds to the "single value leaf" type in the ART paper. Since we
 // have only one kind of leaf nodes, we call them simply "leaf" nodes. Should we
@@ -190,7 +189,7 @@ union basic_node_ptr {
   constexpr basic_node_ptr(inode256_type *node_256_) noexcept
       : node_256{node_256_} {}
 
-  [[nodiscard]] __attribute__((pure)) constexpr auto type() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto type() const noexcept {
     return header->type();
   }
 

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -45,11 +45,13 @@ inline constexpr auto to_counter(T value) {
 template <class Db, class Thread>
 class concurrent_benchmark {
  protected:
+  DISABLE_GCC_WARNING("-Wsuggest-final-methods")
   virtual void setup() {}
 
   virtual void end_workload_in_main_thread() {}
 
   virtual void teardown() {}
+  RESTORE_GCC_WARNINGS()
 
  public:
   virtual ~concurrent_benchmark() {}

--- a/global.hpp
+++ b/global.hpp
@@ -68,6 +68,8 @@
 #define unlikely(x) __builtin_expect(x, 0)
 
 #ifdef NDEBUG
+// Cannot do [[gnu::unused]], as that does not play well with structured
+// bindings when compiling with GCC.
 #define USED_IN_DEBUG __attribute__((unused))
 #else
 #define USED_IN_DEBUG
@@ -85,9 +87,9 @@
 // LCOV_EXCL_START
 namespace unodb::detail {
 
-inline __attribute__((noreturn)) void cannot_happen(
-    const char *file USED_IN_DEBUG, int line USED_IN_DEBUG,
-    const char *func USED_IN_DEBUG) {
+[[noreturn]] inline void cannot_happen(const char *file USED_IN_DEBUG,
+                                       int line USED_IN_DEBUG,
+                                       const char *func USED_IN_DEBUG) {
 #ifndef NDEBUG
   std::cerr << "Execution reached an unreachable point at " << file << ':'
             << line << ": " << func << '\n';

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -120,7 +120,7 @@ class mutex_db final {
   }
 
   // Debugging
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
     const std::lock_guard guard{mutex};
     db_.dump(os);
   }

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -237,7 +237,7 @@ class olc_inode_4 final : public basic_inode_4<olc_art_policy> {
     return basic_inode_4::leave_last_child(child_to_delete, db_instance);
   }
 
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
     os << ", ";
     lock(*this).dump(os);
     basic_inode_4::dump(os);
@@ -321,7 +321,7 @@ class olc_inode_16 final : public basic_inode_16<olc_art_policy> {
 #endif
   }
 
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
     os << ", ";
     lock(*this).dump(os);
     basic_inode_16::dump(os);
@@ -420,7 +420,7 @@ class olc_inode_48 final : public basic_inode_48<olc_art_policy> {
     basic_inode_48::remove(child_index, db_instance);
   }
 
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
     os << ", ";
     lock(*this).dump(os);
     basic_inode_48::dump(os);
@@ -507,7 +507,7 @@ class olc_inode_256 final : public basic_inode_256<olc_art_policy> {
     basic_inode_256::remove(child_index, db_instance);
   }
 
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
     os << ", ";
     lock(*this).dump(os);
     basic_inode_256::dump(os);

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -144,7 +144,7 @@ class olc_db final {
   }
 
   // Debugging
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const;
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const;
 
  private:
   // If get_result is not present, the search was interrupted. Yes, this

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -184,7 +184,7 @@ class optimistic_lock final {
   }
 #endif
 
-  __attribute__((cold, noinline)) void dump(std::ostream &os) const {
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
     const auto dump_version = version.load();
     os << "lock: version = 0x" << std::hex << std::setfill('0') << std::setw(8)
        << dump_version << std::dec;

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -17,7 +17,7 @@
 
 namespace {
 
-__attribute__((constructor)) void run_tls_ctor_in_main_thread() {
+[[gnu::constructor]] void run_tls_ctor_in_main_thread() {
   unodb::construct_current_thread_reclamator();
 }
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -133,7 +133,7 @@ class qsbr final {
 
   void reset() noexcept;
 
-  __attribute__((cold, noinline)) void dump(std::ostream &out) const;
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &out) const;
 
   [[nodiscard]] auto get_epoch_callback_count_max() const noexcept {
     // TODO(laurynas): std::max against current_interval_callbacks.size(), but


### PR DESCRIPTION
The majority of attributes are still GNU-specific ones, but a couple of
omissions were converted to C++ ones, increasing portability by an epsilon.