### PR TITLE
Fix locking and lifetime for unodb::mutex_db query results

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -79,7 +79,7 @@ namespace unodb {
 
 db::~db() noexcept { delete_root_subtree(); }
 
-get_result db::get(key search_key) const noexcept {
+db::get_result db::get(key search_key) const noexcept {
   if (unlikely(root.header == nullptr)) return {};
 
   auto node{root};

--- a/art.hpp
+++ b/art.hpp
@@ -47,11 +47,10 @@ auto make_db_leaf_ptr(art_key, value_view, Db &);
 
 }  // namespace detail
 
-// Search result type. If value is not present, it was not found
-using get_result = std::optional<value_view>;
-
 class db final {
  public:
+  using get_result = std::optional<value_view>;
+
   // Creation and destruction
   constexpr db() noexcept {}
 
@@ -133,6 +132,12 @@ class db final {
 
   [[nodiscard]] constexpr auto get_key_prefix_splits() const noexcept {
     return key_prefix_splits;
+  }
+
+  // Public utils
+  [[nodiscard]] static constexpr auto key_found(
+      const get_result &result) noexcept {
+    return static_cast<bool>(result);
   }
 
   // Debugging

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -159,15 +159,15 @@ void do_get_key(const Db &db, unodb::key k) {
 
 template <class Db>
 void do_get_existing_key(const Db &db, unodb::key k) {
-  const auto result = db.get(k);
+  auto result = db.get(k);
 
 #ifndef NDEBUG
-  if (!result) {
+  if (!Db::key_found(result)) {
     std::cerr << "Failed to get existing ";
     ::unodb::detail::dump_key(std::cerr, k);
     std::cerr << "\nTree:";
     db.dump(std::cerr);
-    assert(result);
+    assert(false);
   }
 #endif
   ::benchmark::DoNotOptimize(result);

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -561,7 +561,7 @@ olc_db::~olc_db() noexcept {
   delete_root_subtree();
 }
 
-qsbr_get_result olc_db::get(key search_key) const noexcept {
+olc_db::get_result olc_db::get(key search_key) const noexcept {
   try_get_result_type result;
   const detail::art_key bin_comparable_key{search_key};
   do {
@@ -585,7 +585,7 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
 
   if (unlikely(node.header == nullptr)) {
     if (unlikely(!parent_lock->try_read_unlock(parent_version))) return {};
-    return std::make_optional<qsbr_get_result>(std::nullopt);
+    return std::make_optional<get_result>(std::nullopt);
   }
 
   auto remaining_key{k};
@@ -608,7 +608,7 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
         return qsbr_ptr_span<const std::byte>{value};
       }
       if (unlikely(!node_lock.try_read_unlock(version))) return {};
-      return std::make_optional<qsbr_get_result>(std::nullopt);
+      return std::make_optional<get_result>(std::nullopt);
     }
 
     const auto key_prefix_length = node.internal->key_prefix_length();
@@ -617,7 +617,7 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
 
     if (shared_key_prefix_length < key_prefix_length) {
       if (unlikely(!node_lock.try_read_unlock(version))) return {};
-      return std::make_optional<qsbr_get_result>(std::nullopt);
+      return std::make_optional<get_result>(std::nullopt);
     }
 
     if (unlikely(!node_lock.check(version))) return {};
@@ -631,7 +631,7 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
 
     if (child_loc == nullptr) {
       if (unlikely(!node_lock.try_read_unlock(version))) return {};
-      return std::make_optional<qsbr_get_result>(std::nullopt);
+      return std::make_optional<get_result>(std::nullopt);
     }
 
     const auto child = child_loc->load();


### PR DESCRIPTION
The problem was the mutex_db::get returned views into values with lock released.
Fix by returning a pair of search result and locked mutex instead, which then is
released after inspecting the search result as required. This might be not the
best design but mutex_db exists only as a concurrency baseline anyway.

Introduce a helper key_found in all the ART classes that checks whether a key
was found in a given search result, and, in the case of mutex_db, releases the
mutex.

At the same time move all the get_result types into their corresponding ART
classes.