### PR TITLE
Make node_ptr independent from actual node classes

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -20,20 +20,12 @@ namespace detail {
 
 struct node_header;
 
-template <class, template <class> class, class, template <class> class,
-          template <class, class> class, template <class> class>
+template <class, template <class> class, class, class, template <class> class,
+          template <class, class> class,
+          template <class> class>
 struct basic_art_policy;  // IWYU pragma: keep
 
-class inode;
-
-class inode_4;
-class inode_16;
-class inode_48;
-class inode_256;
-
-using inode_defs = basic_inode_def<inode_4, inode_16, inode_48, inode_256>;
-
-using node_ptr = basic_node_ptr<node_header, inode, inode_defs>;
+using node_ptr = basic_node_ptr<node_header>;
 
 template <class Header, class Db>
 auto make_db_leaf_ptr(art_key, value_view, Db &);
@@ -54,9 +46,7 @@ class db final {
   // Querying
   [[nodiscard]] get_result get(key search_key) const noexcept;
 
-  [[nodiscard]] auto empty() const noexcept {
-    return root == nullptr;
-  }
+  [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
 
   // Modifying
   // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
@@ -166,7 +156,7 @@ class db final {
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
 
-  template <class, template <class> class, class, template <class> class,
+  template <class, template <class> class, class, class, template <class> class,
             template <class, class> class, template <class> class>
   friend struct detail::basic_art_policy;
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -22,35 +22,14 @@ namespace unodb {
 
 namespace detail {
 
-template <class>
-class basic_inode_4;  // IWYU pragma: keep
-
-template <class>
-class basic_inode_16;  // IWYU pragma: keep
-
-template <class>
-class basic_inode_48;  // IWYU pragma: keep
-
-template <class>
-class basic_inode_256;  // IWYU pragma: keep
-
-template <class, template <class> class, class, template <class> class,
-          template <class, class> class, template <class> class>
+template <class, template <class> class, class, class, template <class> class,
+          template <class, class> class,
+          template <class> class>
 struct basic_art_policy;  // IWYU pragma: keep
 
 struct olc_node_header;
 
-class olc_inode;
-
-class olc_inode_4;
-class olc_inode_16;
-class olc_inode_48;
-class olc_inode_256;
-
-using olc_inode_defs =
-    basic_inode_def<olc_inode_4, olc_inode_16, olc_inode_48, olc_inode_256>;
-
-using olc_node_ptr = basic_node_ptr<olc_node_header, olc_inode, olc_inode_defs>;
+using olc_node_ptr = basic_node_ptr<olc_node_header>;
 
 template <class>
 class db_inode_qsbr_deleter;  // IWYU pragma: keep
@@ -199,12 +178,7 @@ class olc_db final {
   }
 
   template <class INode>
-  constexpr void increment_inode_count() noexcept {
-    static_assert(detail::olc_inode_defs::is_inode<INode>());
-
-    node_counts[as_i<INode::type>].fetch_add(1, std::memory_order_relaxed);
-    increase_memory_use(sizeof(INode));
-  }
+  constexpr void increment_inode_count() noexcept;
 
   template <class INode>
   constexpr void decrement_inode_count() noexcept;
@@ -247,7 +221,7 @@ class olc_db final {
   template <class>
   friend class detail::db_inode_qsbr_deleter;
 
-  template <class, template <class> class, class, template <class> class,
+  template <class, template <class> class, class, class, template <class> class,
             template <class, class> class, template <class> class>
   friend struct detail::basic_art_policy;
 


### PR DESCRIPTION
This breaks (or makes the cycle much smaller) cyclic type dependencies.

- Move basic_inode_def instantiations to anonymous namespaces in art.cpp /
  olc_art.cpp source files.
- Likewise for concrete inode classes.
- Move basic_inode_def struct template from art_internal.hpp to
  art_internal_impl.hpp.
- Move dump_node to basic_art_policy so that it has access to concrete node
  types.