### PR TITLE
QSBR: don't pause in the per-thread destructor if the current thread …

### DIFF
--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -49,7 +49,9 @@ class qsbr_per_thread final {
  public:
   qsbr_per_thread() noexcept;
 
-  ~qsbr_per_thread() { pause(); }
+  ~qsbr_per_thread() {
+    if (!is_paused()) pause();
+  }
 
   void quiescent_state() noexcept;
 

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -134,6 +134,12 @@ TEST_F(QSBR, TwoThreads) {
   ASSERT_EQ(unodb::qsbr::instance().number_of_threads(), 1);
 }
 
+TEST_F(QSBR, TwoThreadsSecondQuitPaused) {
+  unodb::qsbr_thread second_thread(
+      [] { unodb::current_thread_reclamator().pause(); });
+  second_thread.join();
+}
+
 TEST_F(QSBR, TwoThreadsSecondPaused) {
   unodb::qsbr_thread second_thread([] {
     EXPECT_EQ(unodb::qsbr::instance().number_of_threads(), 2);


### PR DESCRIPTION
…is already paused

Add a testcase.

Another catch by fuzzer.