### PR TITLE
Rename "node" to "n" in benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,20 +1,20 @@
 # Copyright 2020-2021 Laurynas Biveinis
 
 set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
-set(micro_benchmark_node4_quick_arg "--benchmark_filter='/16|/25|/100'")
-set(micro_benchmark_node16_quick_arg "--benchmark_filter='/64'")
-set(micro_benchmark_node48_quick_arg "--benchmark_filter='/8$|/128|/192'")
-set(micro_benchmark_node256_quick_arg "--benchmark_filter='/8|/128|/192'")
+set(micro_benchmark_n4_quick_arg "--benchmark_filter='/16|/25|/100'")
+set(micro_benchmark_n16_quick_arg "--benchmark_filter='/64'")
+set(micro_benchmark_n48_quick_arg "--benchmark_filter='/8$|/128|/192'")
+set(micro_benchmark_n256_quick_arg "--benchmark_filter='/8|/128|/192'")
 set(micro_benchmark_quick_arg "--benchmark_filter='.*/512$|.*/800/|.*/1000/'")
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter='/4/70000/'")
 set(micro_benchmark_olc_quick_arg "--benchmark_filter='/4/70000/'")
 
 add_custom_target(benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_key_prefix
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node4
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node16
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node48
-  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_node256
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_n4
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_n16
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_n48
+  COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_n256
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_mutex
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV} ./micro_benchmark_olc)
@@ -23,13 +23,13 @@ add_custom_target(quick_benchmarks
   env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark_key_prefix ${micro_benchmark_key_prefix_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node4 ${micro_benchmark_node4_quick_arg}
+  ./micro_benchmark_n4 ${micro_benchmark_n4_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node16 ${micro_benchmark_node16_quick_arg}
+  ./micro_benchmark_n16 ${micro_benchmark_n16_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node48 ${micro_benchmark_node48_quick_arg}
+  ./micro_benchmark_n48 ${micro_benchmark_n48_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
-  ./micro_benchmark_node256 ${micro_benchmark_node256_quick_arg}
+  ./micro_benchmark_n256 ${micro_benchmark_n256_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
   ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND env ${ASAN_ENV} ${UBSAN_ENV}
@@ -40,14 +40,14 @@ add_custom_target(quick_benchmarks
 add_custom_target(valgrind_benchmarks
   COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_key_prefix
   ${micro_benchmark_key_prefix_quick_arg}
-  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node4
-  ${micro_benchmark_node4_quick_arg}
-  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node16
-  ${micro_benchmark_node16_quick_arg}
-  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node48
-  ${micro_benchmark_node48_quick_arg}
-  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_node256
-  ${micro_benchmark_node256_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_n4
+  ${micro_benchmark_n4_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_n16
+  ${micro_benchmark_n16_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_n48
+  ${micro_benchmark_n48_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_n256
+  ${micro_benchmark_n256_quick_arg}
   COMMAND ${VALGRIND_COMMAND} ./micro_benchmark ${micro_benchmark_quick_arg}
   COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_mutex
   ${micro_benchmark_mutex_quick_arg}
@@ -84,10 +84,10 @@ function(ADD_CONCURRENT_BENCHMARK_TARGET TARGET)
 endfunction()
 
 add_benchmark_target(micro_benchmark_key_prefix)
-add_node_benchmark_target(micro_benchmark_node4)
-add_node_benchmark_target(micro_benchmark_node16)
-add_node_benchmark_target(micro_benchmark_node48)
-add_node_benchmark_target(micro_benchmark_node256)
+add_node_benchmark_target(micro_benchmark_n4)
+add_node_benchmark_target(micro_benchmark_n16)
+add_node_benchmark_target(micro_benchmark_n48)
+add_node_benchmark_target(micro_benchmark_n256)
 add_node_benchmark_target(micro_benchmark)
 add_concurrent_benchmark_target(micro_benchmark_mutex)
 add_concurrent_benchmark_target(micro_benchmark_olc)

--- a/benchmark/micro_benchmark_n16.cpp
+++ b/benchmark/micro_benchmark_n16.cpp
@@ -12,184 +12,184 @@
 namespace {
 
 template <class Db>
-void grow_node4_to_node16_sequentially(benchmark::State &state) {
+void grow_n4_to_n16_sequentially(benchmark::State &state) {
   unodb::benchmark::grow_node_sequentially_benchmark<Db, 4>(state);
 }
 
 template <class Db>
-void grow_node4_to_node16_randomly(benchmark::State &state) {
+void grow_n4_to_n16_randomly(benchmark::State &state) {
   unodb::benchmark::grow_node_randomly_benchmark<Db, 4>(state);
 }
 
 template <class Db>
-void node16_sequential_add(benchmark::State &state) {
+void n16_sequential_add(benchmark::State &state) {
   unodb::benchmark::sequential_add_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void node16_random_add(benchmark::State &state) {
+void n16_random_add(benchmark::State &state) {
   unodb::benchmark::random_add_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void minimal_node16_tree_full_scan(benchmark::State &state) {
+void minimal_n16_tree_full_scan(benchmark::State &state) {
   unodb::benchmark::minimal_tree_full_scan<Db, 16>(state);
 }
 
 template <class Db>
-void minimal_node16_tree_random_gets(benchmark::State &state) {
+void minimal_n16_tree_random_gets(benchmark::State &state) {
   unodb::benchmark::minimal_tree_random_gets<Db, 16>(state);
 }
 
 template <class Db>
-void full_node16_tree_full_scan(benchmark::State &state) {
+void full_n16_tree_full_scan(benchmark::State &state) {
   unodb::benchmark::full_node_scan_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void full_node16_tree_random_gets(benchmark::State &state) {
+void full_n16_tree_random_gets(benchmark::State &state) {
   unodb::benchmark::full_node_random_get_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void full_node16_tree_sequential_delete(benchmark::State &state) {
+void full_n16_tree_sequential_delete(benchmark::State &state) {
   unodb::benchmark::sequential_delete_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void full_node16_tree_random_delete(benchmark::State &state) {
+void full_n16_tree_random_delete(benchmark::State &state) {
   unodb::benchmark::random_delete_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void shrink_node48_to_node16_sequentially(benchmark::State &state) {
+void shrink_n48_to_n16_sequentially(benchmark::State &state) {
   unodb::benchmark::shrink_node_sequentially_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void shrink_node48_to_node16_randomly(benchmark::State &state) {
+void shrink_n48_to_n16_randomly(benchmark::State &state) {
   unodb::benchmark::shrink_node_randomly_benchmark<Db, 16>(state);
 }
 
 }  // namespace
 
-BENCHMARK_TEMPLATE(grow_node4_to_node16_sequentially, unodb::db)
+BENCHMARK_TEMPLATE(grow_n4_to_n16_sequentially, unodb::db)
     ->Range(20, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node4_to_node16_sequentially, unodb::mutex_db)
+BENCHMARK_TEMPLATE(grow_n4_to_n16_sequentially, unodb::mutex_db)
     ->Range(20, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node4_to_node16_sequentially, unodb::olc_db)
-    ->Range(20, 16383)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(grow_node4_to_node16_randomly, unodb::db)
-    ->Range(20, 16383)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node4_to_node16_randomly, unodb::mutex_db)
-    ->Range(20, 16383)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node4_to_node16_randomly, unodb::olc_db)
+BENCHMARK_TEMPLATE(grow_n4_to_n16_sequentially, unodb::olc_db)
     ->Range(20, 16383)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node16_sequential_add, unodb::db)
+BENCHMARK_TEMPLATE(grow_n4_to_n16_randomly, unodb::db)
+    ->Range(20, 16383)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(grow_n4_to_n16_randomly, unodb::mutex_db)
+    ->Range(20, 16383)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(grow_n4_to_n16_randomly, unodb::olc_db)
+    ->Range(20, 16383)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(n16_sequential_add, unodb::db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node16_sequential_add, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n16_sequential_add, unodb::mutex_db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node16_sequential_add, unodb::olc_db)
+BENCHMARK_TEMPLATE(n16_sequential_add, unodb::olc_db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node16_random_add, unodb::db)
+BENCHMARK_TEMPLATE(n16_random_add, unodb::db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node16_random_add, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n16_random_add, unodb::mutex_db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node16_random_add, unodb::olc_db)
-    ->Range(10, 16383)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(minimal_node16_tree_full_scan, unodb::db)
-    ->Range(10, 16383)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node16_tree_full_scan, unodb::mutex_db)
-    ->Range(10, 16383)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node16_tree_full_scan, unodb::olc_db)
+BENCHMARK_TEMPLATE(n16_random_add, unodb::olc_db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(minimal_node16_tree_random_gets, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n16_tree_full_scan, unodb::db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node16_tree_random_gets, unodb::mutex_db)
+BENCHMARK_TEMPLATE(minimal_n16_tree_full_scan, unodb::mutex_db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node16_tree_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(minimal_n16_tree_full_scan, unodb::olc_db)
     ->Range(10, 16383)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node16_tree_full_scan, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n16_tree_random_gets, unodb::db)
+    ->Range(10, 16383)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(minimal_n16_tree_random_gets, unodb::mutex_db)
+    ->Range(10, 16383)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(minimal_n16_tree_random_gets, unodb::olc_db)
+    ->Range(10, 16383)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(full_n16_tree_full_scan, unodb::db)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_full_scan, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n16_tree_full_scan, unodb::mutex_db)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_full_scan, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n16_tree_full_scan, unodb::olc_db)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node16_tree_random_gets, unodb::db)
+BENCHMARK_TEMPLATE(full_n16_tree_random_gets, unodb::db)
     ->Range(64, 24600)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_random_gets, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n16_tree_random_gets, unodb::mutex_db)
     ->Range(64, 24600)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n16_tree_random_gets, unodb::olc_db)
     ->Range(64, 24600)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node16_tree_sequential_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n16_tree_sequential_delete, unodb::db)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_sequential_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n16_tree_sequential_delete, unodb::mutex_db)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_sequential_delete, unodb::olc_db)
-    ->Range(64, 246000)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(full_node16_tree_random_delete, unodb::db)
-    ->Range(64, 246000)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_random_delete, unodb::mutex_db)
-    ->Range(64, 246000)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node16_tree_random_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n16_tree_sequential_delete, unodb::olc_db)
     ->Range(64, 246000)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(shrink_node48_to_node16_sequentially, unodb::db)
+BENCHMARK_TEMPLATE(full_n16_tree_random_delete, unodb::db)
+    ->Range(64, 246000)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(full_n16_tree_random_delete, unodb::mutex_db)
+    ->Range(64, 246000)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(full_n16_tree_random_delete, unodb::olc_db)
+    ->Range(64, 246000)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(shrink_n48_to_n16_sequentially, unodb::db)
     ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node48_to_node16_sequentially, unodb::mutex_db)
+BENCHMARK_TEMPLATE(shrink_n48_to_n16_sequentially, unodb::mutex_db)
     ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node48_to_node16_sequentially, unodb::olc_db)
+BENCHMARK_TEMPLATE(shrink_n48_to_n16_sequentially, unodb::olc_db)
     ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(shrink_node48_to_node16_randomly, unodb::db)
+BENCHMARK_TEMPLATE(shrink_n48_to_n16_randomly, unodb::db)
     ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node48_to_node16_randomly, unodb::mutex_db)
+BENCHMARK_TEMPLATE(shrink_n48_to_n16_randomly, unodb::mutex_db)
     ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node48_to_node16_randomly, unodb::olc_db)
+BENCHMARK_TEMPLATE(shrink_n48_to_n16_randomly, unodb::olc_db)
     ->Range(4, 16383)
     ->Unit(benchmark::kMicrosecond);
 

--- a/benchmark/micro_benchmark_n256.cpp
+++ b/benchmark/micro_benchmark_n256.cpp
@@ -12,154 +12,154 @@
 namespace {
 
 template <class Db>
-void grow_node48_to_node256_sequentially(benchmark::State &state) {
+void grow_n48_to_n256_sequentially(benchmark::State &state) {
   unodb::benchmark::grow_node_sequentially_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void grow_node48_to_node256_randomly(benchmark::State &state) {
+void grow_n48_to_n256_randomly(benchmark::State &state) {
   unodb::benchmark::grow_node_randomly_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void node256_sequential_add(benchmark::State &state) {
+void n256_sequential_add(benchmark::State &state) {
   unodb::benchmark::sequential_add_benchmark<Db, 256>(state);
 }
 
 template <class Db>
-void node256_random_add(benchmark::State &state) {
+void n256_random_add(benchmark::State &state) {
   unodb::benchmark::random_add_benchmark<Db, 256>(state);
 }
 
 template <class Db>
-void minimal_node256_tree_full_scan(benchmark::State &state) {
+void minimal_n256_tree_full_scan(benchmark::State &state) {
   unodb::benchmark::minimal_tree_full_scan<Db, 256>(state);
 }
 
 template <class Db>
-void minimal_node256_tree_random_gets(benchmark::State &state) {
+void minimal_n256_tree_random_gets(benchmark::State &state) {
   unodb::benchmark::minimal_tree_random_gets<Db, 256>(state);
 }
 
 template <class Db>
-void full_node256_tree_full_scan(benchmark::State &state) {
+void full_n256_tree_full_scan(benchmark::State &state) {
   unodb::benchmark::full_node_scan_benchmark<Db, 256>(state);
 }
 
 template <class Db>
-void full_node256_tree_random_gets(benchmark::State &state) {
+void full_n256_tree_random_gets(benchmark::State &state) {
   unodb::benchmark::full_node_random_get_benchmark<Db, 256>(state);
 }
 
 template <class Db>
-void full_node256_tree_sequential_delete(benchmark::State &state) {
+void full_n256_tree_sequential_delete(benchmark::State &state) {
   unodb::benchmark::sequential_delete_benchmark<Db, 256>(state);
 }
 
 template <class Db>
-void full_node256_tree_random_delete(benchmark::State &state) {
+void full_n256_tree_random_delete(benchmark::State &state) {
   unodb::benchmark::random_delete_benchmark<Db, 256>(state);
 }
 
 }  // namespace
 
-BENCHMARK_TEMPLATE(grow_node48_to_node256_sequentially, unodb::db)
+BENCHMARK_TEMPLATE(grow_n48_to_n256_sequentially, unodb::db)
     ->Range(2, 2048)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node48_to_node256_sequentially, unodb::mutex_db)
+BENCHMARK_TEMPLATE(grow_n48_to_n256_sequentially, unodb::mutex_db)
     ->Range(2, 2048)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node48_to_node256_sequentially, unodb::olc_db)
-    ->Range(2, 2048)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(grow_node48_to_node256_randomly, unodb::db)
-    ->Range(2, 2048)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node48_to_node256_randomly, unodb::mutex_db)
-    ->Range(2, 2048)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node48_to_node256_randomly, unodb::olc_db)
+BENCHMARK_TEMPLATE(grow_n48_to_n256_sequentially, unodb::olc_db)
     ->Range(2, 2048)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node256_sequential_add, unodb::db)
+BENCHMARK_TEMPLATE(grow_n48_to_n256_randomly, unodb::db)
+    ->Range(2, 2048)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(grow_n48_to_n256_randomly, unodb::mutex_db)
+    ->Range(2, 2048)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(grow_n48_to_n256_randomly, unodb::olc_db)
+    ->Range(2, 2048)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(n256_sequential_add, unodb::db)
     ->Range(1, 1024)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node256_sequential_add, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n256_sequential_add, unodb::mutex_db)
     ->Range(1, 1024)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node256_sequential_add, unodb::olc_db)
+BENCHMARK_TEMPLATE(n256_sequential_add, unodb::olc_db)
     ->Range(1, 1024)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node256_random_add, unodb::db)
+BENCHMARK_TEMPLATE(n256_random_add, unodb::db)
     ->Range(1, 1024)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node256_random_add, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n256_random_add, unodb::mutex_db)
     ->Range(1, 1024)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node256_random_add, unodb::olc_db)
+BENCHMARK_TEMPLATE(n256_random_add, unodb::olc_db)
     ->Range(1, 1024)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(minimal_node256_tree_full_scan, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n256_tree_full_scan, unodb::db)
     ->Range(4, 4096)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node256_tree_full_scan, unodb::mutex_db)
+BENCHMARK_TEMPLATE(minimal_n256_tree_full_scan, unodb::mutex_db)
     ->Range(4, 4096)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node256_tree_full_scan, unodb::olc_db)
-    ->Range(4, 4096)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(minimal_node256_tree_random_gets, unodb::db)
-    ->Range(4, 4096)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node256_tree_random_gets, unodb::mutex_db)
-    ->Range(4, 4096)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node256_tree_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(minimal_n256_tree_full_scan, unodb::olc_db)
     ->Range(4, 4096)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node256_tree_full_scan, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n256_tree_random_gets, unodb::db)
+    ->Range(4, 4096)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(minimal_n256_tree_random_gets, unodb::mutex_db)
+    ->Range(4, 4096)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(minimal_n256_tree_random_gets, unodb::olc_db)
+    ->Range(4, 4096)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(full_n256_tree_full_scan, unodb::db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_full_scan, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n256_tree_full_scan, unodb::mutex_db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_full_scan, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n256_tree_full_scan, unodb::olc_db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node256_tree_random_gets, unodb::db)
+BENCHMARK_TEMPLATE(full_n256_tree_random_gets, unodb::db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_random_gets, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n256_tree_random_gets, unodb::mutex_db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n256_tree_random_gets, unodb::olc_db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node256_tree_sequential_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n256_tree_sequential_delete, unodb::db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_sequential_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n256_tree_sequential_delete, unodb::mutex_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_sequential_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n256_tree_sequential_delete, unodb::olc_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node256_tree_random_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n256_tree_random_delete, unodb::db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_random_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n256_tree_random_delete, unodb::mutex_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node256_tree_random_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n256_tree_random_delete, unodb::olc_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
 

--- a/benchmark/micro_benchmark_n4.cpp
+++ b/benchmark/micro_benchmark_n4.cpp
@@ -74,12 +74,12 @@ void node4_sequential_insert(benchmark::State &state) {
 }
 
 template <class Db>
-void full_node4_sequential_insert(benchmark::State &state) {
+void full_n4_sequential_insert(benchmark::State &state) {
   node4_sequential_insert<Db, 4>(state);
 }
 
 template <class Db>
-void minimal_node4_sequential_insert(benchmark::State &state) {
+void minimal_n4_sequential_insert(benchmark::State &state) {
   node4_sequential_insert<Db, 2>(state);
 }
 
@@ -107,22 +107,22 @@ void node4_random_insert(benchmark::State &state) {
 }
 
 template <class Db>
-void full_node4_random_insert(benchmark::State &state) {
+void full_n4_random_insert(benchmark::State &state) {
   node4_random_insert<Db, 4>(state);
 }
 
 template <class Db>
-void minimal_node4_random_insert(benchmark::State &state) {
+void minimal_n4_random_insert(benchmark::State &state) {
   node4_random_insert<Db, 2>(state);
 }
 
 template <class Db>
-void node4_full_scan(benchmark::State &state) {
+void n4_full_scan(benchmark::State &state) {
   unodb::benchmark::full_node_scan_benchmark<Db, 4>(state);
 }
 
 template <class Db>
-void node4_random_gets(benchmark::State &state) {
+void n4_random_gets(benchmark::State &state) {
   unodb::benchmark::full_node_random_get_benchmark<Db, 4>(state);
 }
 
@@ -156,7 +156,7 @@ void node4_sequential_delete_benchmark(benchmark::State &state,
 }
 
 template <class Db>
-void full_node4_sequential_delete(benchmark::State &state) {
+void full_n4_sequential_delete(benchmark::State &state) {
   node4_sequential_delete_benchmark<Db, 4>(
       state, unodb::benchmark::node_size_to_key_zero_bits<4>());
 }
@@ -187,7 +187,7 @@ void node4_random_delete_benchmark(benchmark::State &state,
 }
 
 template <class Db>
-void full_node4_random_deletes(benchmark::State &state) {
+void full_n4_random_deletes(benchmark::State &state) {
   node4_random_delete_benchmark<Db, 4>(
       state, unodb::benchmark::node_size_to_key_zero_bits<4>());
 }
@@ -196,147 +196,147 @@ constexpr auto minimal_node4_tree_full_leaf_level_key_zero_bits =
     0xFCFCFCFC'FCFCFCFEULL;
 
 template <class Db>
-void full_node4_to_minimal_sequential_delete(benchmark::State &state) {
+void full_n4_to_minimal_sequential_delete(benchmark::State &state) {
   node4_sequential_delete_benchmark<Db, 4>(
       state, minimal_node4_tree_full_leaf_level_key_zero_bits);
 }
 
 template <class Db>
-void full_node4_to_minimal_random_delete(benchmark::State &state) {
+void full_n4_to_minimal_random_delete(benchmark::State &state) {
   node4_random_delete_benchmark<Db, 4>(
       state, minimal_node4_tree_full_leaf_level_key_zero_bits);
 }
 
 template <class Db>
-void shrink_node16_to_node4_sequentially(benchmark::State &state) {
+void shrink_node16_to_n4_sequentially(benchmark::State &state) {
   unodb::benchmark::shrink_node_sequentially_benchmark<Db, 4>(state);
 }
 
 template <class Db>
-void shrink_node16_to_node4_randomly(benchmark::State &state) {
+void shrink_node16_to_n4_randomly(benchmark::State &state) {
   unodb::benchmark::shrink_node_randomly_benchmark<Db, 4>(state);
 }
 
 }  // namespace
 
 // A maximum Node4-only tree can hold 65K values
-BENCHMARK_TEMPLATE(full_node4_sequential_insert, unodb::db)
+BENCHMARK_TEMPLATE(full_n4_sequential_insert, unodb::db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_sequential_insert, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n4_sequential_insert, unodb::mutex_db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_sequential_insert, unodb::olc_db)
-    ->Range(100, 65535)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(full_node4_random_insert, unodb::db)
-    ->Range(100, 65535)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_random_insert, unodb::mutex_db)
-    ->Range(100, 65535)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_random_insert, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n4_sequential_insert, unodb::olc_db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(minimal_node4_sequential_insert, unodb::db)
-    ->Range(16, 255)
+BENCHMARK_TEMPLATE(full_n4_random_insert, unodb::db)
+    ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node4_sequential_insert, unodb::mutex_db)
-    ->Range(16, 255)
+BENCHMARK_TEMPLATE(full_n4_random_insert, unodb::mutex_db)
+    ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node4_sequential_insert, unodb::olc_db)
-    ->Range(16, 255)
+BENCHMARK_TEMPLATE(full_n4_random_insert, unodb::olc_db)
+    ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(minimal_node4_random_insert, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n4_sequential_insert, unodb::db)
     ->Range(16, 255)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node4_random_insert, unodb::mutex_db)
+BENCHMARK_TEMPLATE(minimal_n4_sequential_insert, unodb::mutex_db)
     ->Range(16, 255)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node4_random_insert, unodb::olc_db)
+BENCHMARK_TEMPLATE(minimal_n4_sequential_insert, unodb::olc_db)
     ->Range(16, 255)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node4_full_scan, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n4_random_insert, unodb::db)
+    ->Range(16, 255)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(minimal_n4_random_insert, unodb::mutex_db)
+    ->Range(16, 255)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(minimal_n4_random_insert, unodb::olc_db)
+    ->Range(16, 255)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(n4_full_scan, unodb::db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node4_full_scan, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n4_full_scan, unodb::mutex_db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node4_full_scan, unodb::olc_db)
+BENCHMARK_TEMPLATE(n4_full_scan, unodb::olc_db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node4_random_gets, unodb::db)
+BENCHMARK_TEMPLATE(n4_random_gets, unodb::db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node4_random_gets, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n4_random_gets, unodb::mutex_db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node4_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(n4_random_gets, unodb::olc_db)
     ->Range(100, 65535)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node4_sequential_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n4_sequential_delete, unodb::db)
     ->Range(100, 65534)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_sequential_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n4_sequential_delete, unodb::mutex_db)
     ->Range(100, 65534)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_sequential_delete, unodb::olc_db)
-    ->Range(100, 65534)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(full_node4_random_deletes, unodb::db)
-    ->Range(100, 65534)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_random_deletes, unodb::mutex_db)
-    ->Range(100, 65534)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_random_deletes, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n4_sequential_delete, unodb::olc_db)
     ->Range(100, 65534)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node4_to_minimal_sequential_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n4_random_deletes, unodb::db)
+    ->Range(100, 65534)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(full_n4_random_deletes, unodb::mutex_db)
+    ->Range(100, 65534)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(full_n4_random_deletes, unodb::olc_db)
+    ->Range(100, 65534)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(full_n4_to_minimal_sequential_delete, unodb::db)
     ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_to_minimal_sequential_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n4_to_minimal_sequential_delete, unodb::mutex_db)
     ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_to_minimal_sequential_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n4_to_minimal_sequential_delete, unodb::olc_db)
     ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node4_to_minimal_random_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n4_to_minimal_random_delete, unodb::db)
     ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_to_minimal_random_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n4_to_minimal_random_delete, unodb::mutex_db)
     ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node4_to_minimal_random_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n4_to_minimal_random_delete, unodb::olc_db)
     ->Range(100, 65532)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(shrink_node16_to_node4_sequentially, unodb::db)
+BENCHMARK_TEMPLATE(shrink_node16_to_n4_sequentially, unodb::db)
     ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node16_to_node4_sequentially, unodb::mutex_db)
+BENCHMARK_TEMPLATE(shrink_node16_to_n4_sequentially, unodb::mutex_db)
     ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node16_to_node4_sequentially, unodb::olc_db)
+BENCHMARK_TEMPLATE(shrink_node16_to_n4_sequentially, unodb::olc_db)
     ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(shrink_node16_to_node4_randomly, unodb::db)
+BENCHMARK_TEMPLATE(shrink_node16_to_n4_randomly, unodb::db)
     ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node16_to_node4_randomly, unodb::mutex_db)
+BENCHMARK_TEMPLATE(shrink_node16_to_n4_randomly, unodb::mutex_db)
     ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node16_to_node4_randomly, unodb::olc_db)
+BENCHMARK_TEMPLATE(shrink_node16_to_n4_randomly, unodb::olc_db)
     ->Range(25, 16383)
     ->Unit(benchmark::kMicrosecond);
 

--- a/benchmark/micro_benchmark_n48.cpp
+++ b/benchmark/micro_benchmark_n48.cpp
@@ -12,184 +12,184 @@
 namespace {
 
 template <class Db>
-void grow_node16_to_node48_sequentially(benchmark::State &state) {
+void grow_n16_to_n48_sequentially(benchmark::State &state) {
   unodb::benchmark::grow_node_sequentially_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void grow_node16_to_node48_randomly(benchmark::State &state) {
+void grow_n16_to_n48_randomly(benchmark::State &state) {
   unodb::benchmark::grow_node_randomly_benchmark<Db, 16>(state);
 }
 
 template <class Db>
-void node48_sequential_add(benchmark::State &state) {
+void n48_sequential_add(benchmark::State &state) {
   unodb::benchmark::sequential_add_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void node48_random_add(benchmark::State &state) {
+void n48_random_add(benchmark::State &state) {
   unodb::benchmark::random_add_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void minimal_node48_tree_full_scan(benchmark::State &state) {
+void minimal_n48_tree_full_scan(benchmark::State &state) {
   unodb::benchmark::minimal_tree_full_scan<Db, 48>(state);
 }
 
 template <class Db>
-void minimal_node48_tree_random_gets(benchmark::State &state) {
+void minimal_n48_tree_random_gets(benchmark::State &state) {
   unodb::benchmark::minimal_tree_random_gets<Db, 48>(state);
 }
 
 template <class Db>
-void full_node48_tree_full_scan(benchmark::State &state) {
+void full_n48_tree_full_scan(benchmark::State &state) {
   unodb::benchmark::full_node_scan_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void full_node48_tree_random_gets(benchmark::State &state) {
+void full_n48_tree_random_gets(benchmark::State &state) {
   unodb::benchmark::full_node_random_get_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void full_node48_tree_sequential_delete(benchmark::State &state) {
+void full_n48_tree_sequential_delete(benchmark::State &state) {
   unodb::benchmark::sequential_delete_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void full_node48_tree_random_delete(benchmark::State &state) {
+void full_n48_tree_random_delete(benchmark::State &state) {
   unodb::benchmark::random_delete_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void shrink_node256_to_node48_sequentially(benchmark::State &state) {
+void shrink_n256_to_n48_sequentially(benchmark::State &state) {
   unodb::benchmark::shrink_node_sequentially_benchmark<Db, 48>(state);
 }
 
 template <class Db>
-void shrink_node256_to_node48_randomly(benchmark::State &state) {
+void shrink_n256_to_n48_randomly(benchmark::State &state) {
   unodb::benchmark::shrink_node_randomly_benchmark<Db, 48>(state);
 }
 
 }  // namespace
 
-BENCHMARK_TEMPLATE(grow_node16_to_node48_sequentially, unodb::db)
+BENCHMARK_TEMPLATE(grow_n16_to_n48_sequentially, unodb::db)
     ->Range(8, 8192)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node16_to_node48_sequentially, unodb::mutex_db)
+BENCHMARK_TEMPLATE(grow_n16_to_n48_sequentially, unodb::mutex_db)
     ->Range(8, 8192)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node16_to_node48_sequentially, unodb::olc_db)
-    ->Range(8, 8192)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(grow_node16_to_node48_randomly, unodb::db)
-    ->Range(8, 8192)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node16_to_node48_randomly, unodb::mutex_db)
-    ->Range(8, 8192)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(grow_node16_to_node48_randomly, unodb::olc_db)
+BENCHMARK_TEMPLATE(grow_n16_to_n48_sequentially, unodb::olc_db)
     ->Range(8, 8192)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(node48_sequential_add, unodb::db)
+BENCHMARK_TEMPLATE(grow_n16_to_n48_randomly, unodb::db)
+    ->Range(8, 8192)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(grow_n16_to_n48_randomly, unodb::mutex_db)
+    ->Range(8, 8192)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(grow_n16_to_n48_randomly, unodb::olc_db)
+    ->Range(8, 8192)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(n48_sequential_add, unodb::db)
     ->Range(2, 4096)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node48_sequential_add, unodb::mutex_db)
+BENCHMARK_TEMPLATE(n48_sequential_add, unodb::mutex_db)
     ->Range(2, 4096)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node48_sequential_add, unodb::olc_db)
-    ->Range(2, 4096)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(node48_random_add, unodb::db)
-    ->Range(2, 4096)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node48_random_add, unodb::mutex_db)
-    ->Range(2, 4096)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(node48_random_add, unodb::olc_db)
+BENCHMARK_TEMPLATE(n48_sequential_add, unodb::olc_db)
     ->Range(2, 4096)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(minimal_node48_tree_full_scan, unodb::db)
+BENCHMARK_TEMPLATE(n48_random_add, unodb::db)
+    ->Range(2, 4096)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(n48_random_add, unodb::mutex_db)
+    ->Range(2, 4096)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(n48_random_add, unodb::olc_db)
+    ->Range(2, 4096)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(minimal_n48_tree_full_scan, unodb::db)
     ->Range(4, 6144)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node48_tree_full_scan, unodb::mutex_db)
+BENCHMARK_TEMPLATE(minimal_n48_tree_full_scan, unodb::mutex_db)
     ->Range(4, 6144)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node48_tree_full_scan, unodb::olc_db)
+BENCHMARK_TEMPLATE(minimal_n48_tree_full_scan, unodb::olc_db)
     ->Range(4, 6144)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(minimal_node48_tree_random_gets, unodb::db)
+BENCHMARK_TEMPLATE(minimal_n48_tree_random_gets, unodb::db)
     ->Range(4, 6144)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node48_tree_random_gets, unodb::mutex_db)
+BENCHMARK_TEMPLATE(minimal_n48_tree_random_gets, unodb::mutex_db)
     ->Range(4, 6144)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(minimal_node48_tree_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(minimal_n48_tree_random_gets, unodb::olc_db)
     ->Range(4, 6144)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node48_tree_full_scan, unodb::db)
+BENCHMARK_TEMPLATE(full_n48_tree_full_scan, unodb::db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_full_scan, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n48_tree_full_scan, unodb::mutex_db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_full_scan, unodb::olc_db)
-    ->Range(128, 131064)
-    ->Unit(benchmark::kMicrosecond);
-
-BENCHMARK_TEMPLATE(full_node48_tree_random_gets, unodb::db)
-    ->Range(128, 131064)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_random_gets, unodb::mutex_db)
-    ->Range(128, 131064)
-    ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_random_gets, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n48_tree_full_scan, unodb::olc_db)
     ->Range(128, 131064)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node48_tree_sequential_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n48_tree_random_gets, unodb::db)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(full_n48_tree_random_gets, unodb::mutex_db)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(full_n48_tree_random_gets, unodb::olc_db)
+    ->Range(128, 131064)
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(full_n48_tree_sequential_delete, unodb::db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_sequential_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n48_tree_sequential_delete, unodb::mutex_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_sequential_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n48_tree_sequential_delete, unodb::olc_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(full_node48_tree_random_delete, unodb::db)
+BENCHMARK_TEMPLATE(full_n48_tree_random_delete, unodb::db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_random_delete, unodb::mutex_db)
+BENCHMARK_TEMPLATE(full_n48_tree_random_delete, unodb::mutex_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(full_node48_tree_random_delete, unodb::olc_db)
+BENCHMARK_TEMPLATE(full_n48_tree_random_delete, unodb::olc_db)
     ->Range(192, 196608)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(shrink_node256_to_node48_sequentially, unodb::db)
+BENCHMARK_TEMPLATE(shrink_n256_to_n48_sequentially, unodb::db)
     ->Range(4, 2048)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node256_to_node48_sequentially, unodb::mutex_db)
+BENCHMARK_TEMPLATE(shrink_n256_to_n48_sequentially, unodb::mutex_db)
     ->Range(4, 2048)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node256_to_node48_sequentially, unodb::olc_db)
+BENCHMARK_TEMPLATE(shrink_n256_to_n48_sequentially, unodb::olc_db)
     ->Range(4, 2048)
     ->Unit(benchmark::kMicrosecond);
 
-BENCHMARK_TEMPLATE(shrink_node256_to_node48_randomly, unodb::db)
+BENCHMARK_TEMPLATE(shrink_n256_to_n48_randomly, unodb::db)
     ->Range(4, 2048)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node256_to_node48_randomly, unodb::mutex_db)
+BENCHMARK_TEMPLATE(shrink_n256_to_n48_randomly, unodb::mutex_db)
     ->Range(4, 2048)
     ->Unit(benchmark::kMicrosecond);
-BENCHMARK_TEMPLATE(shrink_node256_to_node48_randomly, unodb::olc_db)
+BENCHMARK_TEMPLATE(shrink_n256_to_n48_randomly, unodb::olc_db)
     ->Range(4, 2048)
     ->Unit(benchmark::kMicrosecond);
 


### PR DESCRIPTION
Because horizontal screen space is valuable.