### PR TITLE
Continue switching over CMake scripts to CMake generator expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,11 +93,7 @@ else()
     "valgrind.h not found, disabling Valgrind client requests in debug config")
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # TODO(laurynas): switch to -Og once it actually works in the oldest
-  # supported compilers
-  list(APPEND CXX_FLAGS "-O0")
-else()
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
   if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
       "${CMAKE_CXX_COMPILER_VERSION}" VERSION_GREATER_EQUAL 9)
     include(CheckIPOSupported)
@@ -188,13 +184,7 @@ endif()
 
 option(STATIC_ANALYSIS "Enable compiler static analysis")
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(UNODB_DETAIL_DEBUG "ON")
-endif()
-
 set(THREADS_PREFER_PTHREAD_FLAG ON)
-
-configure_file(config.hpp.in config.hpp)
 
 find_package(Threads REQUIRED)
 
@@ -277,10 +267,9 @@ if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_SYSTEM_NAME}"
   endif()
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
-    AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_definitions(benchmark PUBLIC _GLIBCXX_DEBUG
-    _GLIBCXX_DEBUG_PEDANTIC)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  target_compile_definitions(benchmark PUBLIC
+    "$<$<CONFIG:Debug>:_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC>")
 endif()
 
 # Add benchmark_include_dirs by target_include_directories(... SYSTEM ...)
@@ -371,6 +360,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     "$<$<CXX_COMPILER_ID:AppleClang,Clang>:${CLANG_CXX_WARNING_FLAGS}>"
     "$<$<CXX_COMPILER_ID:GNU>:${GCC_CXX_WARNING_FLAGS}>"
     "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11.0>>:${GCC_GE_11_CXX_WARNING_FLAGS}>"
+    "$<$<CONFIG:Debug>:-O0>"
     "$<$<CONFIG:Release>:$<IF:$<BOOL:${COVERAGE}>,-O0,-O3>>"
     "$<$<BOOL:${COVERAGE}>:--coverage>")
   target_compile_options(${TARGET} PRIVATE "${CXX_FLAGS}")

--- a/config.hpp.in
+++ b/config.hpp.in
@@ -1,7 +1,0 @@
-// Copyright 2019-2021 Laurynas Biveinis
-#ifndef UNODB_DETAIL_CONFIG_HPP
-#define UNODB_DETAIL_CONFIG_HPP
-
-#cmakedefine UNODB_DETAIL_DEBUG
-
-#endif  // UNODB_DETAIL_CONFIG_HPP

--- a/global.hpp
+++ b/global.hpp
@@ -2,9 +2,7 @@
 #ifndef UNODB_DETAIL_GLOBAL_HPP
 #define UNODB_DETAIL_GLOBAL_HPP
 
-#include "config.hpp"
-
-#ifdef UNODB_DETAIL_DEBUG
+#ifndef NDEBUG
 #ifndef __clang__
 
 #ifndef _GLIBCXX_DEBUG
@@ -16,14 +14,7 @@
 #endif
 
 #endif  // #ifndef __clang__
-
-#else  // #ifdef UNODB_DETAIL_DEBUG
-
-#ifndef NDEBUG
-#define NDEBUG
-#endif
-
-#endif  // #ifdef UNODB_DETAIL_DEBUG
+#endif  // #ifndef NDEBUG
 
 #if defined(__has_feature) && !defined(__clang__)
 #if __has_feature(address_sanitizer)


### PR DESCRIPTION
Step 4: debug build

This will make it easier to use multi-configuration CMake backends, if needed
later.

At the same time simplify debug configuration by removing config.hpp,
UNODB_DETAIL_DEBUG define, and using NDEBUG instead.