### PR TITLE
Add GCC 11 support

### DIFF
--- a/.cmake-build.el
+++ b/.cmake-build.el
@@ -8,12 +8,12 @@
   (debug-tsan "-DCMAKE_BUILD_TYPE=Debug -DSANITIZE_THREAD=ON")
   (debug-ubsan "-DCMAKE_BUILD_TYPE=Debug -DSANITIZE_UB=ON")
 
-  (gcc-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10")
-  (gcc-release-asan "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_ADDRESS=ON")
-  (gcc-release-ubsan "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_UB=ON")
-  (gcc-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10")
-  (gcc-debug-asan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_ADDRESS=ON")
-  (gcc-debug-tsan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSANITIZE_THREAD=ON")
+  (gcc-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11")
+  (gcc-release-asan "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSANITIZE_ADDRESS=ON")
+  (gcc-release-ubsan "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSANITIZE_UB=ON")
+  (gcc-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11")
+  (gcc-debug-asan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSANITIZE_ADDRESS=ON")
+  (gcc-debug-tsan "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSANITIZE_THREAD=ON")
 
   (llvm-release "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++")
   (llvm-release-tsan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_THREAD=ON")
@@ -21,8 +21,8 @@
   (llvm-debug-asan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_ADDRESS=ON")
   (llvm-debug-tsan "-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DSANITIZE_THREAD=ON")
 
-  (gcc-static-analysis-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSTATIC_ANALYSIS=ON")
-  (gcc-static-analysis-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSTATIC_ANALYSIS=ON"))
+  (gcc-static-analysis-debug "-DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSTATIC_ANALYSIS=ON")
+  (gcc-static-analysis-release "-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSTATIC_ANALYSIS=ON"))
 
  (cmake-build-run-configs
   (test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,55 +31,54 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: GCC 10 Release
+          - name: GCC 11 Release
             os: ubuntu-20.04
             BUILD_TYPE: Release
 
-          - name: GCC 10 Release with ASan
+          - name: GCC 11 Release with ASan
             os: ubuntu-20.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 10 Release with TSan
+          - name: GCC 11 Release with TSan
             os: ubuntu-20.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
 
-          - name: GCC 10 Release with UBSan
+          - name: GCC 11 Release with UBSan
             os: ubuntu-20.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
 
-          - name: GCC 10 Debug
+          - name: GCC 11 Debug
             os: ubuntu-20.04
             BUILD_TYPE: Debug
 
-          - name: GCC 10 Debug with ASan
+          - name: GCC 11 Debug with ASan
             os: ubuntu-20.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 10 Debug with TSan
+          - name: GCC 11 Debug with TSan
             os: ubuntu-20.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
 
-          - name: GCC 10 Debug with UBSan
+          - name: GCC 11 Debug with UBSan
             os: ubuntu-20.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
 
-          - name: GCC 10 Release static analysis & cpplint
+          - name: GCC 11 Release static analysis & cpplint
             os: ubuntu-20.04
             BUILD_TYPE: Release
             STATIC_ANALYSIS: ON
             CPPLINT: ON
 
-# Compilation gets killed, presumably by the OOM killer
-#          - name: GCC 10 Debug static analysis
-#            os: ubuntu-20.04
-#            BUILD_TYPE: Debug
-#            STATIC_ANALYSIS: ON
+          - name: GCC 11 Debug static analysis
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            STATIC_ANALYSIS: ON
 
           - name: clang 12 Release
             os: ubuntu-20.04
@@ -225,7 +224,9 @@ jobs:
             sudo apt-get install -y valgrind
           fi
           if [[ $COMPILER == "gcc" ]]; then
-            sudo apt-get install -y g++-10
+            sudo add-apt-repository -y 'ppa:ubuntu-toolchain-r/test'
+            sudo apt-get update
+            sudo apt-get install -y g++-11
           elif [[ $COMPILER == "clang" ]]; then
             sudo apt-get install -y clang-12
             if [[ $BUILD_TYPE == "Release" ]]; then
@@ -247,14 +248,16 @@ jobs:
           CPPCHECK="${CPPCHECK:-$DEFAULT_CPPCHECK}"
           COVERAGE="${COVERAGE:-$DEFAULT_COVERAGE}"
           COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
-          brew install boost
-          if [[ $CPPCHECK == "ON" ]]; then
-            brew install cppcheck
-          fi
           if [[ $COVERAGE == "ON" ]]; then
+            brew update
+            brew upgrade gcc
             brew install cpanm lcov
             sudo cpanm install JSON
           fi
+          if [[ $CPPCHECK == "ON" ]]; then
+            brew install cppcheck
+          fi
+          brew install boost
         if: runner.os == 'macOS'
 
       - name: Create build environment
@@ -274,10 +277,10 @@ jobs:
           COVERAGE="${COVERAGE:-$DEFAULT_COVERAGE}"
           export PATH=$HOME/.local/bin:$PATH
           if [[ $COMPILER == "gcc" ]]; then
-            export CC=gcc-10
-            export CXX=g++-10
+            export CC=gcc-11
+            export CXX=g++-11
             if [[ $COVERAGE == "ON" ]]; then
-              EXTRA_CMAKE_ARGS="-DGCOV_PATH=/usr/local/bin/gcov-10"
+              EXTRA_CMAKE_ARGS="-DGCOV_PATH=/usr/local/bin/gcov-11"
             fi
           elif [[ $COMPILER == "clang" ]]; then
             export CC=clang-12

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -3,6 +3,7 @@ name: build-with-old-compilers
 on: [push]
 
 env:
+  DEFAULT_COMPILER: gcc
   DEFAULT_SANITIZE_ADDRESS: OFF
   DEFAULT_SANITIZE_THREAD: OFF
   DEFAULT_SANITIZE_UB: OFF
@@ -13,6 +14,7 @@ jobs:
 
     env:
       BUILD_TYPE: ${{matrix.BUILD_TYPE}}
+      COMPILER: ${{matrix.COMPILER}}
       SANITIZE_ADDRESS: ${{matrix.SANITIZE_ADDRESS}}
       SANITIZE_THREAD: ${{matrix.SANITIZE_THREAD}}
       SANITIZE_UB: ${{matrix.SANITIZE_UB}}
@@ -24,40 +26,94 @@ jobs:
           - name: clang 11 Release
             os: ubuntu-20.04
             BUILD_TYPE: Release
+            COMPILER: clang
 
           - name: clang 11 Release with ASan
             os: ubuntu-20.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
+            COMPILER: clang
 
           - name: clang 11 Release with TSan
             os: ubuntu-20.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
+            COMPILER: clang
 
           - name: clang 11 Release with UBSan
             os: ubuntu-20.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
+            COMPILER: clang
 
           - name: clang 11 Debug
             os: ubuntu-20.04
             BUILD_TYPE: Debug
+            COMPILER: clang
 
           - name: clang 11 Debug with ASan
             os: ubuntu-20.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
+            COMPILER: clang
 
           - name: clang 11 Debug with TSan
             os: ubuntu-20.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
+            COMPILER: clang
 
           - name: clang 11 Debug with UBSan
             os: ubuntu-20.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
+            COMPILER: clang
+
+          - name: GCC 10 Release
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            COMPILER: gcc
+
+          - name: GCC 10 Release with ASan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: gcc
+
+          - name: GCC 10 Release with TSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: gcc
+
+          - name: GCC 10 Release with UBSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: gcc
+
+          - name: GCC 10 Debug
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            COMPILER: gcc
+
+          - name: GCC 10 Debug with ASan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: gcc
+
+          - name: GCC 10 Debug with TSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: gcc
+
+          - name: GCC 10 Debug with UBSan
+            os: ubuntu-20.04
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: gcc
 
     steps:
       - uses: actions/checkout@v2
@@ -66,23 +122,30 @@ jobs:
 
       - name: Setup dependencies for Linux
         run: |
+          COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
           SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-$DEFAULT_SANITIZE_ADDRESS}"
           SANITIZE_THREAD="${SANITIZE_THREAD:-$DEFAULT_SANITIZE_THREAD}"
           SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
-          curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
-            | sudo apt-key add -
-          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' \
-            | sudo tee -a /etc/apt/sources.list
+          if [[ $COMPILER == "clang" ]]; then
+            curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
+              | sudo apt-key add -
+            echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' \
+              | sudo tee -a /etc/apt/sources.list
+          fi
           sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
           sudo apt-get update
-          sudo apt-get install -y boost1.74 libc6-dev-i386 clang-11 \
-            clang-tidy-11
+          sudo apt-get install -y boost1.74 libc6-dev-i386
+          if [[ $COMPILER == "gcc" ]]; then
+            sudo apt-get install -y gcc-10
+          else
+            sudo apt-get install -y clang-11 clang-tidy-11
+            if [[ $BUILD_TYPE == "Release" ]]; then
+              sudo apt-get install -y llvm-11-dev lld-11
+            fi
+          fi
           if [[ $SANITIZE_ADDRESS != "ON" && $SANITIZE_THREAD != "ON" \
               && $SANITIZE_UB != "ON" ]]; then
             sudo apt-get install -y valgrind
-          fi
-          if [[ $BUILD_TYPE == "Release" ]]; then
-            sudo apt-get install -y llvm-11-dev lld-11
           fi
         if: runner.os == 'Linux'
 
@@ -95,17 +158,24 @@ jobs:
         shell: bash
         working-directory: ${{github.workspace}}/build
         run: |
+          COMPILER="${COMPILER:-$DEFAULT_COMPILER}"
           SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-$DEFAULT_SANITIZE_ADDRESS}"
           SANITIZE_THREAD="${SANITIZE_THREAD:-$DEFAULT_SANITIZE_THREAD}"
           SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
           export PATH=$HOME/.local/bin:$PATH
-          export CC=clang-11
-          export CXX=clang++-11
-          EXTRA_CMAKE_ARGS+="-DCLANG_TIDY_EXE=/usr/bin/clang-tidy-11 "
-          if [[ $BUILD_TYPE == "Release" ]]; then
-            EXTRA_CMAKE_ARGS+="-DLLVMAR_EXECUTABLE=/usr/bin/llvm-ar-11 \
-              -DLLVMNM_EXECUTABLE=/usr/bin/llvm-nm-11 \
-              -DLLVMRANLIB_EXECUTABLE=/usr/bin/llvm-ranlib-11"
+          if [[ $COMPILER == "gcc" ]]; then
+            export CC=gcc-10
+            export CXX=g++-10
+            EXTRA_CMAKE_ARGS=
+          else
+            export CC=clang-11
+            export CXX=clang++-11
+            EXTRA_CMAKE_ARGS+="-DCLANG_TIDY_EXE=/usr/bin/clang-tidy-11 "
+            if [[ $BUILD_TYPE == "Release" ]]; then
+              EXTRA_CMAKE_ARGS+="-DLLVMAR_EXECUTABLE=/usr/bin/llvm-ar-11 \
+                -DLLVMNM_EXECUTABLE=/usr/bin/llvm-nm-11 \
+                -DLLVMRANLIB_EXECUTABLE=/usr/bin/llvm-ranlib-11"
+            fi
           fi
           cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DSANITIZE_ADDRESS=${SANITIZE_ADDRESS} \

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,20 @@ dist: focal
 # '[warn] on root: unknown key "os_setups"', could not find a way
 # to fix it.
 os_setups:
+  gcc11_setup: &gcc11
+    os: linux
+    compiler: gcc
+    addons:
+      apt:
+        sources:
+          - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          - sourceline: 'ppa:mhier/libboost-latest'
+        packages:
+          - python3-pip
+          - boost1.73
+          - g++-11
+          - libc6-dev-i386
+          - valgrind
   gcc10_setup: &gcc10
     os: linux
     compiler: gcc
@@ -78,46 +92,46 @@ env:
 
 matrix:
   include:
-    - name: "GCC 10 Release"
-      <<: *gcc10
+    - name: "GCC 11 Release"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release
-    - name: "GCC 10 Release with ASan"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Release
+    - name: "GCC 11 Release with ASan"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_ADDRESS=ON
-    - name: "GCC 10 Release with TSan"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Release SANITIZE_ADDRESS=ON
+    - name: "GCC 11 Release with TSan"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_THREAD=ON
-    - name: "GCC 10 Release with UBSan"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "GCC 11 Release with UBSan"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_UB=ON
-    - name: "GCC 10 Debug"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Release SANITIZE_UB=ON
+    - name: "GCC 11 Debug"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug
-    - name: "GCC 10 Debug with ASan"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Debug
+    - name: "GCC 11 Debug with ASan"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_ADDRESS=ON
-    - name: "GCC 10 Debug with TSan"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Debug SANITIZE_ADDRESS=ON
+    - name: "GCC 11 Debug with TSan"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_THREAD=ON
-    - name: "GCC 10 Debug with UBSan"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "GCC 11 Debug with UBSan"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_UB=ON
-    - name: "GCC 10 static analysis Release"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Debug SANITIZE_UB=ON
+    - name: "GCC 11 static analysis Release"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release STATIC_ANALYSIS=ON
-    - name: "GCC 10 static analysis Debug"
-      <<: *gcc10
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Release STATIC_ANALYSIS=ON
+    - name: "GCC 11 static analysis Debug"
+      <<: *gcc11
       env:
-        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug STATIC_ANALYSIS=ON
+        - MATRIX_EVAL="CC=gcc-11 && CXX=g++-11" BUILD_TYPE=Debug STATIC_ANALYSIS=ON
     - name: "clang 12 Release"
       <<: *clang12
       env:
@@ -226,6 +240,38 @@ matrix:
       <<: *clang11
       env:
         - MATRIX_EVAL="CC=clang-11 && CXX=clang++-11" BUILD_TYPE=Debug SANITIZE_UB=ON
+    - name: "GCC 10 Release"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release
+    - name: "GCC 10 Release with ASan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_ADDRESS=ON
+    - name: "GCC 10 Release with TSan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_THREAD=ON
+    - name: "GCC 10 Release with UBSan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Release SANITIZE_UB=ON
+    - name: "GCC 10 Debug"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug
+    - name: "GCC 10 Debug with ASan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_ADDRESS=ON
+    - name: "GCC 10 Debug with TSan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_THREAD=ON
+    - name: "GCC 10 Debug with UBSan"
+      <<: *gcc10
+      env:
+        - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10" BUILD_TYPE=Debug SANITIZE_UB=ON
   allow_failures:
     - env: MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Release IWYU=ON CPPCHECK_AGGRESSIVE=ON
     - env: MATRIX_EVAL="CC=clang && CXX=clang++" BUILD_TYPE=Debug IWYU=ON CPPCHECK_AGGRESSIVE=ON
@@ -271,7 +317,7 @@ script:
   - ctest -j3 -V
   - echo "Benchmark runs (for benchmark correctness, not performance!)"
   - make quick_benchmarks
-  - if [[ "$TRAVIS_OS_NAME" != "osx" && "$CC" =~ "^(gcc-10|clang-12)$" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" != "osx" && "$CC" =~ "^(gcc-11|clang-12)$" ]]; then
       echo "Fuzzing with DeepState for 1 minute";
       make -j2 deepstate_1m;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ else()
     "-Wunused-macros" "-Wuseless-cast" "-Wvector-operation-performance"
     "-Wvla" "-Wzero-as-null-pointer-constant" "-Wattribute-alias=2"
     "-Warray-bounds=2" "-Wredundant-tags")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0)
+    list(APPEND CXX_FLAGS "-Wctad-maybe-unsupported"
+      "-Wdeprecated-enum-enum-conversion" "-Wdeprecated-enum-float-conversion"
+      "-Wvexing-parse")
+  endif()
 endif()
 
 list(APPEND CXX_FLAGS "${CXX_WARNING_FLAGS}" "-g" "-msse4.1")
@@ -388,6 +393,13 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     endif()
     if(STATIC_ANALYSIS)
       target_compile_options(${TARGET} PRIVATE "-fanalyzer")
+      if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+          "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 11)
+        # GCC 11 -fanalyzer not fully ready for C++ yet
+        target_compile_options(${TARGET} PRIVATE
+          "-Wno-analyzer-possible-null-dereference"
+          "-Wno-analyzer-possible-null-argument")
+      endif()
     endif()
   endif()
 endfunction()

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ C++ tools and ideas. I am trying to describe some of the things I learned at my
 
 ## Requirements
 
-The code uses SSE4.1 intrinsics (Nehalem and higher). This is in contrast to the
-original ART paper needing SSE2 only.
+The source code is C++17, using SSE4.1 intrinsics (Nehalem and higher). This is
+in contrast to the original ART paper needing SSE2 only.
 
-Note: since this is my personal project, it only supports GCC 10 and LLVM
-version 11-12 compilers. Drop me a note if you want to try this and need a lower
-supported compiler version.
+Note: since this is my personal project, it only supports GCC 10, 11, LLVM 11,
+12, and XCode 12.2 compilers. Drop me a note if you want to try this and need a
+lower supported compiler version.
 
 ## Usage
 
@@ -79,22 +79,20 @@ The are three ART classes available:
 
 ## Dependencies
 
-* git
-* a C++17 compiler, currently tested with clang 11, XCode clang 12 and GCC 10.2.
 * CMake, at least 3.12
-* Guidelines Support Library for gsl::span, imported as a git submodule.
 * Boost library. Currently tested with versions 1.74 and 1.75.
+* Guidelines Support Library for gsl::span, bundled as a git submodule.
+* Google Test for tests, bundled as a git submodule.
+* Google Benchmark for microbenchmarks, bundled, as a git submodule.
+* [DeepState][deepstate] for fuzzing tests, bundled as a git submodule.
 * (optional) clang-format
 * (optional) lcov
 * (optional) clang-tidy
+* (optional) clangd
 * (optional) cppcheck
 * (optional) cpplint
 * (optional) include-what-you-use
-* Google Test for tests, bundled as a git submodule.
-* [DeepState][deepstate] for fuzzing tests, currently building with clang only,
-  bundled.
-* libfuzzer
-* (optional) Google Benchmark for microbenchmarks, bundled.
+* (optional) libfuzzer
 
 ## Development
 

--- a/global.hpp
+++ b/global.hpp
@@ -59,10 +59,19 @@
 #if defined(__GNUG__) && !defined(__clang__)
 #define DISABLE_GCC_WARNING(x) DISABLE_WARNING(x)
 #define RESTORE_GCC_WARNINGS() RESTORE_WARNINGS()
-#else
+#if __GNUG__ >= 11
+#define DISABLE_GCC_11_WARNING(x) DISABLE_WARNING(x)
+#define RESTORE_GCC_11_WARNINGS() RESTORE_WARNINGS()
+#else  // __GNUG__ >= 11
+#define DISABLE_GCC_11_WARNING(x)
+#define RESTORE_GCC_11_WARNINGS()
+#endif  // __GNUG__ >= 11
+#else   // defined(__GNUG__) && !defined(__clang__)
 #define DISABLE_GCC_WARNING(x)
 #define RESTORE_GCC_WARNINGS()
-#endif
+#define DISABLE_GCC_11_WARNING(x)
+#define RESTORE_GCC_11_WARNINGS()
+#endif  // defined(__GNUG__) && !defined(__clang__)
 
 #define likely(x) __builtin_expect(x, 1)
 #define unlikely(x) __builtin_expect(x, 0)


### PR DESCRIPTION
- Enable new non-default GCC 11 compilation warnings

- Switch ffs_nonzero to builtin version on GCC 11

- Suppress a -Wmismatched-new-delete false positive

- Add GCC 11 to Github Actions and Travis CI while keeping GCC 10 too

- Re-enable GCC debug configuration static analysis