### PR TITLE
Cleanup attributes

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -15,7 +15,7 @@
 
 namespace unodb::detail {
 
-struct node_header {};
+struct [[nodiscard]] node_header {};
 
 static_assert(std::is_empty_v<node_header>);
 
@@ -74,7 +74,8 @@ struct impl_helpers {
 
 namespace {
 
-class inode_4 final : public unodb::detail::basic_inode_4<art_policy> {
+class [[nodiscard]] inode_4 final
+    : public unodb::detail::basic_inode_4<art_policy> {
  public:
   using basic_inode_4::basic_inode_4;
 
@@ -93,7 +94,8 @@ class inode_4 final : public unodb::detail::basic_inode_4<art_policy> {
 
 static_assert(sizeof(inode_4) == 48);
 
-class inode_16 final : public unodb::detail::basic_inode_16<art_policy> {
+class [[nodiscard]] inode_16 final
+    : public unodb::detail::basic_inode_16<art_policy> {
  public:
   using basic_inode_16::basic_inode_16;
 
@@ -112,7 +114,8 @@ class inode_16 final : public unodb::detail::basic_inode_16<art_policy> {
 
 static_assert(sizeof(inode_16) == 160);
 
-class inode_48 final : public unodb::detail::basic_inode_48<art_policy> {
+class [[nodiscard]] inode_48 final
+    : public unodb::detail::basic_inode_48<art_policy> {
  public:
   using basic_inode_48::basic_inode_48;
 
@@ -131,7 +134,8 @@ class inode_48 final : public unodb::detail::basic_inode_48<art_policy> {
 
 static_assert(sizeof(inode_48) == 656);
 
-class inode_256 final : public unodb::detail::basic_inode_256<art_policy> {
+class [[nodiscard]] inode_256 final
+    : public unodb::detail::basic_inode_256<art_policy> {
  public:
   using basic_inode_256::basic_inode_256;
 

--- a/art.hpp
+++ b/art.hpp
@@ -27,7 +27,7 @@ struct basic_art_policy;  // IWYU pragma: keep
 using node_ptr = basic_node_ptr<node_header>;
 
 template <class Header, class Db>
-auto make_db_leaf_ptr(art_key, value_view, Db &);
+[[nodiscard]] auto make_db_leaf_ptr(art_key, value_view, Db &);
 
 struct impl_helpers;
 
@@ -49,9 +49,11 @@ class db final {
   db &operator=(db &&) = delete;
 
   // Querying
-  [[nodiscard]] get_result get(key search_key) const noexcept;
+  [[nodiscard, gnu::pure]] get_result get(key search_key) const noexcept;
 
-  [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
+  [[nodiscard, gnu::pure]] auto empty() const noexcept {
+    return root == nullptr;
+  }
 
   // Modifying
   // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
@@ -64,43 +66,49 @@ class db final {
   // Stats
 
   // Return current memory use by tree nodes in bytes.
-  [[nodiscard]] constexpr auto get_current_memory_use() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_current_memory_use()
+      const noexcept {
     return current_memory_use;
   }
 
   template <node_type NodeType>
-  [[nodiscard]] constexpr auto get_node_count() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_node_count() const noexcept {
     return node_counts[as_i<NodeType>];
   }
 
-  [[nodiscard]] constexpr auto get_node_counts() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_node_counts() const noexcept {
     return node_counts;
   }
 
   template <node_type NodeType>
-  [[nodiscard]] constexpr auto get_growing_inode_count() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_growing_inode_count()
+      const noexcept {
     return growing_inode_counts[internal_as_i<NodeType>];
   }
 
-  [[nodiscard]] constexpr auto get_growing_inode_counts() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_growing_inode_counts()
+      const noexcept {
     return growing_inode_counts;
   }
 
   template <node_type NodeType>
-  [[nodiscard]] constexpr auto get_shrinking_inode_count() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_shrinking_inode_count()
+      const noexcept {
     return shrinking_inode_counts[internal_as_i<NodeType>];
   }
 
-  [[nodiscard]] constexpr auto get_shrinking_inode_counts() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_shrinking_inode_counts()
+      const noexcept {
     return shrinking_inode_counts;
   }
 
-  [[nodiscard]] constexpr auto get_key_prefix_splits() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto get_key_prefix_splits()
+      const noexcept {
     return key_prefix_splits;
   }
 
   // Public utils
-  [[nodiscard]] static constexpr auto key_found(
+  [[nodiscard, gnu::const]] static constexpr auto key_found(
       const get_result &result) noexcept {
     return static_cast<bool>(result);
   }

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -19,15 +19,15 @@ namespace unodb::detail {
 
 // Forward declarations to use in unodb::db and its siblings
 template <class>
-class basic_leaf;  // IWYU pragma: keep
+class [[nodiscard]] basic_leaf;  // IWYU pragma: keep
 
 template <class, class>
-class basic_db_leaf_deleter;  // IWYU pragma: keep
+class [[nodiscard]] basic_db_leaf_deleter;  // IWYU pragma: keep
 
 // Internal ART key in binary-comparable format
 template <typename KeyType>
-struct basic_art_key final {
-  [[nodiscard]] static constexpr KeyType make_binary_comparable(
+struct [[nodiscard]] basic_art_key final {
+  [[nodiscard, gnu::const]] static constexpr KeyType make_binary_comparable(
       KeyType key) noexcept;
 
   constexpr basic_art_key() noexcept = default;
@@ -47,18 +47,18 @@ struct basic_art_key final {
     std::memcpy(to, &key, size);
   }
 
-  [[nodiscard]] constexpr bool operator==(
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
       // NOLINTNEXTLINE(modernize-avoid-c-arrays)
       const std::byte key2[]) const noexcept {
     return !std::memcmp(&key, key2, size);
   }
 
-  [[nodiscard]] constexpr bool operator==(
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
       basic_art_key<KeyType> key2) const noexcept {
     return !std::memcmp(&key, &key2.key, size);
   }
 
-  [[nodiscard]] constexpr bool operator!=(
+  [[nodiscard, gnu::pure]] constexpr bool operator!=(
       basic_art_key<KeyType> key2) const noexcept {
     return std::memcmp(&key, &key2.key, size);
   }
@@ -70,7 +70,8 @@ struct basic_art_key final {
     return (reinterpret_cast<const std::byte *>(&key))[index];
   }
 
-  [[nodiscard]] constexpr explicit operator KeyType() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr explicit operator KeyType()
+      const noexcept {
     return key;
   }
 
@@ -95,7 +96,7 @@ using art_key = basic_art_key<unodb::key>;
 [[gnu::cold, gnu::noinline]] std::ostream &operator<<(std::ostream &os,
                                                       art_key key);
 
-class tree_depth final {
+class [[nodiscard]] tree_depth final {
  public:
   using value_type = unsigned;
 
@@ -105,7 +106,7 @@ class tree_depth final {
   }
 
   // NOLINTNEXTLINE(google-explicit-constructor)
-  [[nodiscard]] constexpr operator value_type() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr operator value_type() const noexcept {
     assert(value <= art_key::size);
     return value;
   }
@@ -136,7 +137,7 @@ class basic_db_leaf_deleter {
 
   void operator()(leaf_type *to_delete) const noexcept;
 
-  [[nodiscard]] Db &get_db() const noexcept { return db; }
+  [[nodiscard, gnu::pure]] Db &get_db() const noexcept { return db; }
 
  private:
   Db &db;
@@ -156,14 +157,14 @@ class basic_db_inode_deleter {
 
   void operator()(INode *inode_ptr) noexcept;
 
-  [[nodiscard]] Db &get_db() noexcept { return db; }
+  [[nodiscard, gnu::pure]] Db &get_db() noexcept { return db; }
 
  private:
   Db &db;
 };
 
 template <class Header>
-class basic_node_ptr {
+class [[nodiscard]] basic_node_ptr {
  public:
   using header_type = Header;
 
@@ -192,19 +193,19 @@ class basic_node_ptr {
     return reinterpret_cast<Header *>(tagged_ptr & ptr_bit_mask);
   }
 
-  [[nodiscard]] auto operator==(std::nullptr_t) const noexcept {
+  [[nodiscard, gnu::pure]] auto operator==(std::nullptr_t) const noexcept {
     return tagged_ptr == reinterpret_cast<std::uintptr_t>(nullptr);
   }
 
-  [[nodiscard]] auto operator!=(std::nullptr_t) const noexcept {
+  [[nodiscard, gnu::pure]] auto operator!=(std::nullptr_t) const noexcept {
     return tagged_ptr != reinterpret_cast<std::uintptr_t>(nullptr);
   }
 
  private:
   std::uintptr_t tagged_ptr;
 
-  [[nodiscard]] static std::uintptr_t tag_ptr(Header *ptr_,
-                                              unodb::node_type tag) {
+  [[nodiscard, gnu::const]] static std::uintptr_t tag_ptr(
+      Header *ptr_, unodb::node_type tag) {
     const auto uintptr = reinterpret_cast<std::uintptr_t>(ptr_);
     const auto result =
         uintptr | static_cast<std::underlying_type_t<decltype(tag)>>(tag);
@@ -212,7 +213,8 @@ class basic_node_ptr {
     return result;
   }
 
-  static constexpr unsigned mask_bits_needed(unsigned count) {
+  [[nodiscard, gnu::const]] static constexpr unsigned mask_bits_needed(
+      unsigned count) {
     return count < 2 ? 1 : 1 + mask_bits_needed(count >> 1U);
   }
 

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -37,12 +37,12 @@ constexpr void concurrency_ranges32(::benchmark::internal::Benchmark *b) {
 }
 
 template <typename T>
-constexpr auto to_counter(T value) {
+[[nodiscard]] constexpr auto to_counter(T value) {
   return ::benchmark::Counter{static_cast<double>(value)};
 }
 
 template <class Db, class Thread>
-class concurrent_benchmark {
+class [[nodiscard]] concurrent_benchmark {
  protected:
   UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-final-methods")
   virtual void setup() {}

--- a/benchmark/micro_benchmark_mutex.cpp
+++ b/benchmark/micro_benchmark_mutex.cpp
@@ -11,7 +11,7 @@
 
 namespace {
 
-class concurrent_benchmark_mutex final
+class [[nodiscard]] concurrent_benchmark_mutex final
     : public unodb::benchmark::concurrent_benchmark<unodb::mutex_db,
                                                     std::thread> {};
 

--- a/benchmark/micro_benchmark_n4.cpp
+++ b/benchmark/micro_benchmark_n4.cpp
@@ -20,7 +20,7 @@
 namespace {
 
 template <unsigned NodeSize>
-std::vector<unodb::key> make_n_key_sequence(std::size_t n) {
+[[nodiscard]] std::vector<unodb::key> make_n_key_sequence(std::size_t n) {
   std::vector<unodb::key> result;
   result.reserve(n);
 
@@ -34,8 +34,8 @@ std::vector<unodb::key> make_n_key_sequence(std::size_t n) {
   return result;
 }
 
-std::vector<unodb::key> make_limited_key_sequence(unodb::key limit,
-                                                  std::uint64_t key_zero_bits) {
+[[nodiscard]] std::vector<unodb::key> make_limited_key_sequence(
+    unodb::key limit, std::uint64_t key_zero_bits) {
   std::vector<unodb::key> result;
 
   unodb::key insert_key = 0;

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -28,7 +28,7 @@ namespace unodb::benchmark {
 // Key manipulation with key zero bits
 
 template <unsigned NodeSize>
-constexpr auto node_size_to_key_zero_bits() noexcept {
+[[nodiscard]] constexpr auto node_size_to_key_zero_bits() noexcept {
   static_assert(NodeSize == 2 || NodeSize == 4 || NodeSize == 16 ||
                 NodeSize == 256);
   if constexpr (NodeSize == 2) {
@@ -41,7 +41,8 @@ constexpr auto node_size_to_key_zero_bits() noexcept {
   return 0ULL;
 }
 
-constexpr auto next_key(unodb::key k, std::uint64_t key_zero_bits) noexcept {
+[[nodiscard]] constexpr auto next_key(unodb::key k,
+                                      std::uint64_t key_zero_bits) noexcept {
   assert((k & key_zero_bits) == 0);
 
   const auto result = ((k | key_zero_bits) + 1) & ~key_zero_bits;
@@ -54,7 +55,7 @@ constexpr auto next_key(unodb::key k, std::uint64_t key_zero_bits) noexcept {
 
 // PRNG
 
-class batched_prng final {
+class [[nodiscard]] batched_prng final {
   using result_type = std::uint64_t;
 
  public:
@@ -64,7 +65,7 @@ class batched_prng final {
     refill();
   }
 
-  auto get(::benchmark::State &state) {
+  [[nodiscard]] auto get(::benchmark::State &state) {
     if (random_key_ptr == random_keys.cend()) {
       state.PauseTiming();
       refill();
@@ -93,7 +94,7 @@ namespace detail {
 // Node sizes
 
 template <unsigned NodeCapacity>
-constexpr auto node_capacity_to_minimum_size() noexcept {
+[[nodiscard]] constexpr auto node_capacity_to_minimum_size() noexcept {
   static_assert(NodeCapacity == 16 || NodeCapacity == 48 ||
                 NodeCapacity == 256);
   if constexpr (NodeCapacity == 16) {
@@ -105,20 +106,20 @@ constexpr auto node_capacity_to_minimum_size() noexcept {
 }
 
 template <unsigned NodeCapacity>
-constexpr auto node_capacity_over_minimum() noexcept {
+[[nodiscard]] constexpr auto node_capacity_over_minimum() noexcept {
   static_assert(NodeCapacity == 16 || NodeCapacity == 48 ||
                 NodeCapacity == 256);
   return NodeCapacity - node_capacity_to_minimum_size<NodeCapacity>();
 }
 
 template <unsigned NodeSize>
-constexpr auto node_size_has_key_zero_bits() noexcept {
+[[nodiscard]] constexpr auto node_size_has_key_zero_bits() noexcept {
   // If node size is a power of two, then can use key zero bit-based operations
   return (NodeSize & (NodeSize - 1)) == 0;
 }
 
 template <unsigned NodeSize>
-constexpr auto node_size_to_node_type() noexcept {
+[[nodiscard]] constexpr auto node_size_to_node_type() noexcept {
   static_assert(NodeSize == 2 || NodeSize == 4 || NodeSize == 16 ||
                 NodeSize == 48 || NodeSize == 256);
   if constexpr (NodeSize == 2 || NodeSize == 4) return node_type::I4;
@@ -130,7 +131,7 @@ constexpr auto node_size_to_node_type() noexcept {
 #ifndef NDEBUG
 
 template <unsigned SmallerNodeSize>
-constexpr auto node_size_to_larger_node_type() noexcept {
+[[nodiscard]] constexpr auto node_size_to_larger_node_type() noexcept {
   static_assert(SmallerNodeSize == 4 || SmallerNodeSize == 16 ||
                 SmallerNodeSize == 48);
   if constexpr (SmallerNodeSize == 4) return node_type::I16;
@@ -143,11 +144,12 @@ constexpr auto node_size_to_larger_node_type() noexcept {
 // Key manipulation
 
 template <unsigned B, unsigned S, unsigned O>
-constexpr auto to_scaled_base_n_value(std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr auto to_scaled_base_n_value(
+    std::uint64_t i) noexcept {
   assert(i / (static_cast<std::uint64_t>(B) * B * B * B * B * B * B) < B);
   return (i % B * S + O) | (i / B % B * S + O) << 8U |
-         ((i / (B * B) % B * S + O) << 16U) |
-         ((i / (B * B * B) % B * S + O) << 24U) |
+         ((i / (static_cast<std::uint64_t>(B) * B) % B * S + O) << 16U) |
+         ((i / (static_cast<std::uint64_t>(B) * B * B) % B * S + O) << 24U) |
          ((i / (static_cast<std::uint64_t>(B) * B * B * B) % B * S + O)
           << 32U) |
          ((i / (static_cast<std::uint64_t>(B) * B * B * B * B) % B * S + O)
@@ -160,24 +162,27 @@ constexpr auto to_scaled_base_n_value(std::uint64_t i) noexcept {
 }
 
 template <unsigned B>
-constexpr auto to_base_n_value(std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr auto to_base_n_value(
+    std::uint64_t i) noexcept {
   assert(i / (static_cast<std::uint64_t>(B) * B * B * B * B * B * B) < B);
   return to_scaled_base_n_value<B, 1, 0>(i);
 }
 
 template <unsigned NodeSize>
-constexpr auto number_to_full_node_size_tree_key(std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr auto number_to_full_node_size_tree_key(
+    std::uint64_t i) noexcept {
   return to_base_n_value<NodeSize>(i);
 }
 
 template <unsigned NodeSize>
-constexpr auto number_to_minimal_node_size_tree_key(std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr auto number_to_minimal_node_size_tree_key(
+    std::uint64_t i) noexcept {
   return to_base_n_value<node_capacity_to_minimum_size<NodeSize>()>(i);
 }
 
 template <unsigned NodeSize>
-constexpr auto number_to_full_leaf_over_minimal_tree_key(
-    std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr auto
+number_to_full_leaf_over_minimal_tree_key(std::uint64_t i) noexcept {
   constexpr auto min = node_capacity_to_minimum_size<NodeSize>();
   constexpr auto delta = node_capacity_over_minimum<NodeSize>();
   assert(i / (delta * min * min * min * min * min * min) < min);
@@ -186,15 +191,15 @@ constexpr auto number_to_full_leaf_over_minimal_tree_key(
 }
 
 template <unsigned NodeSize>
-constexpr auto number_to_minimal_leaf_over_smaller_node_tree(
-    std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr auto
+number_to_minimal_leaf_over_smaller_node_tree(std::uint64_t i) noexcept {
   constexpr auto N = static_cast<std::uint64_t>(NodeSize);
   assert(i / (N * N * N * N * N * N) < N);
   return N | number_to_full_node_size_tree_key<N>(i) << 8U;
 }
 
 template <unsigned NodeSize>
-constexpr auto number_to_full_node_tree_with_gaps_key(
+[[nodiscard, gnu::const]] constexpr auto number_to_full_node_tree_with_gaps_key(
     std::uint64_t i) noexcept {
   static_assert(NodeSize == 4 || NodeSize == 16 || NodeSize == 48);
   // Full Node4 tree keys with 1, 3, 5, & 7 as the different key byte values
@@ -213,8 +218,8 @@ constexpr auto number_to_full_node_tree_with_gaps_key(
 // Key vectors
 
 template <typename NumberToKeyFn>
-auto generate_keys_to_limit(unodb::key key_limit,
-                            NumberToKeyFn number_to_key_fn) {
+[[nodiscard]] auto generate_keys_to_limit(unodb::key key_limit,
+                                          NumberToKeyFn number_to_key_fn) {
   std::vector<unodb::key> result;
   std::uint64_t i = 0;
   while (true) {
@@ -227,8 +232,8 @@ auto generate_keys_to_limit(unodb::key key_limit,
 }
 
 template <std::uint8_t NumByteValues>
-std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
-    unodb::key key_limit) {
+[[nodiscard]] std::vector<unodb::key>
+generate_random_keys_over_full_smaller_tree(unodb::key key_limit) {
   // The last byte at the limit will be randomly-generated and may happen to
   // fall above or below the limit. Reset the limit so that any byte value will
   // pass.
@@ -282,7 +287,7 @@ std::vector<unodb::key> generate_random_keys_over_full_smaller_tree(
 // Stats
 
 template <class Db>
-struct tree_stats final {
+struct [[nodiscard]] tree_stats final {
   constexpr tree_stats() noexcept = default;
 
   explicit constexpr tree_stats(const Db &test_db) noexcept
@@ -296,11 +301,12 @@ struct tree_stats final {
     key_prefix_splits = test_db.get_key_prefix_splits();
   }
 
-  constexpr bool operator==(const tree_stats<Db> &other) const noexcept {
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
+      const tree_stats<Db> &other) const noexcept {
     return node_counts == other.node_counts;
   }
 
-  constexpr bool internal_levels_equal(
+  [[nodiscard, gnu::pure]] constexpr bool internal_levels_equal(
       const tree_stats<Db> &other) const noexcept {
     return node_counts[unodb::as_i<unodb::node_type::I4>] ==
                other.node_counts[unodb::as_i<unodb::node_type::I4>] &&
@@ -320,7 +326,7 @@ struct tree_stats final {
 };
 
 template <class Db>
-class growing_tree_node_stats final {
+class [[nodiscard]] growing_tree_node_stats final {
  public:
   constexpr void get(const Db &test_db) noexcept {
     stats.get(test_db);
@@ -440,7 +446,7 @@ void assert_shrinking_nodes(
 }
 
 template <class Db>
-class tree_shape_snapshot final {
+class [[nodiscard]] tree_shape_snapshot final {
  public:
   explicit constexpr tree_shape_snapshot(
       const Db &test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept
@@ -493,8 +499,8 @@ void insert_keys(Db &db, const std::vector<unodb::key> &keys) {
 namespace detail {
 
 template <class Db, typename NumberToKeyFn>
-auto insert_keys_to_limit(Db &db, unodb::key key_limit,
-                          NumberToKeyFn number_to_key_fn) {
+[[nodiscard]] auto insert_keys_to_limit(Db &db, unodb::key key_limit,
+                                        NumberToKeyFn number_to_key_fn) {
   std::uint64_t i{0};
   while (true) {
     unodb::key key = number_to_key_fn(i);
@@ -506,7 +512,8 @@ auto insert_keys_to_limit(Db &db, unodb::key key_limit,
 }
 
 template <class Db, typename NumberToKeyFn>
-auto insert_n_keys(Db &db, unsigned n, NumberToKeyFn number_to_key_fn) {
+[[nodiscard]] auto insert_n_keys(Db &db, unsigned n,
+                                 NumberToKeyFn number_to_key_fn) {
   unodb::key last_inserted_key{0};
 
   for (decltype(n) i = 0; i < n; ++i) {
@@ -518,8 +525,8 @@ auto insert_n_keys(Db &db, unsigned n, NumberToKeyFn number_to_key_fn) {
 }
 
 template <class Db, unsigned NodeSize, typename NumberToKeyFn>
-auto insert_n_keys_to_empty_tree(Db &db, unsigned n,
-                                 NumberToKeyFn number_to_key_fn) {
+[[nodiscard]] auto insert_n_keys_to_empty_tree(Db &db, unsigned n,
+                                               NumberToKeyFn number_to_key_fn) {
   assert(db.empty());
   const auto result = insert_n_keys(db, n, number_to_key_fn);
   assert_dominating_inode_size_tree<Db, NodeSize>(db);
@@ -541,8 +548,8 @@ auto make_full_node_size_tree(Db &db, unsigned key_count) {
 }
 
 template <class Db, unsigned NodeCapacity>
-std::tuple<unodb::key, const tree_shape_snapshot<Db>> make_base_tree_for_add(
-    Db &test_db, unsigned node_count) {
+[[nodiscard]] std::tuple<unodb::key, const tree_shape_snapshot<Db>>
+make_base_tree_for_add(Db &test_db, unsigned node_count) {
   const auto key_limit = insert_n_keys_to_empty_tree<
       Db, NodeCapacity,
       decltype(number_to_minimal_node_size_tree_key<NodeCapacity>)>(
@@ -552,7 +559,7 @@ std::tuple<unodb::key, const tree_shape_snapshot<Db>> make_base_tree_for_add(
 }
 
 template <class Db, unsigned NodeSize>
-auto make_minimal_node_size_tree(Db &db, unsigned key_count) {
+[[nodiscard]] auto make_minimal_node_size_tree(Db &db, unsigned key_count) {
   return insert_n_keys_to_empty_tree<
       Db, NodeSize, decltype(number_to_minimal_node_size_tree_key<NodeSize>)>(
       db, key_count * node_capacity_to_minimum_size<NodeSize>(),
@@ -560,8 +567,8 @@ auto make_minimal_node_size_tree(Db &db, unsigned key_count) {
 }
 
 template <class Db, unsigned SmallerNodeSize>
-auto grow_full_node_tree_to_minimal_next_size_leaf_level(Db &db,
-                                                         unodb::key key_limit) {
+[[nodiscard]] auto grow_full_node_tree_to_minimal_next_size_leaf_level(
+    Db &db, unodb::key key_limit) {
   static_assert(SmallerNodeSize == 4 || SmallerNodeSize == 16 ||
                 SmallerNodeSize == 48);
 
@@ -593,8 +600,8 @@ auto grow_full_node_tree_to_minimal_next_size_leaf_level(Db &db,
 // Gets
 
 template <class Db, typename NumberToKeyFn>
-auto get_key_loop(Db &db, unodb::key key_limit,
-                  NumberToKeyFn number_to_key_fn) {
+[[nodiscard]] auto get_key_loop(Db &db, unodb::key key_limit,
+                                NumberToKeyFn number_to_key_fn) {
   std::uint64_t i{0};
   while (true) {
     const auto key = number_to_key_fn(i);

--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 
-class concurrent_benchmark_olc final
+class [[nodiscard]] concurrent_benchmark_olc final
     : public unodb::benchmark::concurrent_benchmark<unodb::olc_db,
                                                     unodb::qsbr_thread> {
  private:

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -42,7 +42,7 @@ inline constexpr std::array<unodb::value_view, 5> values = {
 
 // PRNG
 
-inline auto &get_prng() {
+[[nodiscard]] inline auto &get_prng() {
   static std::random_device rd;
   static std::mt19937 gen{rd()};
   return gen;

--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -13,12 +13,13 @@
 #define UNODB_START_DEEPSTATE_TESTS() \
   UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wmissing-noreturn")
 
-inline std::size_t DeepState_SizeTInRange(std::size_t min, std::size_t max) {
+[[nodiscard]] inline std::size_t DeepState_SizeTInRange(std::size_t min,
+                                                        std::size_t max) {
   return DeepState_UInt64InRange(min, max);
 }
 
 template <class T>
-auto DeepState_ContainerIndex(const T &container) {
+[[nodiscard]] auto DeepState_ContainerIndex(const T &container) {
   ASSERT(!container.empty());
   return DeepState_SizeTInRange(0, std::size(container) - 1);
 }

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -30,7 +30,7 @@ using dynamic_value = std::vector<std::byte>;
 
 using values_type = std::vector<dynamic_value>;
 
-auto make_random_value(dynamic_value::size_type length) {
+[[nodiscard]] auto make_random_value(dynamic_value::size_type length) {
   dynamic_value result{length};
   for (dynamic_value::size_type i = 0; i < length; i++) {
     // Ideally we would take random bytes from DeepState, but we'd end up
@@ -41,7 +41,8 @@ auto make_random_value(dynamic_value::size_type length) {
   return result;
 }
 
-auto get_value(dynamic_value::size_type max_length, values_type &values) {
+[[nodiscard]] auto get_value(dynamic_value::size_type max_length,
+                             values_type &values) {
   const auto make_new_value = values.empty() || DeepState_Bool();
   ASSERT(max_length <= std::numeric_limits<std::uint32_t>::max());
   if (make_new_value) {
@@ -59,8 +60,8 @@ auto get_value(dynamic_value::size_type max_length, values_type &values) {
   return unodb::value_view{existing_value};
 }
 
-unodb::key get_key(unodb::key max_key_value,
-                   const std::vector<unodb::key> &keys) {
+[[nodiscard]] unodb::key get_key(unodb::key max_key_value,
+                                 const std::vector<unodb::key> &keys) {
   const auto use_existing_key = !keys.empty() && DeepState_Bool();
   if (use_existing_key) {
     ASSERT(!keys.empty());

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -27,17 +27,10 @@ constexpr auto max_thread_id{102400};
 
 constexpr std::uint64_t object_mem = 0xAABBCCDD22446688ULL;
 
-enum class thread_operation {
-  ALLOCATE_POINTER,
-  DEALLOCATE_POINTER,
-  TAKE_ACTIVE_POINTER,
-  RELEASE_ACTIVE_POINTER,
-  QUIESCENT_STATE,
-  QUIT_THREAD,
-  PAUSE_THREAD,
-  RESUME_THREAD,
-  RESET_STATS
-};
+enum class [[nodiscard]] thread_operation{
+    ALLOCATE_POINTER,       DEALLOCATE_POINTER, TAKE_ACTIVE_POINTER,
+    RELEASE_ACTIVE_POINTER, QUIESCENT_STATE,    QUIT_THREAD,
+    PAUSE_THREAD,           RESUME_THREAD,      RESET_STATS};
 
 thread_operation thread_op;
 std::size_t op_thread_i;
@@ -46,7 +39,7 @@ std::unordered_set<std::uint64_t *> allocated_pointers;
 
 using active_pointers = std::vector<unodb::qsbr_ptr<std::uint64_t>>;
 
-struct thread_info {
+struct [[nodiscard]] thread_info final {
   unodb::qsbr_thread thread;
   std::size_t id{SIZE_MAX};
   bool is_paused{false};
@@ -81,7 +74,7 @@ std::array<unodb::detail::thread_sync, max_thread_id> thread_sync;
 std::size_t new_thread_id{1};
 
 template <class T>
-std::pair<typename T::difference_type, typename T::iterator>
+[[nodiscard]] std::pair<typename T::difference_type, typename T::iterator>
 randomly_advanced_pos_and_iterator(T &container) {
   auto itr{container.begin()};
   auto i{static_cast<typename T::difference_type>(
@@ -90,9 +83,9 @@ randomly_advanced_pos_and_iterator(T &container) {
   return std::make_pair(i, std::move(itr));
 }
 
-auto choose_thread() { return DeepState_ContainerIndex(threads); }
+[[nodiscard]] auto choose_thread() { return DeepState_ContainerIndex(threads); }
 
-auto choose_non_main_thread() {
+[[nodiscard]] auto choose_non_main_thread() {
   ASSERT(threads.size() >= 2);
   return DeepState_SizeTInRange(1, threads.size() - 1);
 }

--- a/heap.hpp
+++ b/heap.hpp
@@ -40,7 +40,7 @@ template <typename T>
                   static_cast<std::size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__));
 }
 
-inline void* allocate_aligned(
+[[nodiscard]] inline void* allocate_aligned(
     std::size_t size,
     std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
   void* result;

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -13,7 +13,7 @@ namespace unodb {
 // loads and stores are direct instead of relaxed atomic. It enables having a
 // common templatized implementation of single-threaded and OLC node algorithms.
 template <typename T>
-class in_fake_critical_section final {
+class [[nodiscard]] in_fake_critical_section final {
  public:
   constexpr in_fake_critical_section() noexcept = default;
   // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
@@ -46,20 +46,22 @@ class in_fake_critical_section final {
 
   template <typename T_ = T,
             typename = std::enable_if_t<!std::is_integral_v<T_>>>
-  [[nodiscard]] constexpr auto operator==(std::nullptr_t) const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto operator==(
+      std::nullptr_t) const noexcept {
     return value == nullptr;
   }
 
   template <typename T_ = T,
             typename = std::enable_if_t<!std::is_integral_v<T_>>>
-  [[nodiscard]] constexpr auto operator!=(std::nullptr_t) const noexcept {
+  [[nodiscard, gnu::pure]] constexpr auto operator!=(
+      std::nullptr_t) const noexcept {
     return value != nullptr;
   }
 
   // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
-  constexpr operator T() const noexcept { return value; }
+  [[nodiscard]] constexpr operator T() const noexcept { return value; }
 
-  constexpr T load() const noexcept { return value; }
+  [[nodiscard]] constexpr T load() const noexcept { return value; }
 
  private:
   T value;

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -10,7 +10,7 @@
 
 namespace unodb {
 
-enum class node_type : std::uint8_t { LEAF, I4, I16, I48, I256 };
+enum class [[nodiscard]] node_type : std::uint8_t{LEAF, I4, I16, I48, I256};
 
 namespace detail {
 

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -19,7 +19,7 @@
 
 namespace unodb::detail {
 
-struct olc_node_header {
+struct [[nodiscard]] olc_node_header {
   [[nodiscard]] constexpr optimistic_lock &lock() const noexcept {
     return m_lock;
   }
@@ -131,7 +131,7 @@ template <class INode>
 }
 
 template <class T>
-std::remove_reference_t<T> &&obsolete_and_move(
+[[nodiscard]] std::remove_reference_t<T> &&obsolete_and_move(
     T &&t, unodb::optimistic_lock::write_guard &&guard) noexcept {
   assert(guard.guards(lock(*t)));
 
@@ -143,7 +143,7 @@ std::remove_reference_t<T> &&obsolete_and_move(
   return static_cast<std::remove_reference_t<T> &&>(t);
 }
 
-inline auto obsolete_child_by_index(
+[[nodiscard]] inline auto obsolete_child_by_index(
     std::uint8_t child, unodb::optimistic_lock::write_guard &&guard) noexcept {
   guard.unlock_and_obsolete();
 
@@ -202,7 +202,8 @@ struct olc_impl_helpers {
 
 namespace {
 
-class olc_inode_4 final : public unodb::detail::basic_inode_4<olc_art_policy> {
+class [[nodiscard]] olc_inode_4 final
+    : public unodb::detail::basic_inode_4<olc_art_policy> {
   using parent_class = basic_inode_4<olc_art_policy>;
 
  public:
@@ -274,8 +275,8 @@ class olc_inode_4 final : public unodb::detail::basic_inode_4<olc_art_policy> {
     basic_inode_4::remove(child_index, db_instance);
   }
 
-  auto leave_last_child(std::uint8_t child_to_delete,
-                        unodb::olc_db &db_instance) noexcept {
+  [[nodiscard]] auto leave_last_child(std::uint8_t child_to_delete,
+                                      unodb::olc_db &db_instance) noexcept {
     assert(::lock(*this).is_obsoleted_by_this_thread());
     assert(node_ptr_lock(children[child_to_delete].load())
                .is_obsoleted_by_this_thread());
@@ -297,7 +298,7 @@ static_assert(sizeof(olc_inode_4) == 48 + 8);
 static_assert(sizeof(olc_inode_4) == 48 + 24);
 #endif
 
-class olc_inode_16 final
+class [[nodiscard]] olc_inode_16 final
     : public unodb::detail::basic_inode_16<olc_art_policy> {
   using parent_class = basic_inode_16<olc_art_policy>;
 
@@ -405,7 +406,7 @@ olc_inode_4::olc_inode_4(
       std::move(source_node_guard), child_to_delete, std::move(child_guard));
 }
 
-class olc_inode_48 final
+class [[nodiscard]] olc_inode_48 final
     : public unodb::detail::basic_inode_48<olc_art_policy> {
   using parent_class = basic_inode_48<olc_art_policy>;
 
@@ -499,7 +500,7 @@ olc_inode_16::olc_inode_16(
   assert(!child_guard.active());
 }
 
-class olc_inode_256 final
+class [[nodiscard]] olc_inode_256 final
     : public unodb::detail::basic_inode_256<olc_art_policy> {
   using parent_class = basic_inode_256<olc_art_policy>;
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -37,7 +37,7 @@ template <class, class>
 class db_leaf_qsbr_deleter;  // IWYU pragma: keep
 
 template <class Header, class Db>
-auto make_db_leaf_ptr(art_key, value_view, Db &);
+[[nodiscard]] auto make_db_leaf_ptr(art_key, value_view, Db &);
 
 struct olc_impl_helpers;
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -49,7 +49,7 @@ namespace unodb {
 // safe destruction in concurrent containers" ever gets anywhere, consider
 // changing to its interface, like Stamp-it paper does.
 
-class qsbr_per_thread final {
+class [[nodiscard]] qsbr_per_thread final {
  public:
   qsbr_per_thread() noexcept;
 
@@ -63,7 +63,7 @@ class qsbr_per_thread final {
 
   void resume();
 
-  [[nodiscard]] bool is_paused() const noexcept { return paused; }
+  [[nodiscard, gnu::pure]] bool is_paused() const noexcept { return paused; }
 
   qsbr_per_thread(const qsbr_per_thread &) = delete;
   qsbr_per_thread(qsbr_per_thread &&) = delete;
@@ -235,7 +235,7 @@ class qsbr final {
 #endif
   }
 
-  struct deallocation_request {
+  struct [[nodiscard]] deallocation_request final {
     void *const pointer;
 
 #ifndef NDEBUG
@@ -260,7 +260,7 @@ class qsbr final {
     }
   };
 
-  class deferred_requests {
+  class [[nodiscard]] deferred_requests final {
    public:
     std::array<std::vector<deallocation_request>, 2> requests;
 
@@ -323,7 +323,7 @@ class qsbr final {
 
   void assert_invariants() const noexcept;
 
-  deferred_requests make_deferred_requests() const noexcept {
+  [[nodiscard]] deferred_requests make_deferred_requests() const noexcept {
     return deferred_requests{
 #ifndef NDEBUG
         get_current_epoch(), single_thread_mode_locked()
@@ -415,7 +415,7 @@ struct quiescent_state_on_scope_exit final {
 
 // Replace with C++20 std::remove_cvref once it's available
 template <typename T>
-struct remove_cvref {
+struct remove_cvref final {
   using type = std::remove_cv_t<std::remove_reference_t<T>>;
 };
 
@@ -424,7 +424,7 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 
 // All the QSBR users must use qsbr_thread instead of std::thread so that
 // a thread-local current_thread_reclamator instance gets properly constructed
-class qsbr_thread : public std::thread {
+class [[nodiscard]] qsbr_thread : public std::thread {
  public:
   using thread::thread;
 

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -29,7 +29,7 @@ class qsbr_ptr_base {
 // build. A smart pointer class that provides a raw pointer-like interface.
 // Implemented bare minimum to get things to work, expand as necessary.
 template <class T>
-class qsbr_ptr : public detail::qsbr_ptr_base {
+class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
  public:
   using pointer_type = T *;
 
@@ -80,7 +80,8 @@ class qsbr_ptr : public detail::qsbr_ptr_base {
     return *this;
   }
 
-  [[nodiscard]] constexpr std::add_lvalue_reference_t<T> operator*() const {
+  [[nodiscard, gnu::pure]] constexpr std::add_lvalue_reference_t<T> operator*()
+      const {
     return *ptr;
   }
 
@@ -95,24 +96,27 @@ class qsbr_ptr : public detail::qsbr_ptr_base {
     return *this;
   }
 
-  [[nodiscard]] constexpr std::ptrdiff_t operator-(
+  [[nodiscard, gnu::pure]] constexpr std::ptrdiff_t operator-(
       qsbr_ptr<T> other) const noexcept {
     return get() - other.get();
   }
 
-  [[nodiscard]] constexpr bool operator==(qsbr_ptr<T> other) const noexcept {
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
+      qsbr_ptr<T> other) const noexcept {
     return get() == other.get();
   }
 
-  [[nodiscard]] constexpr bool operator!=(qsbr_ptr<T> other) const noexcept {
+  [[nodiscard, gnu::pure]] constexpr bool operator!=(
+      qsbr_ptr<T> other) const noexcept {
     return get() != other.get();
   }
 
-  [[nodiscard]] constexpr bool operator<=(qsbr_ptr<T> other) const noexcept {
+  [[nodiscard, gnu::pure]] constexpr bool operator<=(
+      qsbr_ptr<T> other) const noexcept {
     return get() <= other.get();
   }
 
-  [[nodiscard]] constexpr T *get() const noexcept { return ptr; }
+  [[nodiscard, gnu::pure]] constexpr T *get() const noexcept { return ptr; }
 
  private:
   pointer_type ptr;
@@ -154,9 +158,11 @@ class qsbr_ptr_span {
   UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(
       qsbr_ptr_span<T> &&) noexcept = default;
 
-  constexpr qsbr_ptr<const T> cbegin() const noexcept { return start; }
+  [[nodiscard, gnu::pure]] constexpr qsbr_ptr<const T> cbegin() const noexcept {
+    return start;
+  }
 
-  constexpr qsbr_ptr<const T> cend() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr qsbr_ptr<const T> cend() const noexcept {
     return qsbr_ptr<const T>{start.get() + length};
   }
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -111,7 +111,7 @@ inline void assert_result_eq(const unodb::olc_db &db, unodb::key key,
   detail::assert_result_eq(test_db, key, expected, __FILE__, __LINE__)
 
 template <class Db>
-class tree_verifier final {
+class [[nodiscard]] tree_verifier final {
  private:
   void do_insert(unodb::key k, unodb::value_view v) {
     ASSERT_TRUE(test_db.insert(k, v));
@@ -303,7 +303,7 @@ class tree_verifier final {
     values.clear();
   }
 
-  [[nodiscard]] constexpr Db &get_db() noexcept { return test_db; }
+  [[nodiscard, gnu::pure]] constexpr Db &get_db() noexcept { return test_db; }
 
  private:
   Db test_db{};

--- a/thread_sync.hpp
+++ b/thread_sync.hpp
@@ -10,7 +10,7 @@
 
 namespace unodb::detail {
 
-class thread_sync final {
+class [[nodiscard]] thread_sync final {
  public:
   thread_sync() noexcept = default;
   ~thread_sync() noexcept { assert(is_reset()); }


### PR DESCRIPTION
- TIL that `nodiscard` can be applied to types too
- Add several nodiscard, gnu::const, and gnu::pure attributes to functions
- Removed an incorrect gnu::pure attribute from one method, replaced some
  gnu::pure instances with a stronged gnu::const where applicable
- Fixed a minor compilation warning under clangd
- Converted recently added `__attribute__` syntax instances to `[[..]]`