### PR TITLE
QSBR: do not deallocate previous interval requests on entering single…

### DIFF
--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -214,7 +214,11 @@ class qsbr final {
     // FIXME(laurynas): copy-paste-tweak with expect_idle_qsbr, but not clear
     // how to fix this
     assert(previous_interval_deallocation_requests.empty());
+    assert(previous_interval_total_dealloc_size.load(
+               std::memory_order_relaxed) == 0);
     assert(current_interval_deallocation_requests.empty());
+    assert(current_interval_total_dealloc_size.load(
+               std::memory_order_relaxed) == 0);
     if (threads.empty()) {
       assert(reserved_thread_capacity == 0);
       assert(threads_in_previous_epoch == 0);
@@ -290,13 +294,13 @@ class qsbr final {
       }
     }
 
+#ifndef NDEBUG
     // TODO(laurynas): get rid of this wart
     void update_single_thread_mode() noexcept {
-#ifndef NDEBUG
       dealloc_epoch_single_thread_mode =
           qsbr::instance().single_thread_mode_locked();
-#endif
     }
+#endif
 
    private:
 #ifndef NDEBUG
@@ -346,6 +350,7 @@ class qsbr final {
   std::size_t threads_in_previous_epoch{0};
 
 #ifndef NDEBUG
+  std::uint64_t single_threaded_mode_start_epoch{0};
   bool thread_count_changed_in_current_epoch{false};
   bool thread_count_changed_in_previous_epoch{false};
 #endif


### PR DESCRIPTION
…-threaded mode

This done-previously "optimization" is incorrect as the last live thread may
well have acquired live pointers from other threads before their deallocation.
Adjust testcases as needed.

At the same time tighten up QSBR invariant checker by saving the single thread
mode start epoch and checking that old requests do not stay around after one
more epoch.

This also pointed out a missed update of previous_interval_total_dealloc_size,
fix that too.

Another fuzzer catch, this time worth fuzzer's weight in gold.