### PR TITLE
Get rid of basic_art_policy::reclaim_node_ptr_at_scope_exit

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -226,9 +226,7 @@ bool db::remove(key remove_key) {
 
   if (root.type() == detail::node_type::LEAF) {
     if (leaf::matches(root.leaf, k)) {
-      // FIXME(laurynas): why not same in node deleters?
-      const auto delete_root_leaf_on_scope_exit{
-          art_policy::make_db_reclaimable_leaf_ptr(root.leaf, *this)};
+      const auto r{art_policy::reclaim_leaf_on_scope_exit(root, *this)};
       root = nullptr;
       return true;
     }

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -864,8 +864,7 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
 
       node_lock->write_unlock_and_obsolete();
 
-      const auto reclaim_root_leaf_on_scope_exit{
-          olc_art_policy::make_db_reclaimable_leaf_ptr(node.leaf, *this)};
+      const auto r{olc_art_policy::reclaim_leaf_on_scope_exit(node, *this)};
       root = nullptr;
       return true;
     }


### PR DESCRIPTION
Observe that whenever a single node is deleted from an internal node, it is
always a leaf node, thus there is no need for polymorphic deletion in such case.
Refactor db_defs::make_db_reclaimable_leaf_ptr to reclaim_leaf_on_scope_exit,
use it everywhere where applicable. This also enables removing LeafReclamator
template argument from basic_reclaim_db_node_ptr_at_scope_exit template.