### PR TITLE
Refactor basic_inode_{4|16|48|256}::add methods

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -20,18 +20,6 @@ namespace detail {
 
 struct node_header;
 
-template <class>
-class basic_inode_4;  // IWYU pragma: keep
-
-template <class>
-class basic_inode_16;  // IWYU pragma: keep
-
-template <class>
-class basic_inode_48;  // IWYU pragma: keep
-
-template <class>
-class basic_inode_256;  // IWYU pragma: keep
-
 template <class, template <class> class, class, template <class> class,
           template <class, class> class, template <class> class>
 struct basic_art_policy;  // IWYU pragma: keep
@@ -49,6 +37,8 @@ using node_ptr = basic_node_ptr<node_header, inode, inode_defs>;
 
 template <class Header, class Db>
 auto make_db_leaf_ptr(art_key, value_view, Db &);
+
+struct impl_helpers;
 
 }  // namespace detail
 
@@ -183,22 +173,7 @@ class db final {
   template <class, class, class, template <class> class>
   friend class detail::basic_db_inode_deleter;
 
-  template <class>
-  friend class detail::basic_inode_4;
-
-  template <class>
-  friend class detail::basic_inode_16;
-
-  template <class>
-  friend class detail::basic_inode_48;
-
-  template <class>
-  friend class detail::basic_inode_256;
-
-  friend class detail::inode_4;
-  friend class detail::inode_16;
-  friend class detail::inode_48;
-  friend class detail::inode_256;
+  friend struct detail::impl_helpers;
 };
 
 }  // namespace unodb

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1074,26 +1074,6 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
                           keys.byte_array.cbegin() + this->f.f.children_count));
   }
 
-  // TODO(laurynas): refactor all the add() sibling methods to a single one
-  constexpr void add(db_leaf_unique_ptr &&child, db &db_instance,
-                     tree_depth depth, node_ptr *node_in_parent) noexcept {
-    assert(reinterpret_cast<node_header *>(this)->type() ==
-           basic_inode_4::static_node_type);
-
-    const auto children_count = this->f.f.children_count.load();
-
-    if (likely(children_count < parent_class::capacity)) {
-      add_to_nonfull(std::move(child), depth, children_count);
-    } else {
-      auto current_node{ArtPolicy::make_db_inode_unique_ptr(
-          db_instance, static_cast<inode4_type *>(this))};
-      auto larger_node{inode16_type::create(std::move(current_node),
-                                            std::move(child), depth)};
-      *node_in_parent = node_ptr{larger_node.release()};
-      db_instance.template account_growing_inode<node_type::I16>();
-    }
-  }
-
   constexpr void add_to_nonfull(db_leaf_unique_ptr &&child, tree_depth depth,
                                 std::uint8_t children_count) noexcept {
     assert(children_count == this->f.f.children_count);
@@ -1356,25 +1336,6 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
                           keys.byte_array.cbegin() + basic_inode_16::capacity));
   }
 
-  constexpr void add(db_leaf_unique_ptr &&child, db &db_instance,
-                     tree_depth depth, node_ptr *node_in_parent) noexcept {
-    assert(reinterpret_cast<node_header *>(this)->type() ==
-           basic_inode_16::static_node_type);
-
-    const auto children_count = this->f.f.children_count.load();
-
-    if (likely(children_count < parent_class::capacity)) {
-      add_to_nonfull(std::move(child), depth, children_count);
-    } else {
-      auto current_node{ArtPolicy::make_db_inode_unique_ptr(
-          db_instance, static_cast<inode16_type *>(this))};
-      auto larger_node{inode48_type::create(std::move(current_node),
-                                            std::move(child), depth)};
-      *node_in_parent = node_ptr{larger_node.release()};
-      db_instance.template account_growing_inode<node_type::I48>();
-    }
-  }
-
   constexpr void add_to_nonfull(db_leaf_unique_ptr &&child, tree_depth depth,
                                 std::uint8_t children_count) noexcept {
     assert(children_count == this->f.f.children_count);
@@ -1601,25 +1562,6 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   }
   RESTORE_GCC_WARNINGS()
 
-  constexpr void add(db_leaf_unique_ptr &&child, db &db_instance,
-                     tree_depth depth, node_ptr *node_in_parent) noexcept {
-    assert(reinterpret_cast<node_header *>(this)->type() ==
-           basic_inode_48::static_node_type);
-
-    const auto children_count = this->f.f.children_count.load();
-
-    if (likely(children_count < parent_class::capacity)) {
-      add_to_nonfull(std::move(child), depth, children_count);
-    } else {
-      auto current_node{ArtPolicy::make_db_inode_unique_ptr(
-          db_instance, static_cast<inode48_type *>(this))};
-      auto larger_node{inode256_type::create(std::move(current_node),
-                                             std::move(child), depth)};
-      *node_in_parent = node_ptr{larger_node.release()};
-      db_instance.template account_growing_inode<node_type::I256>();
-    }
-  }
-
   constexpr void add_to_nonfull(db_leaf_unique_ptr &&child, tree_depth depth,
                                 std::uint8_t children_count) noexcept {
     assert(this->f.f.children_count == children_count);
@@ -1813,11 +1755,6 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
         basic_inode_256::leaf_type::key(child.get())[depth]);
     assert(children[key_byte] == nullptr);
     children[key_byte] = node_ptr{child.release()};
-  }
-
-  constexpr void add(db_leaf_unique_ptr &&child, db &, tree_depth depth,
-                     node_ptr *) noexcept {
-    add_to_nonfull(std::move(child), depth, this->f.f.children_count.load());
   }
 
   constexpr void add_to_nonfull(db_leaf_unique_ptr &&child, tree_depth depth,

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -253,18 +253,6 @@ class olc_db final {
   template <class, class, class, template <class> class>
   friend class detail::basic_db_inode_deleter;
 
-  template <class>
-  friend class detail::basic_inode_4;
-
-  template <class>
-  friend class detail::basic_inode_16;
-
-  template <class>
-  friend class detail::basic_inode_48;
-
-  template <class>
-  friend class detail::basic_inode_256;
-
   friend struct detail::olc_impl_helpers;
 };
 


### PR DESCRIPTION
They were specific to the single-threaded ART flavor, so merge them to a
template and move to art.cpp as impl_helpers::add.

Remove a bunch of newly-redundant and previously missed forward and friend
declarations from art.hpp and olc_art.hpp.

For olc_impl_helpers::olc_inode_add_or_choose_subtree, pass node by reference.