### PR TITLE
OLC: introduce immediate delete of inodes where needed

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -21,11 +21,17 @@ struct inode_pool_getter {
         unodb::detail::get_inode_pool_options<INode>()};
     return inode_pool;
   }
+
+  inode_pool_getter() = delete;
 };
+
+template <class INode>
+using db_inode_deleter = unodb::detail::basic_db_inode_deleter<
+    INode, unodb::db, unodb::detail::inode_defs, inode_pool_getter>;
 
 using art_policy = unodb::detail::basic_art_policy<
     unodb::db, unodb::critical_section_unprotected, unodb::detail::node_ptr,
-    unodb::detail::basic_db_leaf_deleter, inode_pool_getter>;
+    db_inode_deleter, unodb::detail::basic_db_leaf_deleter, inode_pool_getter>;
 
 using inode_base = unodb::detail::basic_inode_impl<art_policy>;
 

--- a/art.hpp
+++ b/art.hpp
@@ -31,7 +31,8 @@ class basic_inode_48;  // IWYU pragma: keep
 template <class>
 class basic_inode_256;  // IWYU pragma: keep
 
-template <class, class, template <class, class> class>
+template <class, class, template <class> class, template <class, class> class,
+          template <class> class>
 struct db_defs;
 
 class inode;
@@ -211,10 +212,11 @@ class db final {
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
 
-  template <class, class, template <class, class> class>
+  template <class, class, template <class> class, template <class, class> class,
+            template <class> class>
   friend struct detail::db_defs;
 
-  template <class, class, class>
+  template <class, class, class, template <class> class>
   friend class detail::basic_db_inode_deleter;
 
   template <class>

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -162,14 +162,18 @@ struct basic_inode_def final {
 template <class T>
 struct dependent_false : std::false_type {};
 
-template <class INode, class Db, class INodeDefs>
+template <class INode, class Db, class INodeDefs,
+          template <class> class INodePoolGetter>
 class basic_db_inode_deleter {
  public:
   constexpr explicit basic_db_inode_deleter(Db &db_) noexcept : db{db_} {}
 
-  void operator()(INode *inode_ptr) const noexcept;
+  void operator()(INode *inode_ptr) noexcept;
 
-  [[nodiscard]] Db &get_db() const noexcept { return db; }
+  [[nodiscard]] Db &get_db() noexcept { return db; }
+
+ protected:
+  void account_delete_in_db() noexcept;
 
  private:
   Db &db;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -32,7 +32,8 @@ class basic_inode_48;  // IWYU pragma: keep
 template <class>
 class basic_inode_256;  // IWYU pragma: keep
 
-template <class, class, template <class, class> class>
+template <class, class, template <class> class, template <class, class> class,
+          template <class> class>
 struct db_defs;
 
 struct olc_node_header;
@@ -48,6 +49,9 @@ using olc_inode_defs =
     basic_inode_def<olc_inode_4, olc_inode_16, olc_inode_48, olc_inode_256>;
 
 using olc_node_ptr = basic_node_ptr<olc_node_header, olc_inode, olc_inode_defs>;
+
+template <class>
+class db_inode_qsbr_deleter;
 
 template <class, class>
 class db_leaf_qsbr_deleter;  // IWYU pragma: keep
@@ -245,10 +249,14 @@ class olc_db final {
   template <class, class>
   friend class detail::db_leaf_qsbr_deleter;
 
-  template <class, class, template <class, class> class>
+  template <class>
+  friend class detail::db_inode_qsbr_deleter;
+
+  template <class, class, template <class> class, template <class, class> class,
+            template <class> class>
   friend struct detail::db_defs;
 
-  template <class, class, class>
+  template <class, class, class, template <class> class>
   friend class detail::basic_db_inode_deleter;
 
   template <class>


### PR DESCRIPTION
Previously, any deallocated OLC inodes would go through QSBR, even when that was
not needed: for just-created inodes and on whole tree tear down. Use immediate
delete in those cases now.

- Refactor basic_db_inode_deleter to take INodePoolGetter template argument and
  have a protected member function account_delete_in_db that updates db
  counters. In the call operator, replace delete with pmr_deallocate. This makes
  basic_db_inode_deleter to serve as a immediate deleter.
- Rename basic_reclaim_db_node_ptr_at_scope_exit to
  basic_delete_db_node_ptr_at_scope_exit to better reflect its
  purpose (hopefully before its not-premature demise).
- New function make_db_inode_reclaimable_ptr in olc_art.cpp, use it for inodes
  that have to be QSBR-deallocated.
- Remove operator delete from all inode classes except basic_inode_impl
- New class unodb::detail::db_inode_qsbr_deleter, remove qsbr_delete helper
  function.