### PR TITLE
Cleanup Node4 creation interface for two given child node case

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -292,12 +292,9 @@ bool db::insert(key insert_key, value_view v) {
       const auto existing_key = leaf::key(node->leaf);
       if (UNODB_DETAIL_UNLIKELY(k == existing_key)) return false;
 
-      auto leaf = art_policy::make_db_leaf_ptr(k, v, *this);
-      // TODO(laurynas): try to pass leaf node type instead of generic node
-      // below. This way it would be apparent that its key prefix does not need
-      // updating as leaves don't have any.
-      auto new_node = detail::inode_4::create(existing_key, remaining_key,
-                                              depth, *node, std::move(leaf));
+      auto new_leaf = art_policy::make_db_leaf_ptr(k, v, *this);
+      auto new_node = detail::inode_4::create(
+          existing_key, remaining_key, depth, node->leaf, std::move(new_leaf));
       *node = detail::node_ptr{new_node.release()};
       account_growing_inode<node_type::I4>();
       return true;

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -970,9 +970,10 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   using typename parent_class::larger_derived_type;
   using typename parent_class::node_ptr;
 
-  // Create a new node with two given child nodes
+  // Create a new node with two given child leaves
   [[nodiscard]] static constexpr auto create(art_key k1, art_key shifted_k2,
-                                             tree_depth depth, node_ptr child1,
+                                             tree_depth depth,
+                                             raw_leaf_ptr child1,
                                              db_leaf_unique_ptr &&child2) {
     return ArtPolicy::template make_db_inode_unique_ptr<inode4_type>(
         child2.get_deleter().get_db(), k1, shifted_k2, depth, child1,
@@ -993,11 +994,12 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   }
 
   constexpr basic_inode_4(art_key k1, art_key shifted_k2, tree_depth depth,
-                          node_ptr child1, db_leaf_unique_ptr &&child2) noexcept
+                          raw_leaf_ptr child1,
+                          db_leaf_unique_ptr &&child2) noexcept
       : parent_class{k1, shifted_k2, depth} {
     const auto k2_next_byte_depth = this->key_prefix_length();
     const auto k1_next_byte_depth = k2_next_byte_depth + depth;
-    add_two_to_empty(k1[k1_next_byte_depth], child1,
+    add_two_to_empty(k1[k1_next_byte_depth], node_ptr{child1},
                      shifted_k2[k2_next_byte_depth], std::move(child2));
   }
 


### PR DESCRIPTION
Both of these children are always leaves, but the interface took one of them by
a generic node pointer. Take it more exactly by a raw leaf pointer instead.