### PR TITLE
Introduce unodb_util CMake header-only library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,11 +376,13 @@ function(SET_CLANG_TIDY_OPTIONS TARGET COMMAND)
   endif()
 endfunction()
 
-add_library(unodb_qsbr qsbr.cpp qsbr.hpp heap.hpp global.hpp
-  debug_thread_sync.h)
+add_library(unodb_util INTERFACE global.hpp debug_thread_sync.hpp heap.hpp)
+
+add_library(unodb_qsbr qsbr.cpp qsbr.hpp)
 common_target_properties(unodb_qsbr)
 target_include_directories(unodb_qsbr PUBLIC ".")
 target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+target_link_libraries(unodb_qsbr PRIVATE unodb_util)
 target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
 if(DO_CLANG_TIDY)
   set_target_properties(unodb_qsbr PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
@@ -392,6 +394,7 @@ add_library(unodb art.cpp art.hpp art_common.cpp art_common.hpp mutex_art.hpp
   optimistic_lock.hpp art_internal_impl.hpp olc_art.hpp olc_art.cpp
   art_internal.cpp art_internal.hpp)
 common_target_properties(unodb)
+target_link_libraries(unodb PRIVATE unodb_util)
 target_link_libraries(unodb PUBLIC unodb_qsbr)
 target_include_directories(unodb PUBLIC ".")
 target_include_directories(unodb SYSTEM PUBLIC "${GSL_INCLUDES}")

--- a/debug_thread_sync.hpp
+++ b/debug_thread_sync.hpp
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 Laurynas Biveinis
-#ifndef UNODB_DEBUG_THREAD_SYNC_H_
-#define UNODB_DEBUG_THREAD_SYNC_H_
+#ifndef UNODB_DEBUG_THREAD_SYNC_HPP_
+#define UNODB_DEBUG_THREAD_SYNC_HPP_
 
 #include "global.hpp"
 
@@ -44,4 +44,4 @@ class thread_wait final {
 
 }  // namespace unodb::debug
 
-#endif  // UNODB_DEBUG_THREAD_SYNC_H_
+#endif  // UNODB_DEBUG_THREAD_SYNC_HPP_

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -10,7 +10,7 @@
 
 #include <deepstate/DeepState.hpp>
 
-#include "debug_thread_sync.h"
+#include "debug_thread_sync.hpp"
 #include "deepstate_utils.hpp"
 #include "heap.hpp"
 #include "qsbr.hpp"

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -23,7 +23,7 @@
 #include <boost/accumulators/statistics/variance.hpp>
 
 #ifndef NDEBUG
-#include "debug_thread_sync.h"
+#include "debug_thread_sync.hpp"
 #endif
 #include "heap.hpp"
 

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>  // IWYU pragma: keep
 
-#include "debug_thread_sync.h"
+#include "debug_thread_sync.hpp"
 #include "heap.hpp"
 #include "qsbr.hpp"
 #include "qsbr_test_utils.hpp"


### PR DESCRIPTION
At the same time rename debug_thread_sync.h to debug_thread_sync.hpp as it
should have been named at first.