### PR TITLE
Update DeepState and remove workarounds for fixed bugs

### DIFF
--- a/fuzz_deepstate/CMakeLists.txt
+++ b/fuzz_deepstate/CMakeLists.txt
@@ -14,22 +14,6 @@ function(COMMON_DEEPSTATE_TARGET_PROPERTIES TARGET WITH_LIBFUZZER)
     target_link_libraries(${TARGET} PRIVATE deepstate)
     set_clang_tidy_options(${TARGET} "${DO_CLANG_TIDY_DEEPSTATE}")
   endif()
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug"
-      AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    # Workaround https://github.com/trailofbits/deepstate/issues/375 -
-    # In file included from
-    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.hpp:20,
-    # from
-    # /home/travis/build/laurynas-biveinis/unodb/fuzz_deepstate/test_art_fuzz_deepstate.cpp:8:
-    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.h: In function ‘size_t deepstate::PickIndex(double*, size_t)’:
-    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.h:392:1: error: inlining failed in call to ‘always_inline’ ‘uint32_t DeepState_UIntInRange(uint32_t, uint32_t)’: function not considered for inlining
-    # 392 | DEEPSTATE_MAKE_SYMBOLIC_RANGE(UInt, uint32_t)
-    #      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    # /home/travis/build/laurynas-biveinis/unodb/3rd_party/deepstate/src/include/deepstate/DeepState.h:392:1: note: called from here
-    # 392 | DEEPSTATE_MAKE_SYMBOLIC_RANGE(UInt, uint32_t)
-    #      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    target_compile_options(${TARGET} PRIVATE "-O1")
-  endif()
 endfunction()
 
 set(DEEPSTATE_FAIL_DIR "deepstate_fails")

--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -13,14 +13,8 @@
 #define UNODB_START_DEEPSTATE_TESTS() \
   DISABLE_CLANG_WARNING("-Wmissing-noreturn")
 
-// Cast for logging to std::uint64_t to workaround
-// https://github.com/trailofbits/deepstate/issues/138, but then
-// error: useless cast to type ‘uint64_t’ {aka ‘long unsigned int’}
-// [-Werror=useless-cast]
-DISABLE_GCC_WARNING("-Wuseless-cast")
-
-inline auto DeepState_SizeTInRange(std::size_t min, std::size_t max) {
-  return static_cast<std::size_t>(DeepState_UInt64InRange(min, max));
+inline std::size_t DeepState_SizeTInRange(std::size_t min, std::size_t max) {
+  return DeepState_UInt64InRange(min, max);
 }
 
 template <class T>

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -45,11 +45,10 @@ auto get_value(dynamic_value::size_type max_length, values_type &values) {
   const auto make_new_value = values.empty() || DeepState_Bool();
   ASSERT(max_length <= std::numeric_limits<std::uint32_t>::max());
   if (make_new_value) {
-    const auto new_value_len = static_cast<dynamic_value::size_type>(
-        DeepState_SizeTInRange(0, max_length));
+    const dynamic_value::size_type new_value_len =
+        DeepState_SizeTInRange(0, max_length);
     auto new_value = make_random_value(new_value_len);
-    LOG(TRACE) << "Making a new value of length "
-               << static_cast<std::uint64_t>(new_value_len);
+    LOG(TRACE) << "Making a new value of length " << new_value_len;
     const auto &inserted_value = values.emplace_back(std::move(new_value));
     return unodb::value_view{inserted_value};
   }
@@ -90,8 +89,7 @@ TEST(ART, DeepStateFuzz) {
           ? DeepState_UInt64InRange(0, std::numeric_limits<unodb::key>::max())
           : std::numeric_limits<unodb::key>::max();
   if (limit_max_key)
-    LOG(TRACE) << "Limiting maximum key value to "
-               << static_cast<std::uint64_t>(max_key_value);
+    LOG(TRACE) << "Limiting maximum key value to " << max_key_value;
   else
     LOG(TRACE) << "Not limiting maximum key value (" << max_key_value << ")";
 
@@ -143,9 +141,7 @@ TEST(ART, DeepStateFuzz) {
             ASSERT(mem_use_after == mem_use_before);
           }
           dump_tree(test_db);
-          LOG(TRACE) << "Current mem use: "
-                     << static_cast<std::uint64_t>(
-                            test_db.get_current_memory_use());
+          LOG(TRACE) << "Current mem use: " << test_db.get_current_memory_use();
         },
         // Query
         [&] {
@@ -195,9 +191,7 @@ TEST(ART, DeepStateFuzz) {
                 << "If delete failed, oracle delete must fail too";
           }
           dump_tree(test_db);
-          LOG(TRACE) << "Current mem use: "
-                     << static_cast<std::uint64_t>(
-                            test_db.get_current_memory_use());
+          LOG(TRACE) << "Current mem use: " << test_db.get_current_memory_use();
         });
   }
 
@@ -210,8 +204,7 @@ TEST(ART, DeepStateFuzz) {
     const auto db_remove_result = test_db.remove(key);
     ASSERT(db_remove_result);
     const auto current_mem_use = test_db.get_current_memory_use();
-    LOG(TRACE) << "Current mem use: "
-               << static_cast<std::uint64_t>(current_mem_use);
+    LOG(TRACE) << "Current mem use: " << current_mem_use;
     ASSERT(current_mem_use < prev_mem_use);
     prev_mem_use = current_mem_use;
   }

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -90,16 +90,12 @@ randomly_advanced_pos_and_iterator(T &container) {
   return std::make_pair(i, std::move(itr));
 }
 
-DISABLE_GCC_WARNING("-Wuseless-cast")
-
 auto choose_thread() { return DeepState_ContainerIndex(threads); }
 
 auto choose_non_main_thread() {
   ASSERT(threads.size() >= 2);
   return DeepState_SizeTInRange(1, threads.size() - 1);
 }
-
-RESTORE_GCC_WARNINGS()
 
 void resume_thread(std::size_t thread_i) {
   ASSERT(threads[thread_i].is_paused ==
@@ -180,20 +176,16 @@ void deallocate_pointer(std::size_t thread_i) {
   }
 
   auto [ptr_i, itr] = randomly_advanced_pos_and_iterator(allocated_pointers);
-  LOG(TRACE) << "Deallocating pointer index "
-             << static_cast<std::uint64_t>(ptr_i);
+  LOG(TRACE) << "Deallocating pointer index " << ptr_i;
   auto *const ptr{*itr};
   deallocate_pointer(ptr);
   allocated_pointers.erase(itr);
 }
 
-DISABLE_GCC_WARNING("-Wuseless-cast")
-
 void new_active_pointer_from_allocated_pointer(active_pointers &active_ptrs) {
   auto [allocated_ptr_i, allocated_ptr_itr] =
       randomly_advanced_pos_and_iterator(allocated_pointers);
-  LOG(TRACE) << "Taking allocated pointer "
-             << static_cast<std::uint64_t>(allocated_ptr_i);
+  LOG(TRACE) << "Taking allocated pointer " << allocated_ptr_i;
   ASSERT(**allocated_ptr_itr == object_mem);
   active_ptrs.emplace_back(*allocated_ptr_itr);
 }
@@ -201,8 +193,7 @@ void new_active_pointer_from_allocated_pointer(active_pointers &active_ptrs) {
 void new_copy_constructed_active_pointer(active_pointers &active_ptrs) {
   auto [active_ptr_i, active_ptr_itr] =
       randomly_advanced_pos_and_iterator(active_ptrs);
-  LOG(TRACE) << "Copy-constructing active pointer from "
-             << static_cast<std::uint64_t>(active_ptr_i);
+  LOG(TRACE) << "Copy-constructing active pointer from " << active_ptr_i;
   ASSERT(**active_ptr_itr == object_mem);
   active_ptrs.emplace_back(*active_ptr_itr);
 }
@@ -210,8 +201,7 @@ void new_copy_constructed_active_pointer(active_pointers &active_ptrs) {
 void new_move_constructed_active_pointer(active_pointers &active_ptrs) {
   auto [active_ptr_i, active_ptr_itr] =
       randomly_advanced_pos_and_iterator(active_ptrs);
-  LOG(TRACE) << "Move-constructing active pointer from "
-             << static_cast<std::uint64_t>(active_ptr_i);
+  LOG(TRACE) << "Move-constructing active pointer from " << active_ptr_i;
   ASSERT(**active_ptr_itr == object_mem);
   active_ptrs.emplace_back(std::move(*active_ptr_itr));
   active_ptrs.erase(active_ptrs.begin() + active_ptr_i);
@@ -222,9 +212,8 @@ void copy_assign_active_pointer(active_pointers &active_ptrs) {
       randomly_advanced_pos_and_iterator(active_ptrs);
   auto [dest_active_ptr_i, dest_active_ptr_itr] =
       randomly_advanced_pos_and_iterator(active_ptrs);
-  LOG(TRACE) << "Copy-assigning active pointer from "
-             << static_cast<std::uint64_t>(source_active_ptr_i) << " to "
-             << static_cast<std::uint64_t>(dest_active_ptr_i);
+  LOG(TRACE) << "Copy-assigning active pointer from " << source_active_ptr_i
+             << " to " << dest_active_ptr_i;
   ASSERT(**dest_active_ptr_itr == object_mem);
   ASSERT(**source_active_ptr_itr == object_mem);
   *dest_active_ptr_itr = *source_active_ptr_itr;
@@ -238,17 +227,15 @@ void move_assign_active_pointer(active_pointers &active_ptrs) {
   auto [dest_active_ptr_i, dest_active_ptr_itr] =
       randomly_advanced_pos_and_iterator(active_ptrs);
   if (source_active_ptr_i != dest_active_ptr_i) {
-    LOG(TRACE) << "Move-assigning active pointer from "
-               << static_cast<std::uint64_t>(source_active_ptr_i) << " to "
-               << static_cast<std::uint64_t>(dest_active_ptr_i);
+    LOG(TRACE) << "Move-assigning active pointer from " << source_active_ptr_i
+               << " to " << dest_active_ptr_i;
     ASSERT(**dest_active_ptr_itr == object_mem);
     ASSERT(**source_active_ptr_itr == object_mem);
     *dest_active_ptr_itr = std::move(*source_active_ptr_itr);
     ASSERT(**dest_active_ptr_itr == object_mem);
     active_ptrs.erase(source_active_ptr_itr);
   } else {
-    LOG(TRACE) << "Copy-self-assigning active pointer "
-               << static_cast<std::uint64_t>(source_active_ptr_i);
+    LOG(TRACE) << "Copy-self-assigning active pointer " << source_active_ptr_i;
     ASSERT(**dest_active_ptr_itr == object_mem);
     ASSERT(**source_active_ptr_itr == object_mem);
     *dest_active_ptr_itr = *source_active_ptr_itr;
@@ -256,8 +243,6 @@ void move_assign_active_pointer(active_pointers &active_ptrs) {
     ASSERT(**source_active_ptr_itr == object_mem);
   }
 }
-
-RESTORE_GCC_WARNINGS()
 
 void take_active_pointer(std::size_t thread_i) {
   ASSERT(threads[thread_i].is_paused ==
@@ -316,8 +301,6 @@ void take_active_pointer(std::size_t thread_i) {
   }
 }
 
-DISABLE_GCC_WARNING("-Wuseless-cast")
-
 void release_active_pointer(std::size_t thread_i) {
   ASSERT(threads[thread_i].is_paused ==
          unodb::current_thread_reclamator().is_paused());
@@ -338,8 +321,7 @@ void release_active_pointer(std::size_t thread_i) {
 
   auto [active_ptr_i, active_ptr_itr] =
       randomly_advanced_pos_and_iterator(active_ptrs);
-  LOG(TRACE) << "Releasing active pointer "
-             << static_cast<std::uint64_t>(active_ptr_i);
+  LOG(TRACE) << "Releasing active pointer " << active_ptr_i;
   active_ptrs.erase(active_ptr_itr);
 }
 
@@ -378,8 +360,7 @@ void do_op_in_thread(std::size_t thread_i, thread_operation op) {
 }
 
 void quit_thread(std::size_t thread_i) {
-  LOG(TRACE) << "Trying to quit thread "
-             << static_cast<std::uint64_t>(thread_i);
+  LOG(TRACE) << "Trying to quit thread " << thread_i;
   ASSERT(thread_i > main_thread_i);
 
   const auto thread_itr =
@@ -399,8 +380,7 @@ void quit_thread(std::size_t thread_i) {
   const auto thread_id{tinfo.id};
   ASSERT(thread_id > main_thread_id);
   ASSERT(thread_id < new_thread_id);
-  LOG(TRACE) << "Stopping the thread with ID "
-             << static_cast<std::uint64_t>(thread_id);
+  LOG(TRACE) << "Stopping the thread with ID " << thread_id;
   thread_op = thread_operation::QUIT_THREAD;
   thread_sync[thread_id].notify();
   tinfo.thread.join();
@@ -490,8 +470,7 @@ void do_or_dispatch_op(std::size_t thread_i, thread_operation op) {
   ASSERT(op != thread_operation::QUIT_THREAD);
   ASSERT(op != thread_operation::RESET_STATS);
 
-  LOG(TRACE) << "Next operation in thread "
-             << static_cast<std::uint64_t>(thread_i);
+  LOG(TRACE) << "Next operation in thread " << thread_i;
   if (thread_i == main_thread_i)
     do_op(thread_i, op);
   else
@@ -537,8 +516,7 @@ TEST(QSBR, DeepStateFuzz) {
             return;
           }
           const auto tid = new_thread_id++;
-          LOG(TRACE) << "Creating a new thread with ID "
-                     << static_cast<std::uint64_t>(tid);
+          LOG(TRACE) << "Creating a new thread with ID " << tid;
           threads.emplace_back(tid, test_thread, tid);
           thread_sync[main_thread_id].wait();
         },
@@ -603,7 +581,7 @@ TEST(QSBR, DeepStateFuzz) {
   }
 
   for (std::size_t i = 0; i < threads.size(); ++i) {
-    LOG(TRACE) << "Cleaning up thread " << static_cast<std::uint64_t>(i);
+    LOG(TRACE) << "Cleaning up thread " << i;
     if (threads[i].is_paused) {
       LOG(TRACE) << "Thread is stopped, resuming";
       ASSERT(threads[i].active_ptrs.empty());
@@ -611,8 +589,7 @@ TEST(QSBR, DeepStateFuzz) {
       continue;
     }
     while (!threads[i].active_ptrs.empty()) {
-      LOG(TRACE) << "Releasing active pointer in thread "
-                 << static_cast<std::uint64_t>(i);
+      LOG(TRACE) << "Releasing active pointer in thread " << i;
       do_or_dispatch_op(i, thread_operation::RELEASE_ACTIVE_POINTER);
     }
   }


### PR DESCRIPTION
Update Deepstate submodule to b0b42eb1d49f9e302dbc49e4b4effbe23568e5cd. This
enables removing workarounds for:
- https://github.com/trailofbits/deepstate/issues/375 (DeepState.hpp fails to
  compile with GCC -O0)
- https://github.com/trailofbits/deepstate/issues/138 (Logging longs doesn't
  compile on macOS)