### PR TITLE
Extract key_prefix class out of basic_inode_impl

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -269,8 +269,9 @@ db::get_result db::get(key search_key) const noexcept {
     assert(node_type != node_type::LEAF);
 
     auto *const inode{node.as_inode()};
-    const auto key_prefix_length{inode->key_prefix_length()};
-    if (inode->get_shared_key_prefix_length(remaining_key) < key_prefix_length)
+    const auto key_prefix_length{inode->get_key_prefix().length()};
+    if (inode->get_key_prefix().get_shared_length(remaining_key) <
+        key_prefix_length)
       return {};
     remaining_key.shift_right(key_prefix_length);
     const auto *const child{
@@ -314,9 +315,9 @@ bool db::insert(key insert_key, value_view v) {
     assert(depth < detail::art_key::size);
 
     auto *const inode{node->as_inode()};
-    const auto key_prefix_length{inode->key_prefix_length()};
+    const auto key_prefix_length{inode->get_key_prefix().length()};
     const auto shared_prefix_len{
-        inode->get_shared_key_prefix_length(remaining_key)};
+        inode->get_key_prefix().get_shared_length(remaining_key)};
     if (shared_prefix_len < key_prefix_length) {
       auto leaf = art_policy::make_db_leaf_ptr(k, v, *this);
       auto new_node = detail::inode_4::create(*node, shared_prefix_len, depth,
@@ -368,9 +369,9 @@ bool db::remove(key remove_key) {
     assert(depth < detail::art_key::size);
 
     auto *const inode{node->as_inode()};
-    const auto key_prefix_length{inode->key_prefix_length()};
+    const auto key_prefix_length{inode->get_key_prefix().length()};
     const auto shared_prefix_len{
-        inode->get_shared_key_prefix_length(remaining_key)};
+        inode->get_key_prefix().get_shared_length(remaining_key)};
     if (shared_prefix_len < key_prefix_length) return false;
 
     assert(shared_prefix_len == key_prefix_length);

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -406,6 +406,162 @@ template <class NodePtr>
   }
 }
 
+template <template <class> class CriticalSectionPolicy>
+class key_prefix final {
+  template <typename T>
+  using critical_section_policy = CriticalSectionPolicy<T>;
+
+  using key_prefix_size = std::uint8_t;
+
+  static constexpr key_prefix_size key_prefix_capacity{7};
+
+  using key_prefix_data =
+      std::array<critical_section_policy<std::byte>, key_prefix_capacity>;
+
+ public:
+  constexpr key_prefix(art_key k1, art_key shifted_k2,
+                       tree_depth depth) noexcept
+      : f{k1, shifted_k2, depth} {}
+
+  constexpr key_prefix(unsigned key_prefix_len,
+                       const key_prefix &source_key_prefix) noexcept
+      : f{key_prefix_len, source_key_prefix.f} {}
+
+  [[nodiscard, gnu::pure]] constexpr auto get_shared_length(
+      art_key shifted_key) const noexcept {
+    const auto u64 = f.u64.load();
+    const auto len = word_to_length(u64);
+    assert(len == length());
+
+    return shared_len(static_cast<std::uint64_t>(shifted_key), u64, len);
+  }
+
+  [[nodiscard]] constexpr unsigned length() const noexcept {
+    const auto result = f.f.key_prefix_length.load();
+    assert(result <= key_prefix_capacity);
+    return result;
+  }
+
+  constexpr void cut(unsigned cut_len) noexcept {
+    assert(cut_len > 0);
+    assert(cut_len <= length());
+
+    const auto u64 = f.u64.load();
+    const auto len = word_to_length(u64);
+    assert(len == length());
+
+    f.u64 = ((u64 >> (cut_len * 8)) & key_bytes_mask) |
+            length_to_word(len - cut_len);
+
+    assert(length() <= key_prefix_capacity);
+  }
+
+  constexpr void prepend(const key_prefix &prefix1,
+                         std::byte prefix2) noexcept {
+    const auto prefix1_u64 = prefix1.f.u64.load();
+    const auto prefix1_length = word_to_length(prefix1_u64);
+    assert(prefix1_length == prefix1.length());
+
+    const auto prefix3_u64 = f.u64.load();
+    const auto prefix3_length = word_to_length(prefix3_u64);
+    assert(prefix3_length == length());
+
+    assert(prefix3_length + prefix1_length < key_prefix_capacity);
+
+    const auto prefix1_bit_length = prefix1_length * 8U;
+    const auto prefix1_mask = (1ULL << prefix1_bit_length) - 1;
+    const auto prefix3_bit_length = prefix3_length * 8U;
+    const auto prefix3_mask = (1ULL << prefix3_bit_length) - 1;
+    const auto prefix3 = prefix3_u64 & prefix3_mask;
+    const auto shifted_prefix3 = prefix3 << (prefix1_bit_length + 8U);
+    const auto shifted_prefix2 = static_cast<std::uint64_t>(prefix2)
+                                 << prefix1_bit_length;
+    const auto masked_prefix1 = prefix1_u64 & prefix1_mask;
+
+    f.u64 = shifted_prefix3 | shifted_prefix2 | masked_prefix1 |
+            length_to_word(prefix1_length + 1U + prefix3_length);
+
+    assert(length() <= key_prefix_capacity);
+  }
+
+  [[nodiscard]] constexpr auto byte_at(std::size_t i) const noexcept {
+    return f.f.key_prefix[i].load();
+  }
+
+  [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
+    const auto len = length();
+    os << ", key prefix len = " << len;
+    if (len > 0) {
+      os << ", key prefix =";
+      for (std::size_t i = 0; i < len; ++i) dump_byte(os, f.f.key_prefix[i]);
+    }
+  }
+
+ private:
+  static constexpr auto key_bytes_mask = 0x00FFFFFF'FFFFFFFFULL;
+  static constexpr auto length_mask = 0xFF000000'00000000ULL;
+
+  union key_prefix_union {
+    struct key_prefix_fields {
+      key_prefix_data key_prefix;
+      critical_section_policy<key_prefix_size> key_prefix_length;
+    } f;
+    critical_section_policy<std::uint64_t> u64;
+
+    key_prefix_union(art_key k1, art_key shifted_k2, tree_depth depth) noexcept
+        : u64{make_u64(k1, shifted_k2, depth)} {}
+
+    key_prefix_union(unsigned key_prefix_len,
+                     const key_prefix_union &source_key_prefix) noexcept
+        : u64{(source_key_prefix.u64 & key_bytes_mask) |
+              length_to_word(key_prefix_len)} {
+      assert(key_prefix_len <= key_prefix_capacity);
+    }
+
+    key_prefix_union(const key_prefix_union &other) noexcept
+        : u64{other.u64.load()} {}
+
+    ~key_prefix_union() noexcept = default;
+
+    key_prefix_union(key_prefix_union &&) noexcept = delete;
+    key_prefix_union &operator=(const key_prefix_union &) noexcept = delete;
+    key_prefix_union &operator=(key_prefix_union &&) noexcept = delete;
+
+    static std::uint64_t make_u64(art_key k1, art_key shifted_k2,
+                                  tree_depth depth) noexcept {
+      k1.shift_right(depth);
+
+      const auto k1_u64 = static_cast<std::uint64_t>(k1) & key_bytes_mask;
+
+      return k1_u64 | length_to_word(shared_len(
+                          k1_u64, static_cast<std::uint64_t>(shifted_k2),
+                          key_prefix_capacity));
+    }
+  } f;
+
+  static_assert(sizeof(key_prefix_union) == sizeof(std::uint64_t));
+
+  [[nodiscard, gnu::pure]] static constexpr unsigned shared_len(
+      std::uint64_t k1, std::uint64_t k2, unsigned clamp_byte_pos) noexcept {
+    assert(clamp_byte_pos < 8);
+
+    const auto diff = k1 ^ k2;
+    const auto clamped = diff | (1ULL << (clamp_byte_pos * 8U));
+    return static_cast<unsigned>(__builtin_ctzl(clamped)) >> 3U;
+  }
+
+  [[nodiscard, gnu::pure]] static constexpr std::uint64_t length_to_word(
+      unsigned length) noexcept {
+    assert(length <= key_prefix_capacity);
+    return static_cast<std::uint64_t>(length) << 56U;
+  }
+
+  [[nodiscard, gnu::pure]] static constexpr key_prefix_size word_to_length(
+      std::uint64_t u64) noexcept {
+    return gsl::narrow_cast<key_prefix_size>((u64 & length_mask) >> 56U);
+  }
+};
+
 // A class used as a sentinel for basic_inode template args: the
 // larger node type for the largest node type and the smaller node type for
 // the smallest node type.
@@ -454,73 +610,10 @@ class basic_inode_impl : public ArtPolicy::header_type {
   using inode48_type = typename ArtPolicy::inode48_type;
   using inode256_type = typename ArtPolicy::inode256_type;
 
-  // key_prefix fields and methods
  public:
-  using key_prefix_size = std::uint8_t;
+  constexpr auto &get_key_prefix() noexcept { return k_prefix; }
 
- private:
-  static constexpr key_prefix_size key_prefix_capacity = 7;
-
- public:
-  using key_prefix_data =
-      std::array<critical_section_policy<std::byte>, key_prefix_capacity>;
-
-  [[nodiscard, gnu::pure]] constexpr auto get_shared_key_prefix_length(
-      unodb::detail::art_key shifted_key) const noexcept {
-    return shared_len(static_cast<std::uint64_t>(shifted_key), f.u64,
-                      key_prefix_length());
-  }
-
-  [[nodiscard]] constexpr unsigned key_prefix_length() const noexcept {
-    const auto result = f.f.key_prefix_length.load();
-    assert(result <= key_prefix_capacity);
-    return result;
-  }
-
-  constexpr void cut_key_prefix(unsigned cut_len) noexcept {
-    assert(cut_len > 0);
-    assert(cut_len <= key_prefix_length());
-
-    f.u64 = ((f.u64 >> (cut_len * 8)) & key_bytes_mask) |
-            length_to_word(key_prefix_length() - cut_len);
-
-    assert(f.f.key_prefix_length.load() <= key_prefix_capacity);
-  }
-
-  constexpr void prepend_key_prefix(const basic_inode_impl &prefix1,
-                                    std::byte prefix2) noexcept {
-    assert(key_prefix_length() + prefix1.key_prefix_length() <
-           key_prefix_capacity);
-
-    const auto prefix1_bit_length = prefix1.key_prefix_length() * 8U;
-    const auto prefix1_mask = (1ULL << prefix1_bit_length) - 1;
-    const auto prefix3_bit_length = key_prefix_length() * 8U;
-    const auto prefix3_mask = (1ULL << prefix3_bit_length) - 1;
-    const auto prefix3 = f.u64 & prefix3_mask;
-    const auto shifted_prefix3 = prefix3 << (prefix1_bit_length + 8U);
-    const auto shifted_prefix2 = static_cast<std::uint64_t>(prefix2)
-                                 << prefix1_bit_length;
-    const auto masked_prefix1 = prefix1.f.u64 & prefix1_mask;
-
-    f.u64 =
-        shifted_prefix3 | shifted_prefix2 | masked_prefix1 |
-        length_to_word(key_prefix_length() + prefix1.key_prefix_length() + 1);
-
-    assert(f.f.key_prefix_length.load() <= key_prefix_capacity);
-  }
-
-  [[nodiscard]] constexpr const auto &get_key_prefix() const noexcept {
-    return f.f.key_prefix;
-  }
-
-  [[gnu::cold, gnu::noinline]] void dump_key_prefix(std::ostream &os) const {
-    const auto len = key_prefix_length();
-    os << ", key prefix len = " << len;
-    if (len > 0) {
-      os << ", key prefix =";
-      for (std::size_t i = 0; i < len; ++i) dump_byte(os, f.f.key_prefix[i]);
-    }
-  }
+  constexpr const auto &get_key_prefix() const noexcept { return k_prefix; }
 
   // Only for unodb::detail use.
   constexpr auto get_children_count() const noexcept {
@@ -613,83 +706,31 @@ class basic_inode_impl : public ArtPolicy::header_type {
   }
   UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
-  constexpr basic_inode_impl(unsigned children_count_, art_key k1, art_key k2,
-                             tree_depth depth) noexcept
-      : f{k1, k2, depth},
+  constexpr basic_inode_impl(unsigned children_count_, art_key k1,
+                             art_key shifted_k2, tree_depth depth) noexcept
+      : k_prefix{k1, shifted_k2, depth},
         children_count{gsl::narrow_cast<std::uint8_t>(children_count_)} {}
 
   constexpr basic_inode_impl(unsigned children_count_, unsigned key_prefix_len,
                              const inode_type &key_prefix_source_node) noexcept
-      : f{key_prefix_len, key_prefix_source_node},
+      : k_prefix{key_prefix_len, key_prefix_source_node.get_key_prefix()},
         children_count{gsl::narrow_cast<std::uint8_t>(children_count_)} {}
 
   constexpr basic_inode_impl(unsigned children_count_,
                              const basic_inode_impl &other) noexcept
-      : f{other},
+      : k_prefix{other.k_prefix},
         children_count{gsl::narrow_cast<std::uint8_t>(children_count_)} {}
 
  protected:
   [[gnu::cold, gnu::noinline]] void dump(std::ostream &os) const {
-    dump_key_prefix(os);
+    k_prefix.dump(os);
     const auto children_count_ = this->children_count.load();
     os << ", # children = "
        << (children_count_ == 0 ? 256 : static_cast<unsigned>(children_count_));
   }
 
  private:
-  static constexpr auto key_bytes_mask = 0x00FFFFFF'FFFFFFFFULL;
-
-  [[nodiscard, gnu::pure]] static constexpr unsigned shared_len(
-      std::uint64_t k1, std::uint64_t k2, unsigned clamp_byte_pos) noexcept {
-    assert(clamp_byte_pos < 8);
-
-    const auto diff = k1 ^ k2;
-    const auto clamped = diff | (1ULL << (clamp_byte_pos * 8U));
-    return static_cast<unsigned>(__builtin_ctzl(clamped)) >> 3U;
-  }
-
-  [[nodiscard, gnu::pure]] static constexpr std::uint64_t length_to_word(
-      unsigned length) {
-    assert(length <= key_prefix_capacity);
-    return static_cast<std::uint64_t>(length) << 56U;
-  }
-
-  union inode_union {
-    struct inode_fields {
-      key_prefix_data key_prefix;
-      critical_section_policy<key_prefix_size> key_prefix_length;
-    } f;
-    critical_section_policy<std::uint64_t> u64;
-
-    static void static_asserts() noexcept {
-      static_assert(offsetof(inode_fields, key_prefix_data) == 0);
-      static_assert(offsetof(inode_fields, key_prefix_length) == 7);
-      static_assert(offsetof(inode_fields, children_count) == 8);
-      static_assert(sizeof(inode_fields) == 9);
-    }
-
-    inode_union(art_key k1, art_key shifted_k2, tree_depth depth) noexcept {
-      k1.shift_right(depth);
-
-      const auto k1_u64 = static_cast<std::uint64_t>(k1) & key_bytes_mask;
-
-      u64 = k1_u64 | length_to_word(shared_len(
-                         k1_u64, static_cast<std::uint64_t>(shifted_k2),
-                         key_prefix_capacity));
-    }
-
-    inode_union(unsigned key_prefix_len,
-                const basic_inode_impl &key_prefix_source_node) noexcept {
-      assert(key_prefix_len <= key_prefix_capacity);
-
-      u64 = (key_prefix_source_node.f.u64 & key_bytes_mask) |
-            length_to_word(key_prefix_len);
-    }
-
-    explicit inode_union(const basic_inode_impl &other) noexcept
-        : inode_union{other.key_prefix_length(), other} {}
-  } f;
-
+  key_prefix<critical_section_policy> k_prefix;
   critical_section_policy<std::uint8_t> children_count;
 
  protected:
@@ -869,7 +910,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
                           raw_leaf_ptr child1,
                           db_leaf_unique_ptr &&child2) noexcept
       : parent_class{k1, shifted_k2, depth} {
-    const auto k2_next_byte_depth = this->key_prefix_length();
+    const auto k2_next_byte_depth = this->get_key_prefix().length();
     const auto k1_next_byte_depth = k2_next_byte_depth + depth;
     add_two_to_empty(k1[k1_next_byte_depth], node_ptr{child1},
                      shifted_k2[k2_next_byte_depth], std::move(child2));
@@ -879,12 +920,13 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
                           db_leaf_unique_ptr &&child1) noexcept
       : parent_class{len, *source_node.as_inode()} {
     auto *const source_inode = source_node.as_inode();
-    assert(len < source_inode->key_prefix_length());
+    // FIXME(laurynas): consolidate source_inode key prefix loads
+    assert(len < source_inode->get_key_prefix().length());
     assert(depth + len < art_key::size);
 
     const auto source_node_key_byte =
-        source_inode->get_key_prefix()[len].load();
-    source_inode->cut_key_prefix(len + 1);
+        source_inode->get_key_prefix().byte_at(len);
+    source_inode->get_key_prefix().cut(len + 1);
     const auto new_key_byte = leaf_type::key(child1.get())[depth + len];
     add_two_to_empty(source_node_key_byte, source_node, new_key_byte,
                      std::move(child1));
@@ -999,8 +1041,8 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     const std::uint8_t child_to_leave = (child_to_delete == 0) ? 1 : 0;
     const auto child_to_leave_ptr = children[child_to_leave].load();
     if (child_to_leave_ptr.type() != node_type::LEAF) {
-      child_to_leave_ptr.as_inode()->prepend_key_prefix(
-          *this, keys.byte_array[child_to_leave]);
+      child_to_leave_ptr.as_inode()->get_key_prefix().prepend(
+          this->get_key_prefix(), keys.byte_array[child_to_leave]);
     }
     return child_to_leave_ptr;
   }

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -807,9 +807,9 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
     }
 
     auto *const inode{node.as_inode()};
-    const auto key_prefix_length{inode->key_prefix_length()};
+    const auto key_prefix_length{inode->get_key_prefix().length()};
     const auto shared_key_prefix_length{
-        inode->get_shared_key_prefix_length(remaining_key)};
+        inode->get_key_prefix().get_shared_length(remaining_key)};
 
     if (shared_key_prefix_length < key_prefix_length) {
       if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
@@ -917,9 +917,9 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
     assert(depth < detail::art_key::size);
 
     auto *const inode{node.as_inode()};
-    const auto key_prefix_length{inode->key_prefix_length()};
+    const auto key_prefix_length{inode->get_key_prefix().length()};
     const auto shared_prefix_length{
-        inode->get_shared_key_prefix_length(remaining_key)};
+        inode->get_key_prefix().get_shared_length(remaining_key)};
 
     if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check())) return {};
 
@@ -1030,9 +1030,9 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
     assert(depth < detail::art_key::size);
 
     auto *const inode{node.as_inode()};
-    const auto key_prefix_length{inode->key_prefix_length()};
+    const auto key_prefix_length{inode->get_key_prefix().length()};
     const auto shared_prefix_length{
-        inode->get_shared_key_prefix_length(remaining_key)};
+        inode->get_key_prefix().get_shared_length(remaining_key)};
 
     if (shared_prefix_length < key_prefix_length) {
       if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))


### PR DESCRIPTION
At the same time consolidate some of the key prefix loads to help the OLC
flavor.