### PR TITLE
Move unodb::db-specific code from art_internal_impl.hpp to art.cpp

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -953,24 +953,6 @@ class basic_inode : public basic_inode_impl<ArtPolicy> {
     assert(source_node.is_min_size());
     assert(is_full_for_add());
   }
-
- private:
-  [[nodiscard]] auto *add_or_choose_subtree(std::byte key_byte, art_key k,
-                                            value_view v, db &db_instance,
-                                            tree_depth depth,
-                                            node_ptr *node_in_parent) {
-    auto *const child = reinterpret_cast<node_ptr *>(
-        static_cast<Derived *>(this)->find_child(key_byte).second);
-    if (child == nullptr) {
-      auto leaf = ArtPolicy::make_db_leaf_ptr(k, v, db_instance);
-      static_cast<Derived *>(this)->add(std::move(leaf), db_instance, depth,
-                                        node_in_parent);
-    }
-    return child;
-  }
-
-  template <class>
-  friend class basic_inode_impl;
 };
 
 template <class ArtPolicy>


### PR DESCRIPTION
Move basic_inode::add_or_choose_subtree to art.cpp:impl_helpers because it's
unodb::db-specific. Inline impl_helpers::add.

At the same time inline olc_art.cpp:struct olc_impl_helpers::grow_inode into
caller, and rename child_loc local variables to child_in_parent.