### PR TITLE
Introduce custom deleters for inode unique_ptr

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -169,6 +169,11 @@ class db final {
     --leaf_count;
   }
 
+  inline constexpr void decrement_inode4_count() noexcept;
+  inline constexpr void decrement_inode16_count() noexcept;
+  inline constexpr void decrement_inode48_count() noexcept;
+  inline constexpr void decrement_inode256_count() noexcept;
+
   detail::node_ptr root{nullptr};
 
   std::size_t current_memory_use{0};
@@ -197,6 +202,9 @@ class db final {
 
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
+
+  template <class, class, class, class>
+  friend class detail::basic_db_inode_deleter;
 
   template <class>
   friend class detail::basic_inode_4;

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -139,6 +139,8 @@ class basic_db_leaf_deleter {
 
   void operator()(raw_leaf_ptr to_delete) const noexcept;
 
+  [[nodiscard]] Db &get_db() const noexcept { return db; }
+
  private:
   Db &db;
 };
@@ -157,6 +159,22 @@ struct basic_inode_def final {
   basic_inode_def() = delete;
 };
 
+template <class INode, class Header, class Db, class INodeDefs>
+class basic_db_inode_deleter {
+ public:
+  constexpr explicit basic_db_inode_deleter(Db &db_) noexcept : db{db_} {}
+
+  void operator()(INode *inode_ptr) const noexcept;
+
+  [[nodiscard]] Db &get_db() const noexcept { return db; }
+
+ private:
+  template <class T>
+  struct dependent_false : std::false_type {};
+
+  Db &db;
+};
+
 // A pointer to some kind of node. It can be accessed either as a node header,
 // to query the right node type, a leaf, or as one of the internal nodes. This
 // depends on all types being of standard layout and Header being at the same
@@ -165,6 +183,7 @@ struct basic_inode_def final {
 template <class Header, class INode, class INodeDefs>
 union basic_node_ptr {
   using header_type = Header;
+  using inode_defs = INodeDefs;
   using inode = INode;
   using inode4_type = typename INodeDefs::n4;
   using inode16_type = typename INodeDefs::n16;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -192,6 +192,11 @@ class olc_db final {
     assert(old_leaf_count > 0);
   }
 
+  inline void decrement_inode4_count() noexcept;
+  inline void decrement_inode16_count() noexcept;
+  inline void decrement_inode48_count() noexcept;
+  inline void decrement_inode256_count() noexcept;
+
   mutable optimistic_lock root_pointer_lock;
 
   critical_section_protected<detail::olc_node_ptr> root{nullptr};
@@ -231,6 +236,9 @@ class olc_db final {
 
   template <class, class>
   friend class detail::db_leaf_qsbr_deleter;
+
+  template <class, class, class, class>
+  friend class detail::basic_db_inode_deleter;
 
   template <class>
   friend class detail::basic_inode_4;


### PR DESCRIPTION
- New unique_ptr deleter class template basic_db_inode_deleter that deletes the
  node but also decrements the counters and memory usage.
- New db_defs class template, move almost everything from basic_art_policy
  there. Two class templates are needed to break the cycle with
  basic_reclaim_db_node_ptr_at_scope_exit. At the same time cleanup some things,
  i.e. replace inode_pool_getter_type type with get_inode_pool function.
- Introduce decement_inode{4|16|48|256}_count helpers in the db classes for the
  inode deleters to use.
- Change some class using declarations to pull down the declarations from parent
  classes.
- Remove db argument from some of the inode factory functions which already take
  a db unique_ptr and so already have it.
- Remove inode delete memory and node accounting on inode delete from db
  classes.