### PR TITLE
Make leaf a proper class

### DIFF
--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -238,9 +238,6 @@ class olc_db final {
   friend auto detail::make_db_leaf_ptr<detail::olc_node_header, olc_db>(
       detail::art_key, value_view, olc_db &);
 
-  template <class>
-  friend struct detail::basic_leaf;
-
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
 


### PR DESCRIPTION
Previously leaves were raw byte arrays, with a helper struct that took care of
accessing "fields" in that array at known offsets. The reason for that was lack
of flexible array member support in C++.

Replace that implementation with an actual class with simulated-flexible array
member.