### PR TITLE
Prefix all the macros in public headers with UNODB_DETAIL_

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,4 +2,4 @@
 Language: Cpp
 BasedOnStyle: Google
 IncludeBlocks: Preserve
-StatementAttributeLikeMacros: [USED_IN_DEBUG, RELEASE_CONSTEXPR]
+StatementAttributeLikeMacros: [UNODB_DETAIL_USED_IN_DEBUG, UNODB_DETAIL_RELEASE_CONSTEXPR]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ endif()
 option(STATIC_ANALYSIS "Enable compiler static analysis")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(DEBUG "ON")
+  set(UNODB_DETAIL_DEBUG "ON")
 endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The are three ART classes available:
   readers do not take locks), and for that a Quiescent State Based Reclamation
   (QSBR) was chosen.
 
+Any macros starting with `UNODB_DETAIL_` are internal and should not be used.
+
 ## Dependencies
 
 * CMake, at least 3.12

--- a/art.hpp
+++ b/art.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_ART_HPP_
-#define UNODB_ART_HPP_
+#ifndef UNODB_DETAIL_ART_HPP
+#define UNODB_DETAIL_ART_HPP
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -178,4 +178,4 @@ class db final {
 
 }  // namespace unodb
 
-#endif  // UNODB_ART_HPP_
+#endif  // UNODB_DETAIL_ART_HPP

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_ART_COMMON_HPP_
-#define UNODB_ART_COMMON_HPP_
+#ifndef UNODB_DETAIL_ART_COMMON_HPP
+#define UNODB_DETAIL_ART_COMMON_HPP
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -27,4 +27,4 @@ using value_view = gsl::span<const std::byte>;
 
 }  // namespace unodb
 
-#endif  // UNODB_ART_COMMON_HPP_
+#endif  // UNODB_DETAIL_ART_COMMON_HPP

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_ART_INTERNAL_HPP_
-#define UNODB_ART_INTERNAL_HPP_
+#ifndef UNODB_DETAIL_ART_INTERNAL_HPP
+#define UNODB_DETAIL_ART_INTERNAL_HPP
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -234,4 +234,4 @@ union basic_node_ptr {
 
 }  // namespace unodb::detail
 
-#endif  // UNODB_ART_INTERNAL_HPP_
+#endif  // UNODB_DETAIL_ART_INTERNAL_HPP

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_ART_INTERNAL_IMPL_HPP_
-#define UNODB_ART_INTERNAL_IMPL_HPP_
+#ifndef UNODB_DETAIL_ART_INTERNAL_IMPL_HPP
+#define UNODB_DETAIL_ART_INTERNAL_IMPL_HPP
 
 #include "global.hpp"
 
@@ -156,7 +156,7 @@ struct basic_leaf final {
                                                 raw_leaf_ptr leaf);
 
   static constexpr void assert_invariants(
-      USED_IN_DEBUG raw_leaf_ptr leaf) noexcept {
+      UNODB_DETAIL_USED_IN_DEBUG raw_leaf_ptr leaf) noexcept {
 #ifndef NDEBUG
     assert(reinterpret_cast<std::uintptr_t>(leaf) % alignof(Header) == 0);
     const auto *const assume_aligned =
@@ -169,7 +169,7 @@ struct basic_leaf final {
  private:
   static constexpr auto minimum_size = offset_value;
 
-  DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
+  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
   [[nodiscard]] static auto value_size(raw_leaf_ptr leaf) noexcept {
     assert_invariants(leaf);
 
@@ -177,7 +177,7 @@ struct basic_leaf final {
     std::memcpy(&result, &leaf[offset_value_size], sizeof(result));
     return result;
   }
-  RESTORE_GCC_WARNINGS()
+  UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 };
 
 template <class Header, class Db>
@@ -185,7 +185,8 @@ auto make_db_leaf_ptr(art_key k, value_view v, Db &db) {
   using leaf_type = basic_leaf<Header>;
   using value_size_type = typename leaf_type::value_size_type;
 
-  if (unlikely(v.size() > std::numeric_limits<value_size_type>::max())) {
+  if (UNODB_DETAIL_UNLIKELY(v.size() >
+                            std::numeric_limits<value_size_type>::max())) {
     throw std::length_error("Value length must fit in std::uint32_t");
   }
 
@@ -309,7 +310,7 @@ struct basic_art_policy final {
                                 LeafReclamator<header_type, Db>{db_instance}};
   }
 
-  DISABLE_GCC_11_WARNING("-Wmismatched-new-delete")
+  UNODB_DETAIL_DISABLE_GCC_11_WARNING("-Wmismatched-new-delete")
   template <class INode, class... Args>
   [[nodiscard]] static auto make_db_inode_unique_ptr(Db &db_instance,
                                                      Args &&...args) {
@@ -320,7 +321,7 @@ struct basic_art_policy final {
 
     return result;
   }
-  RESTORE_GCC_11_WARNINGS()
+  UNODB_DETAIL_RESTORE_GCC_11_WARNINGS()
 
   template <class INode>
   [[nodiscard]] static auto make_db_inode_unique_ptr(Db &db_instance,
@@ -370,7 +371,7 @@ struct basic_art_policy final {
           return;
         }
       }
-      CANNOT_HAPPEN();  // LCOV_EXCL_LINE
+      UNODB_DETAIL_CANNOT_HAPPEN();  // LCOV_EXCL_LINE
     }
 
     delete_db_node_ptr_at_scope_exit(const delete_db_node_ptr_at_scope_exit &) =
@@ -572,7 +573,7 @@ class basic_inode_impl {
         break;
         // LCOV_EXCL_START
       case node_type::LEAF:
-        CANNOT_HAPPEN();
+        UNODB_DETAIL_CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
     os << "# children = "
@@ -594,7 +595,7 @@ class basic_inode_impl {
         break;
         // LCOV_EXCL_START
       case node_type::LEAF:
-        CANNOT_HAPPEN();
+        UNODB_DETAIL_CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
   }
@@ -617,9 +618,9 @@ class basic_inode_impl {
             std::forward<Args>(args)...);
         // LCOV_EXCL_START
       case node_type::LEAF:
-        CANNOT_HAPPEN();
+        UNODB_DETAIL_CANNOT_HAPPEN();
     }
-    CANNOT_HAPPEN();
+    UNODB_DETAIL_CANNOT_HAPPEN();
     // LCOV_EXCL_STOP
   }
 
@@ -641,9 +642,9 @@ class basic_inode_impl {
             std::forward<Args>(args)...);
       case node_type::LEAF:
         // LCOV_EXCL_START
-        CANNOT_HAPPEN();
+        UNODB_DETAIL_CANNOT_HAPPEN();
     }
-    CANNOT_HAPPEN();
+    UNODB_DETAIL_CANNOT_HAPPEN();
     // LCOV_EXCL_STOP
   }
 
@@ -659,7 +660,7 @@ class basic_inode_impl {
         return static_cast<inode256_type *>(this)->delete_subtree(db_instance);
         // LCOV_EXCL_START
       case node_type::LEAF:
-        CANNOT_HAPPEN();
+        UNODB_DETAIL_CANNOT_HAPPEN();
         // LCOV_EXCL_STOP
     }
   }
@@ -685,9 +686,9 @@ class basic_inode_impl {
         return static_cast<inode256_type *>(this)->find_child(key_byte);
         // LCOV_EXCL_START
       case node_type::LEAF:
-        CANNOT_HAPPEN();
+        UNODB_DETAIL_CANNOT_HAPPEN();
     }
-    CANNOT_HAPPEN();
+    UNODB_DETAIL_CANNOT_HAPPEN();
     // LCOV_EXCL_STOP
   }
 
@@ -695,14 +696,14 @@ class basic_inode_impl {
   // define their own new and delete operators using node pools
   [[nodiscard, gnu::cold, gnu::noinline]] static void *operator new(
       std::size_t) {
-    CANNOT_HAPPEN();
+    UNODB_DETAIL_CANNOT_HAPPEN();
   }
 
-  DISABLE_CLANG_WARNING("-Wmissing-noreturn")
+  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wmissing-noreturn")
   [[gnu::cold, gnu::noinline]] static void operator delete(void *) {
-    CANNOT_HAPPEN();
+    UNODB_DETAIL_CANNOT_HAPPEN();
   }
-  RESTORE_CLANG_WARNINGS()
+  UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
   constexpr basic_inode_impl(node_type type, unsigned children_count,
                              art_key k1, art_key k2, tree_depth depth) noexcept
@@ -741,7 +742,7 @@ class basic_inode_impl {
   }
 
   constexpr void set_header(std::uint64_t u64) noexcept {
-#ifdef UNODB_THREAD_SANITIZER
+#ifdef UNODB_DETAIL_THREAD_SANITIZER
     // If we write the initial 4 bytes of a header as one uint32_t integer, we
     // overwrite the type byte (with an identical value of course), which gets
     // flagged as a data race. Thus don't touch it under ThreadSanitizer. An
@@ -767,7 +768,7 @@ class basic_inode_impl {
     } f;
     header_type header;
     std::array<critical_section_policy<std::uint32_t>, 2 + header_pad_u32> u32;
-#ifdef UNODB_THREAD_SANITIZER
+#ifdef UNODB_DETAIL_THREAD_SANITIZER
     std::array<critical_section_policy<std::uint8_t>, 4> header_bytes;
 #endif
 
@@ -1504,7 +1505,7 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   }
 
   // The warning disable might go away once C++20 std::atomic_ref is used
-  DISABLE_GCC_WARNING("-Wclass-memaccess")
+  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wclass-memaccess")
   constexpr basic_inode_48(db_inode256_reclaimable_ptr source_node,
                            std::uint8_t child_to_delete) noexcept
       : parent_class{*source_node} {
@@ -1531,7 +1532,7 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
       if (next_child == this->f.f.children_count) break;
     }
   }
-  RESTORE_GCC_WARNINGS()
+  UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
   constexpr void add_to_nonfull(db_leaf_unique_ptr &&child, tree_depth depth,
                                 std::uint8_t children_count) noexcept {
@@ -1805,4 +1806,4 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
 
 }  // namespace unodb::detail
 
-#endif  // UNODB_ART_INTERNAL_IMPL_HPP_
+#endif  // UNODB_DETAIL_ART_INTERNAL_IMPL_HPP

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 Laurynas Biveinis
-#ifndef UNODB_MICRO_BENCHMARK_CONCURRENCY_HPP_
-#define UNODB_MICRO_BENCHMARK_CONCURRENCY_HPP_
+#ifndef UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP
+#define UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP
 
 #include "global.hpp"
 
@@ -44,13 +44,13 @@ constexpr auto to_counter(T value) {
 template <class Db, class Thread>
 class concurrent_benchmark {
  protected:
-  DISABLE_GCC_WARNING("-Wsuggest-final-methods")
+  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-final-methods")
   virtual void setup() {}
 
   virtual void end_workload_in_main_thread() {}
 
   virtual void teardown() {}
-  RESTORE_GCC_WARNINGS()
+  UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
  public:
   concurrent_benchmark() noexcept = default;
@@ -172,4 +172,4 @@ class concurrent_benchmark {
 
 }  // namespace unodb::benchmark
 
-#endif
+#endif  // UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef MICRO_BENCHMARK_NODE_UTILS_HPP_
-#define MICRO_BENCHMARK_NODE_UTILS_HPP_
+#ifndef UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP
+#define UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP
 
 #include "global.hpp"
 
@@ -274,7 +274,7 @@ std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
       }
     }
   }
-  CANNOT_HAPPEN();
+  UNODB_DETAIL_CANNOT_HAPPEN();
 }
 
 }  // namespace detail
@@ -377,7 +377,8 @@ inline void set_size_counter(::benchmark::State &state,
 // Asserts
 
 template <class Db, node_type DominatingINodeType>
-void assert_dominating_inode_tree(const Db &test_db USED_IN_DEBUG) noexcept {
+void assert_dominating_inode_tree(
+    const Db &test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
   static_assert(DominatingINodeType != node_type::LEAF);
   const auto node_counts{test_db.get_node_counts()};
@@ -407,8 +408,9 @@ void assert_dominating_inode_size_tree(const Db &test_db) noexcept {
 
 template <class Db, unsigned SmallerNodeSize>
 void assert_growing_nodes(
-    const Db &test_db USED_IN_DEBUG,
-    std::uint64_t expected_number_of_nodes USED_IN_DEBUG) noexcept {
+    const Db &test_db UNODB_DETAIL_USED_IN_DEBUG,
+    std::uint64_t
+        expected_number_of_nodes UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
   constexpr auto larger_node_type =
       node_size_to_larger_node_type<SmallerNodeSize>();
@@ -424,8 +426,9 @@ void assert_growing_nodes(
 
 template <class Db, unsigned SmallerNodeSize>
 void assert_shrinking_nodes(
-    const Db &test_db USED_IN_DEBUG,
-    std::uint64_t expected_number_of_nodes USED_IN_DEBUG) noexcept {
+    const Db &test_db UNODB_DETAIL_USED_IN_DEBUG,
+    std::uint64_t
+        expected_number_of_nodes UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
   constexpr auto larger_node_type =
       node_size_to_larger_node_type<SmallerNodeSize>();
@@ -440,7 +443,7 @@ template <class Db>
 class tree_shape_snapshot final {
  public:
   explicit constexpr tree_shape_snapshot(
-      const Db &test_db USED_IN_DEBUG) noexcept
+      const Db &test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept
 #ifndef NDEBUG
       : db{test_db}, stats {
     test_db
@@ -620,7 +623,7 @@ void full_node_scan_benchmark(::benchmark::State &state) {
   std::int64_t items_processed{0};
 
   if constexpr (detail::node_size_has_key_zero_bits<NodeSize>()) {
-    const auto key_limit USED_IN_DEBUG =
+    const auto key_limit UNODB_DETAIL_USED_IN_DEBUG =
         detail::make_full_node_size_tree<Db, NodeSize>(test_db, key_count);
     for (auto _ : state) {
       unodb::key k = 0;
@@ -969,7 +972,7 @@ template <class Db, unsigned NodeSize>
 void minimal_tree_random_gets(::benchmark::State &state) {
   const auto node_count = static_cast<unsigned>(state.range(0));
   Db test_db;
-  const auto key_limit USED_IN_DEBUG =
+  const auto key_limit UNODB_DETAIL_USED_IN_DEBUG =
       detail::make_minimal_node_size_tree<Db, NodeSize>(test_db, node_count);
   assert(detail::number_to_minimal_node_size_tree_key<NodeSize>(
              node_count * detail::node_capacity_to_minimum_size<NodeSize>() -
@@ -1059,4 +1062,4 @@ void random_delete_benchmark(::benchmark::State &state) {
 
 }  // namespace unodb::benchmark
 
-#endif  // MICRO_BENCHMARK_NODE_UTILS_HPP_
+#endif  // UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef MICRO_BENCHMARK_UTILS_HPP_
-#define MICRO_BENCHMARK_UTILS_HPP_
+#ifndef UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
+#define UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -211,4 +211,4 @@ extern template void destroy_tree<unodb::olc_db>(unodb::olc_db &,
 
 }  // namespace unodb::benchmark
 
-#endif  // MICRO_BENCHMARK_UTILS_HPP_
+#endif  // UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP

--- a/config.hpp.in
+++ b/config.hpp.in
@@ -1,7 +1,7 @@
-// Copyright 2019 Laurynas Biveinis
-#ifndef UNODB_CONFIG_HPP_
-#define UNODB_CONFIG_HPP_
+// Copyright 2019-2021 Laurynas Biveinis
+#ifndef UNODB_DETAIL_CONFIG_HPP
+#define UNODB_DETAIL_CONFIG_HPP
 
-#cmakedefine DEBUG
+#cmakedefine UNODB_DETAIL_DEBUG
 
-#endif  // UNODB_CONFIG_HPP_
+#endif  // UNODB_DETAIL_CONFIG_HPP

--- a/debug_thread_sync.hpp
+++ b/debug_thread_sync.hpp
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 Laurynas Biveinis
-#ifndef UNODB_DEBUG_THREAD_SYNC_HPP_
-#define UNODB_DEBUG_THREAD_SYNC_HPP_
+#ifndef UNODB_DETAIL_DEBUG_THREAD_SYNC_HPP
+#define UNODB_DETAIL_DEBUG_THREAD_SYNC_HPP
 
 #include "global.hpp"
 
@@ -50,4 +50,4 @@ class thread_wait final {
 
 }  // namespace unodb::debug
 
-#endif  // UNODB_DEBUG_THREAD_SYNC_HPP_
+#endif  // UNODB_DETAIL_DEBUG_THREAD_SYNC_HPP

--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2021 Laurynas Biveinis
-#ifndef DEEPSTATE_UTILS_HPP_
-#define DEEPSTATE_UTILS_HPP_
+#ifndef UNODB_DETAIL_DEEPSTATE_UTILS_HPP
+#define UNODB_DETAIL_DEEPSTATE_UTILS_HPP
 
 #include "global.hpp"
 
@@ -11,7 +11,7 @@
 // warning: function 'DeepState_Run_ART_DeepState_fuzz' could be declared with
 // attribute 'noreturn' [-Wmissing-noreturn]
 #define UNODB_START_DEEPSTATE_TESTS() \
-  DISABLE_CLANG_WARNING("-Wmissing-noreturn")
+  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wmissing-noreturn")
 
 inline std::size_t DeepState_SizeTInRange(std::size_t min, std::size_t max) {
   return DeepState_UInt64InRange(min, max);
@@ -23,4 +23,4 @@ auto DeepState_ContainerIndex(const T &container) {
   return DeepState_SizeTInRange(0, container.size() - 1);
 }
 
-#endif  // DEEPSTATE_UTILS_HPP_
+#endif  // UNODB_DETAIL_DEEPSTATE_UTILS_HPP

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -325,7 +325,7 @@ void release_active_pointer(std::size_t thread_i) {
   active_ptrs.erase(active_ptr_itr);
 }
 
-RESTORE_GCC_WARNINGS()
+UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
 void pause_thread(std::size_t thread_i) {
   ASSERT(threads[thread_i].is_paused ==
@@ -446,7 +446,7 @@ void do_op(std::size_t thread_i, thread_operation op) {
       break;
     case thread_operation::RESET_STATS:
     case thread_operation::QUIT_THREAD:
-      CANNOT_HAPPEN();
+      UNODB_DETAIL_CANNOT_HAPPEN();
   }
 }
 

--- a/global.hpp
+++ b/global.hpp
@@ -1,10 +1,10 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_GLOBAL_HPP_
-#define UNODB_GLOBAL_HPP_
+#ifndef UNODB_DETAIL_GLOBAL_HPP
+#define UNODB_DETAIL_GLOBAL_HPP
 
 #include "config.hpp"
 
-#ifdef DEBUG
+#ifdef UNODB_DETAIL_DEBUG
 #ifndef __clang__
 
 #ifndef _GLIBCXX_DEBUG
@@ -17,13 +17,13 @@
 
 #endif  // #ifndef __clang__
 
-#else  // #ifdef DEBUG
+#else  // #ifdef UNODB_DETAIL_DEBUG
 
 #ifndef NDEBUG
 #define NDEBUG
 #endif
 
-#endif  // #ifdef DEBUG
+#endif  // #ifdef UNODB_DETAIL_DEBUG
 
 #if defined(__has_feature) && !defined(__clang__)
 #if __has_feature(address_sanitizer)
@@ -35,74 +35,75 @@
 
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
-#define UNODB_THREAD_SANITIZER 1
+#define UNODB_DETAIL_THREAD_SANITIZER 1
 #endif
 #elif defined(__SANITIZE_THREAD__)
-#define UNODB_THREAD_SANITIZER 1
+#define UNODB_DETAIL_THREAD_SANITIZER 1
 #endif
 
-#define DO_PRAGMA(x) _Pragma(#x)
+#define UNODB_DETAIL_DO_PRAGMA(x) _Pragma(#x)
 
-#define DISABLE_WARNING(x) \
-  _Pragma("GCC diagnostic push") DO_PRAGMA(GCC diagnostic ignored x)
+#define UNODB_DETAIL_DISABLE_WARNING(x) \
+  _Pragma("GCC diagnostic push")        \
+      UNODB_DETAIL_DO_PRAGMA(GCC diagnostic ignored x)
 
-#define RESTORE_WARNINGS(x) _Pragma("GCC diagnostic pop")
+#define UNODB_DETAIL_RESTORE_WARNINGS(x) _Pragma("GCC diagnostic pop")
 
 #ifdef __clang__
-#define DISABLE_CLANG_WARNING(x) DISABLE_WARNING(x)
-#define RESTORE_CLANG_WARNINGS() RESTORE_WARNINGS()
+#define UNODB_DETAIL_DISABLE_CLANG_WARNING(x) UNODB_DETAIL_DISABLE_WARNING(x)
+#define UNODB_DETAIL_RESTORE_CLANG_WARNINGS() UNODB_DETAIL_RESTORE_WARNINGS()
 #else
-#define DISABLE_CLANG_WARNING(x)
-#define RESTORE_CLANG_WARNINGS()
+#define UNODB_DETAIL_DISABLE_CLANG_WARNING(x)
+#define UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 #endif
 
 #if defined(__GNUG__) && !defined(__clang__)
-#define DISABLE_GCC_WARNING(x) DISABLE_WARNING(x)
-#define RESTORE_GCC_WARNINGS() RESTORE_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_WARNING(x) UNODB_DETAIL_DISABLE_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_WARNINGS() UNODB_DETAIL_RESTORE_WARNINGS()
 #if __GNUG__ == 10
-#define DISABLE_GCC_10_WARNING(x) DISABLE_WARNING(x)
-#define RESTORE_GCC_10_WARNINGS() RESTORE_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_10_WARNING(x) UNODB_DETAIL_DISABLE_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_10_WARNINGS() UNODB_DETAIL_RESTORE_WARNINGS()
 #else  // __GNUG__ == 10
-#define DISABLE_GCC_10_WARNING(x)
-#define RESTORE_GCC_10_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_10_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_10_WARNINGS()
 #endif  // __GNUG__ == 10
 #if __GNUG__ >= 11
-#define DISABLE_GCC_11_WARNING(x) DISABLE_WARNING(x)
-#define RESTORE_GCC_11_WARNINGS() RESTORE_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_11_WARNING(x) UNODB_DETAIL_DISABLE_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_11_WARNINGS() UNODB_DETAIL_RESTORE_WARNINGS()
 #else  // __GNUG__ >= 11
-#define DISABLE_GCC_11_WARNING(x)
-#define RESTORE_GCC_11_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_11_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_11_WARNINGS()
 #endif  // __GNUG__ >= 11
 #else   // defined(__GNUG__) && !defined(__clang__)
-#define DISABLE_GCC_WARNING(x)
-#define RESTORE_GCC_WARNINGS()
-#define DISABLE_GCC_10_WARNING(x)
-#define RESTORE_GCC_10_WARNINGS()
-#define DISABLE_GCC_11_WARNING(x)
-#define RESTORE_GCC_11_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_10_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_10_WARNINGS()
+#define UNODB_DETAIL_DISABLE_GCC_11_WARNING(x)
+#define UNODB_DETAIL_RESTORE_GCC_11_WARNINGS()
 #endif  // defined(__GNUG__) && !defined(__clang__)
 
-#define likely(x) __builtin_expect(x, 1)
-#define unlikely(x) __builtin_expect(x, 0)
+#define UNODB_DETAIL_LIKELY(x) __builtin_expect(x, 1)
+#define UNODB_DETAIL_UNLIKELY(x) __builtin_expect(x, 0)
 
 #ifdef NDEBUG
 // Cannot do [[gnu::unused]], as that does not play well with structured
 // bindings when compiling with GCC.
-#define USED_IN_DEBUG __attribute__((unused))
+#define UNODB_DETAIL_USED_IN_DEBUG __attribute__((unused))
 #else
-#define USED_IN_DEBUG
+#define UNODB_DETAIL_USED_IN_DEBUG
 #endif
 
 #ifdef NDEBUG
-#define RELEASE_CONSTEXPR constexpr
-#define RELEASE_CONST const
+#define UNODB_DETAIL_RELEASE_CONSTEXPR constexpr
+#define UNODB_DETAIL_RELEASE_CONST const
 #else
-#define RELEASE_CONSTEXPR
-#define RELEASE_CONST
+#define UNODB_DETAIL_RELEASE_CONSTEXPR
+#define UNODB_DETAIL_RELEASE_CONST
 #endif
 
 #if defined(__GNUG__) && !defined(__clang__)
-#define USE_STD_PMR
+#define UNODB_DETAIL_USE_STD_PMR
 #endif
 
 #ifndef NDEBUG
@@ -113,9 +114,10 @@
 // LCOV_EXCL_START
 namespace unodb::detail {
 
-[[noreturn]] inline void cannot_happen(const char *file USED_IN_DEBUG,
-                                       int line USED_IN_DEBUG,
-                                       const char *func USED_IN_DEBUG) {
+[[noreturn]] inline void cannot_happen(
+    const char *file UNODB_DETAIL_USED_IN_DEBUG,
+    int line UNODB_DETAIL_USED_IN_DEBUG,
+    const char *func UNODB_DETAIL_USED_IN_DEBUG) {
 #ifndef NDEBUG
   std::cerr << "Execution reached an unreachable point at " << file << ':'
             << line << ": " << func << '\n';
@@ -127,7 +129,7 @@ namespace unodb::detail {
 
 }  // namespace unodb::detail
 
-#define CANNOT_HAPPEN() \
+#define UNODB_DETAIL_CANNOT_HAPPEN() \
   unodb::detail::cannot_happen(__FILE__, __LINE__, __func__)
 
-#endif  // UNODB_GLOBAL_HPP_
+#endif  // UNODB_DETAIL_GLOBAL_HPP

--- a/heap.hpp
+++ b/heap.hpp
@@ -1,16 +1,16 @@
 // Copyright 2020-2021 Laurynas Biveinis
-#ifndef UNODB_HEAP_HPP_
-#define UNODB_HEAP_HPP_
+#ifndef UNODB_DETAIL_HEAP_HPP
+#define UNODB_DETAIL_HEAP_HPP
 
 #include "global.hpp"
 
 #include <algorithm>
 #include <cassert>
-#ifdef USE_STD_PMR
+#ifdef UNODB_DETAIL_USE_STD_PMR
 #include <memory_resource>
 #endif
 
-#ifndef USE_STD_PMR
+#ifndef UNODB_DETAIL_USE_STD_PMR
 #include <boost/container/pmr/global_resource.hpp>
 #include <boost/container/pmr/memory_resource.hpp>
 #include <boost/container/pmr/synchronized_pool_resource.hpp>
@@ -43,7 +43,7 @@
 
 namespace unodb::detail {
 
-#ifdef USE_STD_PMR
+#ifdef UNODB_DETAIL_USE_STD_PMR
 
 using pmr_pool = std::pmr::memory_resource;
 using pmr_pool_options = std::pmr::pool_options;
@@ -79,7 +79,7 @@ pmr_allocate(pmr_pool &pool, std::size_t size,
 
   auto *const result = pool.allocate(size, alignment);
 
-#if defined(VALGRIND_CLIENT_REQUESTS) && !defined(USE_STD_PMR)
+#if defined(VALGRIND_CLIENT_REQUESTS) && !defined(UNODB_DETAIL_USE_STD_PMR)
   if (!pool.is_equal(*pmr_new_delete_resource())) {
     VALGRIND_MALLOCLIKE_BLOCK(result, size, 0, 0);
   }
@@ -95,7 +95,7 @@ inline void pmr_deallocate(
   assert(alignment >= __STDCPP_DEFAULT_NEW_ALIGNMENT__);
 
   ASAN_POISON_MEMORY_REGION(pointer, size);
-#if defined(VALGRIND_CLIENT_REQUESTS) && !defined(USE_STD_PMR)
+#if defined(VALGRIND_CLIENT_REQUESTS) && !defined(UNODB_DETAIL_USE_STD_PMR)
   if (!pool.is_equal(*pmr_new_delete_resource())) {
     VALGRIND_FREELIKE_BLOCK(pointer, 0);
     VALGRIND_MAKE_MEM_UNDEFINED(pointer, size);
@@ -107,4 +107,4 @@ inline void pmr_deallocate(
 
 }  // namespace unodb::detail
 
-#endif  // UNODB_HEAP_HPP_
+#endif  // UNODB_DETAIL_HEAP_HPP

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef IN_FAKE_CRITICAL_SECTION_HPP_
-#define IN_FAKE_CRITICAL_SECTION_HPP_
+#ifndef UNODB_DETAIL_IN_FAKE_CRITICAL_SECTION_HPP
+#define UNODB_DETAIL_IN_FAKE_CRITICAL_SECTION_HPP
 
 #include "global.hpp"
 
@@ -68,4 +68,4 @@ class in_fake_critical_section final {
 
 }  // namespace unodb
 
-#endif  // IN_FAKE_CRITICAL_SECTION_HPP_
+#endif  // UNODB_DETAIL_IN_FAKE_CRITICAL_SECTION_HPP

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -1,6 +1,6 @@
-// Copyright 2019-2020 Laurynas Biveinis
-#ifndef UNODB_MUTEX_ART_HPP_
-#define UNODB_MUTEX_ART_HPP_
+// Copyright 2019-2021 Laurynas Biveinis
+#ifndef UNODB_DETAIL_MUTEX_ART_HPP
+#define UNODB_DETAIL_MUTEX_ART_HPP
 
 #include "global.hpp"
 
@@ -126,4 +126,4 @@ class mutex_db final {
 
 }  // namespace unodb
 
-#endif  // UNODB_MUTEX_ART_HPP_
+#endif  // UNODB_DETAIL_MUTEX_ART_HPP

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -1,6 +1,6 @@
 // Copyright 2021 Laurynas Biveinis
-#ifndef UNODB_NODE_TYPE_HPP_
-#define UNODB_NODE_TYPE_HPP_
+#ifndef UNODB_DETAIL_NODE_TYPE_HPP
+#define UNODB_DETAIL_NODE_TYPE_HPP
 
 #include "global.hpp"
 
@@ -23,7 +23,7 @@ void is_internal() noexcept {
   static_assert(NodeType != node_type::LEAF);
   // This function is not for execution, but to wrap the static_assert, which is
   // not an expression for some reason.
-  CANNOT_HAPPEN();
+  UNODB_DETAIL_CANNOT_HAPPEN();
 }
 
 }  // namespace detail
@@ -43,4 +43,4 @@ inline constexpr auto internal_as_i{
 
 }  // namespace unodb
 
-#endif  // UNODB_NODE_TYPE_HPP_
+#endif  // UNODB_DETAIL_NODE_TYPE_HPP

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_OLC_ART_HPP_
-#define UNODB_OLC_ART_HPP_
+#ifndef UNODB_DETAIL_OLC_ART_HPP
+#define UNODB_DETAIL_OLC_ART_HPP
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -187,7 +187,7 @@ class olc_db final {
   void decrement_leaf_count(std::size_t leaf_size) noexcept {
     decrease_memory_use(leaf_size);
 
-    const auto USED_IN_DEBUG old_leaf_count =
+    const auto UNODB_DETAIL_USED_IN_DEBUG old_leaf_count =
         node_counts[as_i<node_type::LEAF>].fetch_sub(1,
                                                      std::memory_order_relaxed);
     assert(old_leaf_count > 0);
@@ -257,4 +257,4 @@ class olc_db final {
 
 }  // namespace unodb
 
-#endif  // UNODB_OLC_ART_HPP_
+#endif  // UNODB_DETAIL_OLC_ART_HPP

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2019-2021 Laurynas Biveinis
-#ifndef UNODB_QSBR_HPP_
-#define UNODB_QSBR_HPP_
+#ifndef UNODB_DETAIL_QSBR_HPP
+#define UNODB_DETAIL_QSBR_HPP
 
 #include "global.hpp"
 
@@ -118,7 +118,7 @@ class qsbr final {
     bool deallocate_immediately = false;
     {
       std::lock_guard<std::mutex> guard{qsbr_mutex};
-      if (unlikely(single_thread_mode_locked())) {
+      if (UNODB_DETAIL_UNLIKELY(single_thread_mode_locked())) {
         deallocate_immediately = true;
       } else {
         // TODO(laurynas): out of critical section?
@@ -475,4 +475,4 @@ class qsbr_thread : public std::thread {
 
 }  // namespace unodb
 
-#endif  // UNODB_QSBR_HPP_
+#endif  // UNODB_DETAIL_QSBR_HPP

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2021 Laurynas Biveinis
-#ifndef UNODB_QSBR_PTR_HPP_
-#define UNODB_QSBR_PTR_HPP_
+#ifndef UNODB_DETAIL_QSBR_PTR_HPP
+#define UNODB_DETAIL_QSBR_PTR_HPP
 
 #include "global.hpp"
 
@@ -33,14 +33,15 @@ class qsbr_ptr : public detail::qsbr_ptr_base {
  public:
   using pointer_type = T *;
 
-  RELEASE_CONSTEXPR explicit qsbr_ptr(pointer_type ptr_) noexcept : ptr{ptr_} {
+  UNODB_DETAIL_RELEASE_CONSTEXPR explicit qsbr_ptr(pointer_type ptr_) noexcept
+      : ptr{ptr_} {
 #ifndef NDEBUG
     register_active_ptr(ptr);
 #endif
   }
 
   // cppcheck-suppress noExplicitConstructor
-  RELEASE_CONSTEXPR qsbr_ptr(const qsbr_ptr<T> &other) noexcept
+  UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr(const qsbr_ptr<T> &other) noexcept
       : ptr{other.ptr} {
 #ifndef NDEBUG
     register_active_ptr(ptr);
@@ -58,7 +59,8 @@ class qsbr_ptr : public detail::qsbr_ptr_base {
 #endif
   }
 
-  RELEASE_CONSTEXPR qsbr_ptr<T> &operator=(const qsbr_ptr<T> &other) noexcept {
+  UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr<T> &operator=(
+      const qsbr_ptr<T> &other) noexcept {
 #ifndef NDEBUG
     if (this == &other) return *this;
     unregister_active_ptr(ptr);
@@ -70,7 +72,8 @@ class qsbr_ptr : public detail::qsbr_ptr_base {
     return *this;
   }
 
-  RELEASE_CONSTEXPR qsbr_ptr<T> &operator=(qsbr_ptr<T> &&other) noexcept {
+  UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr<T> &operator=(
+      qsbr_ptr<T> &&other) noexcept {
 #ifndef NDEBUG
     unregister_active_ptr(ptr);
 #endif
@@ -139,17 +142,19 @@ namespace unodb {
 template <class T>
 class qsbr_ptr_span {
  public:
-  RELEASE_CONSTEXPR explicit qsbr_ptr_span(const gsl::span<T> &other)
+  UNODB_DETAIL_RELEASE_CONSTEXPR explicit qsbr_ptr_span(
+      const gsl::span<T> &other)
       : start{other.data()}, length{static_cast<std::size_t>(other.size())} {}
 
-  RELEASE_CONSTEXPR qsbr_ptr_span(const qsbr_ptr_span<T> &) noexcept = default;
+  UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span(
+      const qsbr_ptr_span<T> &) noexcept = default;
   constexpr qsbr_ptr_span(qsbr_ptr_span<T> &&) noexcept = default;
   ~qsbr_ptr_span() = default;
 
-  RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(
+  UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(
       const qsbr_ptr_span<T> &) noexcept = default;
-  RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(qsbr_ptr_span<T> &&) noexcept =
-      default;
+  UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(
+      qsbr_ptr_span<T> &&) noexcept = default;
 
   constexpr qsbr_ptr<const T> cbegin() const noexcept { return start; }
 
@@ -164,4 +169,4 @@ class qsbr_ptr_span {
 
 }  // namespace unodb
 
-#endif  // UNODB_QSBR_PTR_HPP_
+#endif  // UNODB_DETAIL_QSBR_PTR_HPP

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_DB_TEST_UTILS_HPP_
-#define UNODB_DB_TEST_UTILS_HPP_
+#ifndef UNODB_DETAIL_DB_TEST_UTILS_HPP
+#define UNODB_DETAIL_DB_TEST_UTILS_HPP
 
 #include "global.hpp"
 
@@ -48,7 +48,7 @@ namespace detail {
 
 // warning: 'ScopedTrace' was marked unused but was used
 // [-Wused-but-marked-unused]
-DISABLE_CLANG_WARNING("-Wused-but-marked-unused")
+UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wused-but-marked-unused")
 
 template <class Db>
 void assert_value_eq(const typename Db::get_result &result,
@@ -85,7 +85,7 @@ void do_assert_result_eq(const Db &db, unodb::key key,
   assert_value_eq<Db>(result, expected);
 }
 
-RESTORE_CLANG_WARNINGS()
+UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 template <class Db>
 void assert_result_eq(const Db &db, unodb::key key, unodb::value_view expected,
@@ -348,4 +348,4 @@ using olc_tree_verifier = tree_verifier<unodb::olc_db>;
 
 }  // namespace unodb::test
 
-#endif  // UNODB_DB_TEST_UTILS_HPP_
+#endif  // UNODB_DETAIL_DB_TEST_UTILS_HPP

--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2021 Laurynas Biveinis
-#ifndef UNODB_DB_GTEST_UTILS_HPP_
-#define UNODB_DB_GTEST_UTILS_HPP_
+#ifndef UNODB_DETAIL_GTEST_UTILS_HPP
+#define UNODB_DETAIL_GTEST_UTILS_HPP
 
 #include "global.hpp"
 
@@ -13,22 +13,23 @@
 // TYPED_TEST_CASE(ARTCorrectnessTest, ARTTypes);
 //                                             ^
 // is not a bug: https://github.com/google/googletest/issues/2271
-#define UNODB_TYPED_TEST_SUITE(Suite, Types)                   \
-  DISABLE_CLANG_WARNING("-Wgnu-zero-variadic-macro-arguments") \
-  TYPED_TEST_SUITE(Suite, Types);                              \
-  RESTORE_CLANG_WARNINGS()
+#define UNODB_TYPED_TEST_SUITE(Suite, Types)                                \
+  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wgnu-zero-variadic-macro-arguments") \
+  TYPED_TEST_SUITE(Suite, Types);                                           \
+  UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 // Because Google thinks
 // error: 'void {anonymous}::ARTCorrectnessTest_single_node_tree_empty_value_
 // Test<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = unodb::db]'
 // can be marked override [-Werror=suggest-override] is not a bug:
 // https://github.com/google/googletest/issues/1063
-#define UNODB_START_TYPED_TESTS() DISABLE_GCC_WARNING("-Wsuggest-override")
+#define UNODB_START_TYPED_TESTS() \
+  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-override")
 
-#define UNODB_ASSERT_DEATH(statement, regex)        \
-  DISABLE_CLANG_WARNING("-Wused-but-marked-unused") \
-  DISABLE_CLANG_WARNING("-Wcovered-switch-default") \
-  ASSERT_DEATH(statement, regex)                    \
-  RESTORE_CLANG_WARNINGS()
+#define UNODB_ASSERT_DEATH(statement, regex)                     \
+  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wused-but-marked-unused") \
+  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wcovered-switch-default") \
+  ASSERT_DEATH(statement, regex)                                 \
+  UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
-#endif  // UNODB_DB_GTEST_UTILS_HPP_
+#endif  // UNODB_DETAIL_GTEST_UTILS_HPP

--- a/test/qsbr_test_utils.hpp
+++ b/test/qsbr_test_utils.hpp
@@ -1,6 +1,6 @@
 // Copyright 2021 Laurynas Biveinis
-#ifndef UNODB_QSBR_TEST_UTILS_HPP_
-#define UNODB_QSBR_TEST_UTILS_HPP_
+#ifndef UNODB_DETAIL_QSBR_TEST_UTILS_HPP
+#define UNODB_DETAIL_QSBR_TEST_UTILS_HPP
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -12,4 +12,4 @@ void expect_idle_qsbr();
 
 }  // namespace unodb::test
 
-#endif  // UNODB_QSBR_TEST_UTILS_HPP_
+#endif  // UNODB_DETAIL_QSBR_TEST_UTILS_HPP

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -29,12 +29,12 @@ class mock_pool : public unodb::detail::pmr_pool {
 
   [[nodiscard]] bool empty() const noexcept { return allocations.empty(); }
 
-  DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
+  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
   [[nodiscard]] auto is_allocated(void *ptr) const {
     return allocations.find(reinterpret_cast<std::uintptr_t>(ptr)) !=
            allocations.cend();
   }
-  RESTORE_GCC_WARNINGS()
+  UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
   [[nodiscard]] void *do_allocate(std::size_t bytes,
                                   std::size_t alignment) override {

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -46,7 +46,7 @@ TEST(QSBRPtr, MoveCtor) {
   ASSERT_EQ(ptr.get(), nullptr);
 }
 
-DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
+UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
 TEST(QSBRPtr, CopyAssignment) {
   unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   unodb::qsbr_ptr<const char> ptr2{raw_ptr_y};
@@ -60,7 +60,7 @@ TEST(QSBRPtr, CopyAssignment) {
   ptr2 = ptr2;
   ASSERT_EQ(*ptr, x);
 }
-RESTORE_CLANG_WARNINGS()
+UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 TEST(QSBRPtr, MoveAssignment) {
   unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
@@ -164,7 +164,7 @@ TEST(QSBRPtrSpan, MoveCtor) {
   ASSERT_EQ(span.cbegin().get(), nullptr);
 }
 
-DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
+UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
 TEST(QSBRPtrSpan, CopyAssignment) {
   unodb::qsbr_ptr_span<const char> span{gsl_span};
   unodb::qsbr_ptr_span<const char> span2{gsl_span2};
@@ -179,7 +179,7 @@ TEST(QSBRPtrSpan, CopyAssignment) {
   ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span.cbegin(),
                          gsl_span.cend()));
 }
-RESTORE_CLANG_WARNINGS()
+UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 TEST(QSBRPtrSpan, MoveAssignment) {
   unodb::qsbr_ptr_span<const char> span{gsl_span};


### PR DESCRIPTION
Prefix header guards in private headers with UNODB_DETAIL_ too, for consistency.
Remove trailing _ from all the header guards.