### PR TITLE
Revive, finish, & cleanup DeepState libfuzzer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,22 +242,42 @@ add_subdirectory(3rd_party/benchmark)
 # https://github.com/trailofbits/deepstate/issues/374
 if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_SYSTEM_NAME}"
       STREQUAL "Darwin"))
+  # ThreadSanitizer is not compatible with libfuzzer and LLVM 11 linker crashes
+  # on libfuzzer release build
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT("${CMAKE_BUILD_TYPE}"
+        STREQUAL "Release") AND NOT(SANITIZE_THREAD))
+    set(LIBFUZZER_AVAILABLE TRUE)
+    set(BUILD_DEEPSTATE_LIBFUZZER "-DDEEPSTATE_LIBFUZZER=ON")
+  else()
+    set(LIBFUZZER_AVAILABLE FALSE)
+    set(BUILD_DEEPSTATE_LIBFUZZER "-DDEEPSTATE_LIBFUZZER=OFF")
+  endif()
+
   include(ExternalProject)
   ExternalProject_Add(3rd_party_deepstate
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rd_party/deepstate"
     BINARY_DIR "${CMAKE_BINARY_DIR}/3rd_party/deepstate"
     CMAKE_ARGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
     "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}" "-DCMAKE_C_FLAGS=-w"
-    "-DCMAKE_CXX_FLAGS=-w"
+    "-DCMAKE_CXX_FLAGS=-w" "${BUILD_DEEPSTATE_LIBFUZZER}"
     INSTALL_COMMAND "")
+  ExternalProject_Get_property(3rd_party_deepstate SOURCE_DIR)
+  ExternalProject_Get_property(3rd_party_deepstate BINARY_DIR)
 
   add_library(deepstate STATIC IMPORTED)
-
-  ExternalProject_Get_property(3rd_party_deepstate SOURCE_DIR)
+  add_dependencies(deepstate 3rd_party_deepstate)
   target_include_directories(deepstate INTERFACE "${SOURCE_DIR}/src/include/")
-  ExternalProject_Get_property(3rd_party_deepstate BINARY_DIR)
   set_target_properties(deepstate PROPERTIES IMPORTED_LOCATION
     "${BINARY_DIR}/libdeepstate.a")
+
+  if(LIBFUZZER_AVAILABLE)
+    add_library(deepstate_lf STATIC IMPORTED)
+    add_dependencies(deepstate_lf 3rd_party_deepstate)
+    target_include_directories(deepstate_lf INTERFACE
+      "${SOURCE_DIR}/src/include/")
+    set_target_properties(deepstate_lf PROPERTIES IMPORTED_LOCATION
+      "${BINARY_DIR}/libdeepstate_LF.a")
+  endif()
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
@@ -344,6 +364,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(GSL_INCLUDES "3rd_party/GSL/include")
 
 function(COMMON_TARGET_PROPERTIES TARGET)
+  cmake_parse_arguments(PARSE_ARGV 1 CTP "SKIP_CHECKS" "" "")
   target_compile_options(${TARGET} PRIVATE "${CXX_FLAGS}")
   target_compile_options(${TARGET} PRIVATE "${SANITIZER_CXX_FLAGS}")
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
@@ -355,17 +376,19 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   if(IPO_SUPPORTED)
     set_target_properties(${TARGET} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
   endif()
-  if(CPPCHECK_EXE)
-    set_target_properties(${TARGET} PROPERTIES CXX_CPPCHECK "${DO_CPPCHECK}")
-  endif()
-  if(CPPLINT_EXE)
-    set_target_properties(${TARGET} PROPERTIES CXX_CPPLINT "${CPPLINT_EXE}")
-  endif()
-  if(IWYU_EXE)
-    set_target_properties(${TARGET} PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "${DO_IWYU}")
-  endif()
-  if(STATIC_ANALYSIS)
-    target_compile_options(${TARGET} PRIVATE "-fanalyzer")
+  if(NOT CTP_SKIP_CHECKS)
+    if(CPPCHECK_EXE)
+      set_target_properties(${TARGET} PROPERTIES CXX_CPPCHECK "${DO_CPPCHECK}")
+    endif()
+    if(CPPLINT_EXE)
+      set_target_properties(${TARGET} PROPERTIES CXX_CPPLINT "${CPPLINT_EXE}")
+    endif()
+    if(IWYU_EXE)
+      set_target_properties(${TARGET} PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "${DO_IWYU}")
+    endif()
+    if(STATIC_ANALYSIS)
+      target_compile_options(${TARGET} PRIVATE "-fanalyzer")
+    endif()
   endif()
 endfunction()
 
@@ -383,26 +406,40 @@ target_sources(unodb_util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/global.hpp
 target_include_directories(unodb_util INTERFACE ".")
 target_include_directories(unodb_util INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
-add_library(unodb_qsbr qsbr.cpp qsbr.hpp qsbr_ptr.cpp qsbr_ptr.hpp)
-common_target_properties(unodb_qsbr)
-target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
-target_link_libraries(unodb_qsbr PUBLIC unodb_util)
-target_include_directories(unodb_qsbr SYSTEM PUBLIC "${GSL_INCLUDES}")
-target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
-if(DO_CLANG_TIDY)
-  set_target_properties(unodb_qsbr PROPERTIES CXX_CLANG_TIDY "${DO_CLANG_TIDY}")
-endif()
-target_link_libraries(unodb_qsbr PUBLIC Threads::Threads)
-set_clang_tidy_options(unodb_qsbr "${DO_CLANG_TIDY}")
+function(ADD_UNODB_LIBRARY LIB)
+  add_library(${LIB} ${ARGN})
+  common_target_properties(${LIB})
+  target_link_libraries(${LIB} PUBLIC unodb_util)
+  target_include_directories(${LIB} SYSTEM PUBLIC "${GSL_INCLUDES}")
+  set_clang_tidy_options(${LIB} "${DO_CLANG_TIDY}")
 
-add_library(unodb art.cpp art.hpp art_common.cpp art_common.hpp mutex_art.hpp
-  optimistic_lock.hpp art_internal_impl.hpp olc_art.hpp olc_art.cpp
-  art_internal.cpp art_internal.hpp)
-common_target_properties(unodb)
-target_link_libraries(unodb PUBLIC unodb_util)
+  if(LIBFUZZER_AVAILABLE)
+    set(LIB_LF "${LIB}_lf")
+    add_library(${LIB_LF} ${ARGN})
+    common_target_properties(${LIB_LF} SKIP_CHECKS)
+    target_link_libraries(${LIB_LF} PUBLIC unodb_util)
+    target_include_directories(${LIB_LF} SYSTEM PUBLIC "${GSL_INCLUDES}")
+    target_compile_options(${LIB_LF} PRIVATE "-fsanitize=fuzzer-no-link")
+  endif()
+endfunction()
+
+add_unodb_library(unodb_qsbr qsbr.cpp qsbr.hpp qsbr_ptr.cpp qsbr_ptr.hpp)
+target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
+target_link_libraries(unodb_qsbr PUBLIC Threads::Threads)
+if(LIBFUZZER_AVAILABLE)
+  target_include_directories(unodb_qsbr_lf SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+  target_link_libraries(unodb_qsbr_lf PRIVATE "${Boost_LIBRARIES}")
+  target_link_libraries(unodb_qsbr_lf PUBLIC Threads::Threads)
+endif()
+
+add_unodb_library(unodb art.cpp art.hpp art_common.cpp art_common.hpp
+  mutex_art.hpp optimistic_lock.hpp art_internal_impl.hpp olc_art.hpp
+  olc_art.cpp art_internal.cpp art_internal.hpp)
 target_link_libraries(unodb PUBLIC unodb_qsbr)
-target_include_directories(unodb SYSTEM PUBLIC "${GSL_INCLUDES}")
-set_clang_tidy_options(unodb "${DO_CLANG_TIDY}")
+if(LIBFUZZER_AVAILABLE)
+  target_link_libraries(unodb_lf PUBLIC unodb_qsbr_lf)
+endif()
 
 set(VALGRIND_COMMAND "valgrind" "--error-exitcode=1" "--leak-check=full"
   "--trace-children=yes")

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ The are three ART classes available:
 * (optional) cpplint
 * (optional) include-what-you-use
 * Google Test for tests, bundled as a git submodule.
-* [DeepState][deepstate] for fuzzing `unodb::db`, currently building with clang
-  only, bundled.
+* [DeepState][deepstate] for fuzzing tests, currently building with clang only,
+  bundled.
+* libfuzzer
 * (optional) Google Benchmark for microbenchmarks, bundled.
 
 ## Development
@@ -110,7 +111,8 @@ To enable AddressSanitizer and LeakSanitizers, add `-DSANITIZE_ADDRESS=ON` CMake
 option. It is incompatible with `-DSANITIZE_THREAD=ON`.
 
 To enable ThreadSanitizer, add `-DSANITIZE_THREAD=ON` CMake option. It is
-incompatible with `-DSANITIZE_ADDRESS=ON`
+incompatible with `-DSANITIZE_ADDRESS=ON`. It is also incompatible with
+libfuzzer, and will disable its support if specified.
 
 To enable UndefinedBehaviorSanitizer, add `-DSANITIZE_UB=ON` CMake option. It is
 compatible with both `-DSANITIZE_ADDRESS=ON` and `-DSANITIZE_THREAD=ON` options,
@@ -134,6 +136,25 @@ To generate coverage reports on tests, fuzzers excluded, using lcov, add
 Google Test and DeepState are used for testing. There will be no unit tests for
 each private implementation class. For DeepState, both LLVM libfuzzer and
 built-in fuzzer are supported.
+
+## Fuzzing
+
+There are fuzzer tests for `unodb::db` and QSBR components in the
+`fuzz_deepstate` subdirectory. The tests use DeepState with either brute force
+or libfuzzer-based backend. The former is always built, the latter is built if
+using non-XCode clang for build in debug configuration and ThreadSanitizer is
+not enabled.
+
+There are several Make targets for fuzzing. For time-based brute-force fuzzing
+of all components, use on of `deepstate_5s`, `deepstate_1m`, `deepstate_20m`,
+and `deepstate_8h`. Individual fuzzers can be used by inserting `art` or `qsbr`,
+i.e. `deepstate_qsbr_20m` or `deepstate_art_8h`. Running fuzzer under Valgrind
+is available through `valgrind_deepstate` for everything or
+`valgrind_{art|qsbr}_deepstate` for individual fuzzers.
+
+Fuzzers that use libfuzzer mirror the above by adding `_lf` before the time
+suffix, i.e. `deepstate_lf_8h`, `deepstate_qsbr_lf_20m`,
+`valgrind_deepstate_lf`, and so on.
 
 ## Literature
 

--- a/fuzz_deepstate/CMakeLists.txt
+++ b/fuzz_deepstate/CMakeLists.txt
@@ -2,36 +2,18 @@
 
 enable_testing()
 
-include(CheckCXXSourceCompiles)
-
-set(CMAKE_REQUIRED_FLAGS "-fsanitize=fuzzer")
-set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=fuzzer")
-check_cxx_source_compiles(
-  "#include <cstddef>
-     #include <cstdint>
-     extern \"C\" int LLVMFuzzerTestOneInput(const std::uint8_t *, std::size_t) {
-       return 0;
-     }" LIBFUZZER_OK)
-
-if(LIBFUZZER_OK)
-  find_library(DEEPSTATE_LF_LIB_PATH deepstate_LF)
-  if(NOT DEEPSTATE_LF_LIB_PATH)
-    message(STATUS "libfuzzer-enabled DeepState not found, not building its fuzz tests")
+function(COMMON_DEEPSTATE_TARGET_PROPERTIES TARGET WITH_LIBFUZZER)
+  # FIXME(laurynas): replace with cmake_parse_arguments
+  if(WITH_LIBFUZZER)
+    common_target_properties(${TARGET} SKIP_CHECKS)
+    target_link_libraries(${TARGET} PRIVATE deepstate_lf)
+    target_compile_options(${TARGET} PRIVATE "-fsanitize=fuzzer-no-link")
+    target_link_libraries(${TARGET} PRIVATE "-fsanitize=fuzzer")
   else()
-    message(STATUS "libfuzzer-enabled DeepState found in ${DEEPSTATE_LF_LIB_PATH}")
+    common_target_properties(${TARGET})
+    target_link_libraries(${TARGET} PRIVATE deepstate)
+    set_clang_tidy_options(${TARGET} "${DO_CLANG_TIDY_DEEPSTATE}")
   endif()
-endif()
-
-if(DEEPSTATE_LF_LIB_PATH)
-  set(DEEPSTATE_LF_OK TRUE)
-endif()
-
-function(COMMON_DEEPSTATE_TARGET_PROPERTIES TARGET)
-  common_target_properties(${TARGET})
-  target_include_directories(${TARGET} SYSTEM PRIVATE
-    "${DEEPSTATE_INCLUDE_PATH}")
-  target_link_libraries(${TARGET} PRIVATE unodb deepstate)
-  set_clang_tidy_options(${TARGET} "${DO_CLANG_TIDY_DEEPSTATE}")
   if(CMAKE_BUILD_TYPE STREQUAL "Debug"
       AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # Workaround https://github.com/trailofbits/deepstate/issues/375 -
@@ -51,8 +33,12 @@ function(COMMON_DEEPSTATE_TARGET_PROPERTIES TARGET)
 endfunction()
 
 set(DEEPSTATE_FAIL_DIR "deepstate_fails")
-set(DEEPSTATE_OPTIONS "--fuzz" "--output_test_dir" "${DEEPSTATE_FAIL_DIR}"
-  "--timeout")
+set(DEEPSTATE_OPTIONS "--fuzz" "--no_fork" "--output_test_dir"
+  "${DEEPSTATE_FAIL_DIR}" "--timeout")
+
+if(LIBFUZZER_AVAILABLE)
+  set(DEEPSTATE_LF_OPTIONS "-use_value_profile=1" "-detect_leaks=0")
+endif()
 
 function(ADD_FUZZ_DEEPSTATE_TARGET ID)
   set(TEST_NAME "test_${ID}_fuzz_deepstate")
@@ -63,7 +49,7 @@ function(ADD_FUZZ_DEEPSTATE_TARGET ID)
   set(VALGRIND_TARGET "valgrind_${ID}_deepstate")
 
   add_executable(${TEST_NAME} "${TEST_NAME}.cpp")
-  common_deepstate_target_properties(${TEST_NAME})
+  common_deepstate_target_properties(${TEST_NAME} FALSE)
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME} ${DEEPSTATE_OPTIONS} 5)
 
   add_custom_target(${TEST_5S} DEPENDS ${TEST_NAME})
@@ -80,6 +66,39 @@ function(ADD_FUZZ_DEEPSTATE_TARGET ID)
     ./${TEST_NAME} ${DEEPSTATE_OPTIONS} 60)
 
   add_dependencies(valgrind_deepstate ${VALGRIND_TARGET})
+
+  if(LIBFUZZER_AVAILABLE)
+    set(SOURCE_NAME "test_${ID}_fuzz_deepstate.cpp")
+    set(TEST_NAME "test_${ID}_fuzz_deepstate_lf")
+    set(CORPUS_DIR "deepstate_lf_corpus_${ID}")
+    set(INVOCATION ${TEST_NAME} ${CORPUS_DIR} ${DEEPSTATE_LF_OPTIONS})
+    set(TEST_5S "deepstate_lf_${ID}_5s")
+    set(TEST_1M "deepstate_lf_${ID}_1m")
+    set(TEST_20M "deepstate_lf_${ID}_20m")
+    set(TEST_8H "deepstate_lf_${ID}_8h")
+    set(VALGRIND_TARGET "valgrind_${ID}_deepstate_lf")
+
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${CORPUS_DIR})
+
+    add_executable(${TEST_NAME} "${SOURCE_NAME}")
+    common_deepstate_target_properties(${TEST_NAME} TRUE)
+    add_test(NAME ${TEST_NAME} COMMAND ${INVOCATION} "-max_total_time=5")
+
+    add_custom_target(${TEST_5S} DEPENDS ${TEST_NAME})
+    add_custom_target(${TEST_1M} COMMAND ${INVOCATION} "-max_total_time=60")
+    add_custom_target(${TEST_20M} COMMAND ${INVOCATION} "-max_total_time=1200")
+    add_custom_target(${TEST_8H} COMMAND ${INVOCATION} "-max_total_time=28800")
+
+    add_dependencies(deepstate_lf_5s ${TEST_5S})
+    add_dependencies(deepstate_lf_1m ${TEST_1M})
+    add_dependencies(deepstate_lf_20m ${TEST_20M})
+    add_dependencies(deepstate_lf_8h ${TEST_8H})
+
+    add_custom_target(${VALGRIND_TARGET} COMMAND ${VALGRIND_COMMAND}
+      ./${INVOCATION} 60)
+
+    add_dependencies(valgrind_deepstate_lf ${VALGRIND_TARGET})
+  endif()
 endfunction()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${DEEPSTATE_FAIL_DIR})
@@ -90,33 +109,23 @@ add_custom_target(deepstate_20m)
 add_custom_target(deepstate_8h)
 add_custom_target(valgrind_deepstate)
 
+if(LIBFUZZER_AVAILABLE)
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${DEEPSTATE_LF_CORPUS_DIR})
+  add_custom_target(deepstate_lf_5s)
+  add_custom_target(deepstate_lf_1m)
+  add_custom_target(deepstate_lf_20m)
+  add_custom_target(deepstate_lf_8h)
+  add_custom_target(valgrind_deepstate_lf)
+endif()
+
 add_fuzz_deepstate_target(art)
+target_link_libraries(test_art_fuzz_deepstate PRIVATE unodb)
+if(LIBFUZZER_AVAILABLE)
+  target_link_libraries(test_art_fuzz_deepstate_lf PRIVATE unodb_lf)
+endif()
+
 add_fuzz_deepstate_target(qsbr)
-
-if(DEEPSTATE_LF_OK)
-  add_executable(test_art_fuzz_deepstate_lf test_art_fuzz_deepstate.cpp)
-  add_test(NAME test_art_fuzz_deepstate_lf COMMAND test_art_fuzz_deepstate_lf -runs=1)
-  common_deepstate_target_properties(test_art_fuzz_deepstate_lf)
-  set_target_properties(test_art_fuzz_deepstate_lf PROPERTIES COMPILE_DEFINITIONS "LIBFUZZER")
-  target_compile_options(test_art_fuzz_deepstate_lf PRIVATE "-fsanitize=fuzzer")
-  target_link_libraries(test_art_fuzz_deepstate_lf PRIVATE "${DEEPSTATE_LF_LIB_PATH}")
-  target_link_libraries(test_art_fuzz_deepstate_lf PRIVATE "-fsanitize=fuzzer")
-
-  add_custom_target(deepstate_lf_1m
-    ${CMAKE_COMMAND} -E make_directory deepstate_lf_corpus
-    COMMAND env ${SANITIZER_ENV}
-    ./test_art_fuzz_deepstate_lf deepstate_lf_corpus/ -use_value_profile=1
-    -detect_leaks=0  -max_total_time=60)
-
-  add_custom_target(deepstate_lf_20m
-    ${CMAKE_COMMAND} -E make_directory deepstate_lf_corpus
-    COMMAND env ${SANITIZER_ENV}
-    ./test_art_fuzz_deepstate_lf deepstate_lf_corpus/ -use_value_profile=1
-    -detect_leaks=0  -max_total_time=1200)
-
-  add_custom_target(deepstate_lf_8h
-    ${CMAKE_COMMAND} -E make_directory deepstate_lf_corpus
-    COMMAND env ${SANITIZER_ENV}
-    ./test_art_fuzz_deepstate_lf deepstate_lf_corpus/ -use_value_profile=1
-    -detect_leaks=0  -max_total_time=28800)
+target_link_libraries(test_qsbr_fuzz_deepstate PRIVATE unodb_qsbr)
+if(LIBFUZZER_AVAILABLE)
+  target_link_libraries(test_qsbr_fuzz_deepstate_lf PRIVATE unodb_qsbr_lf)
 endif()


### PR DESCRIPTION
- Update DeepState submodule to latest master which has a fix for
  https://github.com/trailofbits/deepstate/issues/376 (libfuzzer build ignores
  DeepState command line args, leaving no way turn down output verbosity)
- Add --no_fork to brute force DeepState fuzzer invocations
- Add CMake support for building libfuzzer-enabled qsbr and art libraries
- Add a README.md section on fuzzing.