### PR TITLE
Do not check whether Node256 is full before adding to it

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -173,7 +173,7 @@ bool db::insert(key insert_key, value_view v) {
     if (child == nullptr) {
       auto leaf = art_policy::make_db_leaf_ptr(k, v, *this);
 
-      const auto node_is_full = node->internal->is_full();
+      const auto node_is_full = node->internal->is_full_for_add();
 
       if (likely(!node_is_full)) {
         node->internal->add(std::move(leaf), depth);

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -753,7 +753,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
 
       auto leaf{olc_art_policy::make_db_leaf_ptr(k, v, *this)};
 
-      const auto node_is_full = node.internal->is_full();
+      const auto node_is_full = node.internal->is_full_for_add();
 
       if (likely(!node_is_full)) {
         if (unlikely(!node_lock.try_upgrade_to_write_lock(version))) return {};


### PR DESCRIPTION
Node256 can never be full if it has to be added to, but it can be full at other
times. Thus, rename all the inode is_full methods to is_full_for_add, and
override it in basic_inode_256 to return a constant false.