### PR TITLE
Introduce optimistic_lock::read_critical_section, refactor write guar…

### DIFF
--- a/global.hpp
+++ b/global.hpp
@@ -95,8 +95,10 @@
 
 #ifdef NDEBUG
 #define RELEASE_CONSTEXPR constexpr
+#define RELEASE_CONST const
 #else
 #define RELEASE_CONSTEXPR
+#define RELEASE_CONST
 #endif
 
 #if defined(__GNUG__) && !defined(__clang__)


### PR DESCRIPTION
…ds too

New inner class read_critical_section replaces former version class, but with a
more exact encapsulation of lock and its read version.

Also merge optimistic_write_lock_guard and unique_write_lock_obsoeleting_guard
classes to a single inner write_guard class, rename its commit and abort methods
to unlock_and_obsolete and unlock.

At the same time drop redundant unodb::, unodb::detail:: prefixes in
olc_art.cpp.