### PR TITLE
Cleanup subtree deletion and the rest of basic_art_policy

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -35,9 +35,6 @@ using art_policy = unodb::detail::basic_art_policy<
 
 using inode_base = unodb::detail::basic_inode_impl<art_policy>;
 
-using delete_db_node_ptr_at_scope_exit =
-    art_policy::delete_db_node_ptr_at_scope_exit;
-
 }  // namespace
 
 namespace unodb::detail {
@@ -323,13 +320,8 @@ bool db::remove(key remove_key) {
   }
 }
 
-void db::delete_subtree(unodb::detail::node_ptr node) noexcept {
-  delete_db_node_ptr_at_scope_exit delete_on_scope_exit(node, *this);
-  delete_on_scope_exit.delete_subtree();
-}
-
 void db::delete_root_subtree() noexcept {
-  delete_subtree(root);
+  if (root != nullptr) art_policy::delete_subtree(root, *this);
 
   // It is possible to reset the counter to zero instead of decrementing it for
   // each leaf, but not sure the savings will be significant.

--- a/art.hpp
+++ b/art.hpp
@@ -31,9 +31,9 @@ class basic_inode_48;  // IWYU pragma: keep
 template <class>
 class basic_inode_256;  // IWYU pragma: keep
 
-template <class, class, template <class> class, template <class, class> class,
-          template <class> class>
-struct db_defs;
+template <class, template <class> class, class, template <class> class,
+          template <class, class> class, template <class> class>
+struct basic_art_policy;
 
 class inode;
 
@@ -148,8 +148,6 @@ class db final {
   [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const;
 
  private:
-  void delete_subtree(detail::node_ptr) noexcept;
-
   void delete_root_subtree() noexcept;
 
   constexpr void increase_memory_use(std::size_t delta) noexcept {
@@ -212,9 +210,9 @@ class db final {
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
 
-  template <class, class, template <class> class, template <class, class> class,
-            template <class> class>
-  friend struct detail::db_defs;
+  template <class, template <class> class, class, template <class> class,
+            template <class, class> class, template <class> class>
+  friend struct detail::basic_art_policy;
 
   template <class, class, class, template <class> class>
   friend class detail::basic_db_inode_deleter;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -32,9 +32,9 @@ class basic_inode_48;  // IWYU pragma: keep
 template <class>
 class basic_inode_256;  // IWYU pragma: keep
 
-template <class, class, template <class> class, template <class, class> class,
-          template <class> class>
-struct db_defs;
+template <class, template <class> class, class, template <class> class,
+          template <class, class> class, template <class> class>
+struct basic_art_policy;
 
 struct olc_node_header;
 
@@ -179,8 +179,6 @@ class olc_db final {
 
   [[nodiscard]] try_update_result_type try_remove(detail::art_key k);
 
-  void delete_subtree(detail::olc_node_ptr) noexcept;
-
   void delete_root_subtree() noexcept;
 
   void increase_memory_use(std::size_t delta);
@@ -252,9 +250,9 @@ class olc_db final {
   template <class>
   friend class detail::db_inode_qsbr_deleter;
 
-  template <class, class, template <class> class, template <class, class> class,
-            template <class> class>
-  friend struct detail::db_defs;
+  template <class, template <class> class, class, template <class> class,
+            template <class, class> class, template <class> class>
+  friend struct detail::basic_art_policy;
 
   template <class, class, class, template <class> class>
   friend class detail::basic_db_inode_deleter;


### PR DESCRIPTION
- Move basic_delete_db_node_ptr_at_scope_exit struct template to
  basic_art_policy, rename it to delete_db_node_ptr_at_scope_exit.

- Fix delete_db_node_ptr_at_scope exit to delete immediately leaf nodes instead
  of deferred-reclaiming them.

- Merge db_defs struct template into basic_art_policy

- Introduce basic_art_policy::delete_subtree method, merge
  delete_db_node_ptr_at_scope::delete_subtree to it. Remove redundant nullptr
  checks, introduce them in delete_root_subtree database methods.

- Make leaf_reclaimable_ptr type alias private to basic_art_policy.

- Remove flavor-specific delete_db_node_ptr_at_scope_exit type aliases and
  delete_subtree methods. Make database delete_root_subtree and inode
  delete_subtree methods call basic_art_policy::delete_subtree.