### PR TITLE
Replace PMR with plain old heap allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,22 +167,6 @@ option(SANITIZE_UB "Enable UndefinedBehaviorSanitizer runtime checks")
 if(SANITIZE_UB)
   set_common_sanitizer_flags()
   list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=undefined")
-  # Boost library 1.72 on macOS from Homebrew produces the following error:
-  # SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
-  # /Users/laurynas/unodb/unodb/heap.hpp:83:8 in
-  # /usr/local/include/boost/container/pmr/memory_resource.hpp:49:20: runtime
-  # error: member call on address 0x000105abd0b
-  # 0 which does not point to an object of type
-  # 'boost::container::pmr::memory_resource'
-  # 0x000105abd0b0: note: object is of type
-  # 'boost::container::pmr::new_delete_resource_imp'
-  # It looks like it's because new_delete_resource_imp is not exported as a
-  # visible symbol in the library? I.e.
-  # https://bugs.llvm.org/show_bug.cgi?id=39191,
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80963
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    list(APPEND SANITIZER_CXX_FLAGS "-fno-sanitize=vptr")
-  endif()
   set(SANITIZER_LD_FLAGS "-fsanitize=undefined")
   string(CONCAT UBSAN_ENV "UBSAN_OPTIONS="
     "print_stacktrace=1:halt_on_error=1:abort_on_error=1")
@@ -197,21 +181,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  message(STATUS "Using GCC, using std::pmr instead of boost::pmr")
-else()
-  list(APPEND BOOST_COMPONENTS container)
-  # Workaround https://github.com/boostorg/boost_install/issues/13: Homebrew
-  # Boost 1.71 installs single-thread and MT build to the same prefix, resulting
-  # in -
-  # CMake Warning at /usr/local/lib/cmake/boost_container-1.71.0/libboost_container-variant-shared.cmake:59 (message):
-  # Target Boost::container already has an imported location
-  # '/usr/local/lib/libboost_container-mt.dylib', which will be overwritten
-  # with '/usr/local/lib/libboost_container.dylib'
-  set(Boost_NO_BOOST_CMAKE ON)
-endif()
-
-find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+find_package(Boost REQUIRED)
 
 string(REPLACE ";" " " CXX_FLAGS_FOR_SUBDIR_STR "${SANITIZER_CXX_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS ${CXX_FLAGS_FOR_SUBDIR_STR})

--- a/art.cpp
+++ b/art.cpp
@@ -24,17 +24,6 @@ static_assert(std::is_empty_v<node_header>);
 
 namespace {
 
-template <class INode>
-struct inode_pool_getter {
-  [[nodiscard]] static inline auto &get() {
-    static unodb::detail::pmr_unsynchronized_pool_resource inode_pool{
-        unodb::detail::get_inode_pool_options<INode>()};
-    return inode_pool;
-  }
-
-  inode_pool_getter() = delete;
-};
-
 class inode;
 class inode_4;
 class inode_16;
@@ -46,12 +35,11 @@ using inode_defs = unodb::detail::basic_inode_def<inode, inode_4, inode_16,
 
 template <class INode>
 using db_inode_deleter =
-    unodb::detail::basic_db_inode_deleter<INode, unodb::db, inode_pool_getter>;
+    unodb::detail::basic_db_inode_deleter<INode, unodb::db>;
 
 using art_policy = unodb::detail::basic_art_policy<
     unodb::db, unodb::in_fake_critical_section, unodb::detail::node_ptr,
-    inode_defs, db_inode_deleter, unodb::detail::basic_db_leaf_deleter,
-    inode_pool_getter>;
+    inode_defs, db_inode_deleter, unodb::detail::basic_db_leaf_deleter>;
 
 using inode_base = unodb::detail::basic_inode_impl<art_policy>;
 

--- a/art.hpp
+++ b/art.hpp
@@ -21,8 +21,7 @@ namespace detail {
 struct node_header;
 
 template <class, template <class> class, class, class, template <class> class,
-          template <class, class> class,
-          template <class> class>
+          template <class, class> class>
 struct basic_art_policy;  // IWYU pragma: keep
 
 using node_ptr = basic_node_ptr<node_header>;
@@ -163,10 +162,10 @@ class db final {
   friend class detail::basic_db_leaf_deleter;
 
   template <class, template <class> class, class, class, template <class> class,
-            template <class, class> class, template <class> class>
+            template <class, class> class>
   friend struct detail::basic_art_policy;
 
-  template <class, class, template <class> class>
+  template <class, class>
   friend class detail::basic_db_inode_deleter;
 
   friend struct detail::impl_helpers;

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -149,7 +149,7 @@ using basic_db_leaf_unique_ptr =
 template <class T>
 struct dependent_false : std::false_type {};
 
-template <class INode, class Db, template <class> class INodePoolGetter>
+template <class INode, class Db>
 class basic_db_inode_deleter {
  public:
   constexpr explicit basic_db_inode_deleter(Db &db_) noexcept : db{db_} {}

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -141,7 +141,7 @@ void allocate_pointer(std::size_t thread_i) {
 
   LOG(TRACE) << "Allocating pointer";
   auto *const new_ptr{static_cast<std::uint64_t *>(
-      unodb::detail::pmr_new_delete_resource()->allocate(sizeof(object_mem)))};
+      unodb::detail::allocate_aligned(sizeof(object_mem)))};
   *new_ptr = object_mem;
   allocated_pointers.insert(new_ptr);
 }
@@ -150,8 +150,7 @@ void deallocate_pointer(std::uint64_t *ptr) {
   ASSERT(!unodb::current_thread_reclamator().is_paused());
   ASSERT(*ptr == object_mem);
 
-  unodb::qsbr::instance().on_next_epoch_pool_deallocate(
-      *unodb::detail::pmr_new_delete_resource(), ptr, sizeof(object_mem));
+  unodb::qsbr::instance().on_next_epoch_deallocate(ptr, sizeof(object_mem));
 }
 
 void deallocate_pointer(std::size_t thread_i) {

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -23,8 +23,7 @@ namespace unodb {
 namespace detail {
 
 template <class, template <class> class, class, class, template <class> class,
-          template <class, class> class,
-          template <class> class>
+          template <class, class> class>
 struct basic_art_policy;  // IWYU pragma: keep
 
 struct olc_node_header;
@@ -222,10 +221,10 @@ class olc_db final {
   friend class detail::db_inode_qsbr_deleter;
 
   template <class, template <class> class, class, class, template <class> class,
-            template <class, class> class, template <class> class>
+            template <class, class> class>
   friend struct detail::basic_art_policy;
 
-  template <class, class, template <class> class>
+  template <class, class>
   friend class detail::basic_db_inode_deleter;
 
   friend struct detail::olc_impl_helpers;


### PR DESCRIPTION
Several reasons
- PMR was used incorrectly in unodb::db - if multiple db instances were created,
  unodb::db would use the same std::pmr::unsynchronized_pool_resource instance
  concurrently, without locking
- The direct heap allocation performance is better on overall