### PR TITLE
Enable Valgrind testing for test_qsbr

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,6 +185,7 @@ if(DEEPSTATE_LF_OK)
 endif()
 
 add_custom_target(valgrind
+  COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_qsbr;
   COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_art;
   COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_art_concurrency
-  DEPENDS test_art test_art_concurrency valgrind_benchmarks)
+  DEPENDS test_qsbr test_art test_art_concurrency valgrind_benchmarks)


### PR DESCRIPTION
Stop cheating with a monotonic counter "pointer" fake PMR resource and actually
forward requests to an underlying allocator.