### PR TITLE
Move inode accounting on create to make_db_inode_unique_ptr

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -31,6 +31,9 @@ class basic_inode_48;  // IWYU pragma: keep
 template <class>
 class basic_inode_256;  // IWYU pragma: keep
 
+template <class, class, template <class, class> class>
+struct db_defs;
+
 class inode;
 
 class inode_4;
@@ -169,6 +172,11 @@ class db final {
     --leaf_count;
   }
 
+  inline constexpr void increment_inode4_count() noexcept;
+  inline constexpr void increment_inode16_count() noexcept;
+  inline constexpr void increment_inode48_count() noexcept;
+  inline constexpr void increment_inode256_count() noexcept;
+
   inline constexpr void decrement_inode4_count() noexcept;
   inline constexpr void decrement_inode16_count() noexcept;
   inline constexpr void decrement_inode48_count() noexcept;
@@ -202,6 +210,9 @@ class db final {
 
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
+
+  template <class, class, template <class, class> class>
+  friend struct detail::db_defs;
 
   template <class, class, class, class>
   friend class detail::basic_db_inode_deleter;

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -159,6 +159,9 @@ struct basic_inode_def final {
   basic_inode_def() = delete;
 };
 
+template <class T>
+struct dependent_false : std::false_type {};
+
 template <class INode, class Header, class Db, class INodeDefs>
 class basic_db_inode_deleter {
  public:
@@ -169,9 +172,6 @@ class basic_db_inode_deleter {
   [[nodiscard]] Db &get_db() const noexcept { return db; }
 
  private:
-  template <class T>
-  struct dependent_false : std::false_type {};
-
   Db &db;
 };
 

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -294,8 +294,23 @@ struct db_defs {
   template <class INode, class... Args>
   [[nodiscard]] static auto make_db_inode_unique_ptr(Db &db_instance,
                                                      Args &&...args) {
-    return db_inode_unique_ptr<INode>{new INode{std::forward<Args>(args)...},
+    db_inode_unique_ptr<INode> result{new INode{std::forward<Args>(args)...},
                                       db_inode_deleter<INode>(db_instance)};
+
+    if constexpr (std::is_same_v<INode, inode4_type>)
+      db_instance.increment_inode4_count();
+    else if constexpr (std::is_same_v<INode, inode16_type>)
+      db_instance.increment_inode16_count();
+    else if constexpr (std::is_same_v<INode, inode48_type>)
+      db_instance.increment_inode48_count();
+    else if constexpr (std::is_same_v<INode, inode256_type>)
+      db_instance.increment_inode256_count();
+    else
+      static_assert(
+          dependent_false<INode>::value,
+          "make_db_inode_unique_ptr instantiated with incorrect inode type");
+
+    return result;
   }
 
   template <class INode>

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -32,6 +32,9 @@ class basic_inode_48;  // IWYU pragma: keep
 template <class>
 class basic_inode_256;  // IWYU pragma: keep
 
+template <class, class, template <class, class> class>
+struct db_defs;
+
 struct olc_node_header;
 
 class olc_inode;
@@ -192,6 +195,11 @@ class olc_db final {
     assert(old_leaf_count > 0);
   }
 
+  inline void increment_inode4_count() noexcept;
+  inline void increment_inode16_count() noexcept;
+  inline void increment_inode48_count() noexcept;
+  inline void increment_inode256_count() noexcept;
+
   inline void decrement_inode4_count() noexcept;
   inline void decrement_inode16_count() noexcept;
   inline void decrement_inode48_count() noexcept;
@@ -236,6 +244,9 @@ class olc_db final {
 
   template <class, class>
   friend class detail::db_leaf_qsbr_deleter;
+
+  template <class, class, template <class, class> class>
+  friend struct detail::db_defs;
 
   template <class, class, class, class>
   friend class detail::basic_db_inode_deleter;


### PR DESCRIPTION
Add the needed helpers to the db classes.

Move dependent_false helper template from class basic_db_inode_deleter to top
level.