### PR TITLE
QSBR: allow for paused thread to quit

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -2,3 +2,9 @@ If:
   PathMatch: .*\.hpp
 CompileFlags:
   Add: -Wno-unused-function
+---
+# -Wunused-member-function false positive:
+# https://github.com/clangd/clangd/issues/363
+CompileFlags:
+  Add: -Wno-unused-member-function
+

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -12,11 +12,17 @@ namespace unodb::test {
 
 void expect_idle_qsbr() {
   EXPECT_TRUE(unodb::qsbr::instance().single_thread_mode());
-  EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
   EXPECT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
   EXPECT_EQ(unodb::qsbr::instance().current_interval_size(), 0);
-  EXPECT_EQ(unodb::qsbr::instance().get_reserved_thread_capacity(), 1);
-  EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 1);
+  if (unodb::qsbr::instance().number_of_threads() == 0) {
+    EXPECT_EQ(unodb::qsbr::instance().get_reserved_thread_capacity(), 0);
+    EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 0);
+  } else if (unodb::qsbr::instance().number_of_threads() == 1) {
+    EXPECT_EQ(unodb::qsbr::instance().get_reserved_thread_capacity(), 1);
+    EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 1);
+  } else {
+    EXPECT_LE(unodb::qsbr::instance().number_of_threads(), 1);
+  }
 }
 
 }  // namespace unodb::test


### PR DESCRIPTION
- In unodb::test::expect_idle_qsbr, accept both zero- and one-thread
  configurations as valid for idle QSBR.
- Add qsbr_per_thread::is_paused getter, test it in existing tests. For the
  getter, renamed is_paused data member to paused, and enabled it for release
  builds too.
- Add a QSBR test SingleThreadQuitPaused that just pauses the main thread and
  stops.
- In QSBR test fixture constructor query whether the current (main) thread is
  paused, and resume it if needed.
- Add -Wno-unused-member-function to .clangd to workaround
  https://github.com/clangd/clangd/issues/363

This is a second fix from test_qsbr_fuzz_deepstate work in progress.