### PR TITLE
Move one gtest death test from QSBR to QSBRDeathTest suite

### DIFF
--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -115,6 +115,8 @@ class QSBR : public ::testing::Test {
   std::mutex mock_allocator_mutex;
 };
 
+using QSBRDeathTest = QSBR;
+
 void active_pointer_ops(void *raw_ptr) noexcept {
   unodb::qsbr_ptr<void> active_ptr{raw_ptr};
   unodb::qsbr_ptr<void> active_ptr2{active_ptr};
@@ -345,7 +347,7 @@ TEST_F(QSBR, ActivePointersBeforePause) {
 
 #ifndef NDEBUG
 
-TEST_F(QSBR, ActivePointersDuringQuiescentState) {
+TEST_F(QSBRDeathTest, ActivePointersDuringQuiescentState) {
   auto *ptr = mock_allocate();
   unodb::qsbr_ptr<void> active_ptr{ptr};
   UNODB_ASSERT_DEATH({ unodb::current_thread_reclamator().quiescent_state(); },


### PR DESCRIPTION
The test runner treats suites ending in DeathTest specially to avoid
multithreading issues. This fixes

Warning: NG] /home/runner/work/unodb/unodb/3rd_party/googletest/googletest/src/gtest-death-test.cc:1121:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 2 threads. See https://github.com/google/googletest/blob/master/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times out.
4: [       OK ] QSBR.ActivePointersDuringQuiescentState (343 ms)