### PR TITLE
Dispatch only once by node type on internal node add

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -173,14 +173,15 @@ bool db::insert(key insert_key, value_view v) {
     if (child == nullptr) {
       auto leaf = art_policy::make_db_leaf_ptr(k, v, *this);
 
-      const auto node_is_full = node->internal->is_full_for_add();
+      const auto node_is_full = !node->internal->add<bool>(leaf, depth);
 
       if (likely(!node_is_full)) {
-        node->internal->add(std::move(leaf), depth);
+        assert(leaf == nullptr);
         return true;
       }
 
       assert(node_is_full);
+      assert(leaf != nullptr);
 
       if (node_type == detail::node_type::I4) {
         auto current_node{


### PR DESCRIPTION
Previously, the internal node add path dispatched twice: once for
is_full_for_add call, then for add call. Avoid this by moving the node fullness
check into add, and making it return whether the add was successful or the node
was full.

To accommodate both regular and OLC ART, convert basic_inode_impl::add to a
template method taking arbitrary args and returning templatized return type,
because it is bool in regular ART and std::optional<bool> in OLC ART, with the
addition of "need to restart" state.

Split all the basic_inode_{4|16|48|256}::add methods into bool-returning add and
void-returning add_to_nonfull. The latter also takes node children count as an
argument, to save an atomic load.

Remove basic_node_impl::is_full_for_add.

For OLC, introduce helper function olc_add that takes care of locking between
node fullness check and add. Introduce basic_node_impl::get_children_count, to
be used in this helper.