### PR TITLE
Make qsbr::assert_idle locking

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -111,7 +111,7 @@ void qsbr::unregister_thread(std::thread::id thread_id) {
 void qsbr::reset_stats() noexcept {
   std::lock_guard<std::mutex> guard{qsbr_mutex};
 
-  assert_idle();
+  assert_idle_locked();
   assert_invariants();
 
   deallocation_size_stats = {};

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -209,7 +209,15 @@ class qsbr final {
     return threads_in_previous_epoch;
   }
 
-  void assert_idle() noexcept {
+  void assert_idle() const noexcept {
+#ifndef NDEBUG
+    std::lock_guard guard{qsbr_mutex};
+    assert_idle_locked();
+#endif
+  }
+
+ private:
+  void assert_idle_locked() const noexcept {
 #ifndef NDEBUG
     // Copy-paste-tweak with expect_idle_qsbr, but not clear how to fix this:
     // here we are asserting over internals, over there we are using Google Test
@@ -232,7 +240,6 @@ class qsbr final {
 #endif
   }
 
- private:
   struct deallocation_request {
     // If memory usage becomes an issue, replace pool references with
     // pre-registered pools with tagged pointers

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,3 +3,9 @@ sonar.organization=laurynas-biveinis
 sonar.cfamily.compile-commands=compile_commands.json
 sonar.cfamily.threads=3
 sonar.cfamily.cache.enabled=false
+
+sonar.issue.ignore.multicriteria=e1
+
+# 'Replace this use of "std::lock_guard"" with "std::scoped_lock"'
+sonar.issue.ignore.multicriteria.e1.ruleKey=cpp:S5997
+sonar.issue.ignore.multicriteria.e1.resourceKey=**

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -11,9 +11,9 @@
 namespace unodb::test {
 
 void expect_idle_qsbr() {
-  // Copy-paste-tweak with qsbr::assert_idle, but not clear how to fix this:
-  // here we are using Google Test macros with the public interface, over there
-  // we are asserting over internals.
+  // Copy-paste-tweak with qsbr::assert_idle_locked, but not clear how to fix
+  // this: here we are using Google Test macros with the public interface, over
+  // there we are asserting over internals.
   EXPECT_TRUE(unodb::qsbr::instance().single_thread_mode());
   EXPECT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
   EXPECT_EQ(unodb::qsbr::instance().current_interval_size(), 0);


### PR DESCRIPTION
As pointed out by Sonatype Lift Infer checker, qsbr::assert_idle accesses fields
without locking. While it is always meant to be invoked in a single-threaded
context, the purpose of the asserts is to catch bugs, including when they are
called from multi-threaded context. Thus make it locking, and introduce a
private member function assert_idle_locked to be used when the lock is already
acquired.