### PR TITLE
Implement tagged node pointers

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -13,6 +13,14 @@
 #include "in_fake_critical_section.hpp"
 #include "node_type.hpp"
 
+namespace unodb::detail {
+
+struct node_header {};
+
+static_assert(std::is_empty_v<node_header>);
+
+}  // namespace unodb::detail
+
 namespace {
 
 template <class INode>

--- a/art.hpp
+++ b/art.hpp
@@ -47,14 +47,14 @@ class db final {
   using get_result = std::optional<value_view>;
 
   // Creation and destruction
-  constexpr db() noexcept {}
+  db() noexcept {}
 
   ~db() noexcept;
 
   // Querying
   [[nodiscard]] get_result get(key search_key) const noexcept;
 
-  [[nodiscard]] constexpr auto empty() const noexcept {
+  [[nodiscard]] auto empty() const noexcept {
     return root == nullptr;
   }
 

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -21,7 +21,7 @@ class mutex_db final {
   using get_result = std::pair<db::get_result, std::unique_lock<std::mutex>>;
 
   // Creation and destruction
-  constexpr mutex_db() noexcept : db_{} {}
+  mutex_db() noexcept : db_{} {}
 
   // Querying
   [[nodiscard]] auto get(key k) const noexcept {

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -78,7 +78,7 @@ class olc_db final {
   using get_result = std::optional<qsbr_value_view>;
 
   // Creation and destruction
-  constexpr explicit olc_db() noexcept {}
+  olc_db() noexcept {}
 
   ~olc_db() noexcept;
 


### PR DESCRIPTION
- Convert union basic_node_ptr to a class with a single std::uintptr_t field
  that stores the type of the pointed to node together with the pointer value
  itself.

- For all ART flavors, inode key prefix data and its length always share the
  same eight-byte word. Thus pull children_count out of inode_union up to
  basic_inode_impl.

- For all ART flavors, this retires all the reinit_in_inode / header_extra_size
  / header_pad_u32 / header_pad_bytes /
  rewrite-node-type-with-same-value-but-not-for-ThreadSanitizerbroken crap.

- For regular ART, this makes node header to become empty. To exploit this, make
  basic_inode_impl inherit from it instead of having it as a field.

- Make some constexpr methods regular due to tagged pointer reinterpret_cast
  being present in their callees.