### PR TITLE
Deepstate build and test fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,10 +397,15 @@ target_include_directories(unodb PUBLIC ".")
 target_include_directories(unodb SYSTEM PUBLIC "${GSL_INCLUDES}")
 set_clang_tidy_options(unodb "${DO_CLANG_TIDY}")
 
+set(VALGRIND_COMMAND "valgrind" "--error-exitcode=1" "--leak-check=full")
+
+add_custom_target(valgrind DEPENDS valgrind_tests valgrind_benchmarks)
+
 enable_testing()
 
 add_subdirectory(benchmark)
 if(TARGET deepstate)
   add_subdirectory(fuzz_deepstate)
+  add_dependencies(valgrind valgrind_deepstate)
 endif()
 add_subdirectory(test)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -38,22 +38,21 @@ add_custom_target(quick_benchmarks
   ./micro_benchmark_olc ${micro_benchmark_olc_quick_arg})
 
 add_custom_target(valgrind_benchmarks
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_node256 ${micro_benchmark_node256_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark ${micro_benchmark_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
-  COMMAND valgrind --error-exitcode=1 --leak-check=full
-  ./micro_benchmark_olc ${micro_benchmark_olc_quick_arg})
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_key_prefix
+  ${micro_benchmark_key_prefix_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node4
+  ${micro_benchmark_node4_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node16
+  ${micro_benchmark_node16_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node48
+  ${micro_benchmark_node48_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node256
+  ${micro_benchmark_node256_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark ${micro_benchmark_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_mutex
+  ${micro_benchmark_mutex_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_olc
+  ${micro_benchmark_olc_quick_arg})
 
 add_library(micro_benchmark_utils STATIC micro_benchmark_utils.cpp
   micro_benchmark_utils.hpp)

--- a/fuzz_deepstate/CMakeLists.txt
+++ b/fuzz_deepstate/CMakeLists.txt
@@ -32,26 +32,49 @@ function(COMMON_DEEPSTATE_TARGET_PROPERTIES TARGET)
     "${DEEPSTATE_INCLUDE_PATH}")
   target_link_libraries(${TARGET} PRIVATE unodb deepstate)
   set_clang_tidy_options(${TARGET} "${DO_CLANG_TIDY_DEEPSTATE}")
+  if(CMAKE_BUILD_TYPE MATCHES "Debug"
+      AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # Workaround https://github.com/trailofbits/deepstate/issues/375 -
+    # n file included from
+    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.hpp:20,
+    # from
+    # /home/travis/build/laurynas-biveinis/unodb/fuzz_deepstate/test_art_fuzz_deepstate.cpp:8:
+    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.h: In function ‘size_t deepstate::PickIndex(double*, size_t)’:
+    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.h:392:1: error: inlining failed in call to ‘always_inline’ ‘uint32_t DeepState_UIntInRange(uint32_t, uint32_t)’: function not considered for inlining
+    # 392 | DEEPSTATE_MAKE_SYMBOLIC_RANGE(UInt, uint32_t)
+    #      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.h:392:1: note: called from here
+    # 392 | DEEPSTATE_MAKE_SYMBOLIC_RANGE(UInt, uint32_t)
+    #      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    target_compile_options(${TARGET} PRIVATE "-O1")
+  endif()
 endfunction()
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/deepstate_fails)
+
 add_executable(test_art_fuzz_deepstate test_art_fuzz_deepstate.cpp)
-add_test(NAME test_art_fuzz_deepstate COMMAND test_art_fuzz_deepstate)
+add_test(NAME test_art_fuzz_deepstate
+  COMMAND test_art_fuzz_deepstate --fuzz --timeout 5 --output_test_dir
+  deepstate_fails)
 common_deepstate_target_properties(test_art_fuzz_deepstate)
 
+add_custom_target(deepstate_5s DEPENDS test_art_fuzz_deepstate)
+
 add_custom_target(deepstate_1m
-  ${CMAKE_COMMAND} -E make_directory deepstate_fails
   COMMAND test_art_fuzz_deepstate --fuzz --timeout 60 --output_test_dir
   deepstate_fails)
 
 add_custom_target(deepstate_20m
-  ${CMAKE_COMMAND} -E make_directory deepstate_fails
   COMMAND test_art_fuzz_deepstate --fuzz --timeout 1200 --output_test_dir
   deepstate_fails)
 
 add_custom_target(deepstate_8h
-  ${CMAKE_COMMAND} -E make_directory deepstate_fails
   COMMAND test_art_fuzz_deepstate --fuzz --timeout 28800 --output_test_dir
   deepstate_fails)
+
+add_custom_target(valgrind_deepstate
+  COMMAND ${VALGRIND_COMMAND} ./test_art_fuzz_deepstate --fuzz --timeout 60
+  --output_test_dir deepstate_fails)
 
 if(DEEPSTATE_LF_OK)
   add_executable(test_art_fuzz_deepstate_lf test_art_fuzz_deepstate.cpp)

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 Laurynas Biveinis
+// Copyright 2019-2021 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -77,6 +77,12 @@ void dump_tree(const unodb::db &tree) {
 // attribute 'noreturn' [-Wmissing-noreturn]
 // We consider this to be a TEST macro internal implementation detail
 DISABLE_CLANG_WARNING("-Wmissing-noreturn")
+
+// Cast for logging to std::uint64_t to workaround
+// https://github.com/trailofbits/deepstate/issues/138, but then
+// error: useless cast to type ‘uint64_t’ {aka ‘long unsigned int’}
+// [-Werror=useless-cast]
+DISABLE_GCC_WARNING("-Wuseless-cast")
 
 TEST(ART, DeepStateFuzz) {
   const auto limit_max_key = DeepState_Bool();
@@ -213,5 +219,7 @@ TEST(ART, DeepStateFuzz) {
   ASSERT(prev_mem_use == 0);
   ASSERT(test_db.empty());
 }
+
+RESTORE_GCC_WARNINGS()
 
 RESTORE_CLANG_WARNINGS()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,8 +64,8 @@ if(COVERAGE)
   add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)
 endif()
 
-add_custom_target(valgrind
-  COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_qsbr;
-  COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_art;
-  COMMAND valgrind --error-exitcode=1 --leak-check=full ./test_art_concurrency
-  DEPENDS test_qsbr test_art test_art_concurrency valgrind_benchmarks)
+add_custom_target(valgrind_tests
+  COMMAND ${VALGRIND_COMMAND} ./test_qsbr;
+  COMMAND ${VALGRIND_COMMAND} ./test_art;
+  COMMAND ${VALGRIND_COMMAND} ./test_art_concurrency
+  DEPENDS test_qsbr test_art test_art_concurrency)


### PR DESCRIPTION
- Add a 5 second deepstate fuzz test target, for quick local test runs
- Remove plain unseeded test_art_fuzz_deepstate from test targets, add
  "deepstate_5s" to its place instead;
- Move deepstate_fails dir create from test execution to configure time;
- Add Valgrind target for test_art_fuzz_deepstate, including it in common
  Valgrind target
- Add a GCC warning suppression to workaround the warning that comes from
  working around https://github.com/trailofbits/deepstate/issues/138
- Compile fuzzer with -O1 instead of -O0 in debug to workaround
  https://github.com/trailofbits/deepstate/issues/375
- Factor out VALGRIND_COMMAND in CMake, introduce top level valgrind target in
  place of test subdir valgrind target doing its job, rename the latter to
  valgrind_tests