### PR TITLE
Cleanup qsbr::reset_stats, formerly known as reset

### DIFF
--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -16,7 +16,7 @@ class concurrent_benchmark_olc final
  protected:
   void setup() override {
     unodb::qsbr::instance().assert_idle();
-    unodb::qsbr::instance().reset();
+    unodb::qsbr::instance().reset_stats();
   }
 
   void end_workload_in_main_thread() override {

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -108,15 +108,17 @@ void qsbr::unregister_thread(std::thread::id thread_id) {
   }
 }
 
-void qsbr::reset() noexcept {
+void qsbr::reset_stats() noexcept {
   std::lock_guard<std::mutex> guard{qsbr_mutex};
 
+  assert_idle();
   assert_invariants();
 
   deallocation_size_stats = {};
   epoch_callback_stats = {};
   quiescent_states_per_thread_between_epoch_change_stats = {};
-  current_epoch = 0;
+
+  assert_invariants();
 }
 
 void qsbr::dump(std::ostream &out) const {

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -149,7 +149,7 @@ class qsbr final {
 
   void unregister_thread(std::thread::id thread_id);
 
-  void reset() noexcept;
+  void reset_stats() noexcept;
 
   [[gnu::cold, gnu::noinline]] void dump(std::ostream &out) const;
 


### PR DESCRIPTION
- Rename qsbr::reset to qsbr::reset_stats to better reflect its purpose, stop
  resetting the epoch number there.
- Add a unit test for it.
- Add reset_stats support to the fuzzer.
- At the same time introduce main_thread_i and main_thread_id constants in the
  fuzzer, use them instead of zero where applicable.