### PR TITLE
Print stacktraces on assert failures and unreachable code points

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -4,7 +4,6 @@
 
 #include "global.hpp"  // IWYU pragma: keep
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -124,7 +123,7 @@ class db final {
   }
 
   constexpr void decrease_memory_use(std::size_t delta) noexcept {
-    assert(delta <= current_memory_use);
+    UNODB_DETAIL_ASSERT(delta <= current_memory_use);
     current_memory_use -= delta;
   }
 
@@ -136,7 +135,7 @@ class db final {
   constexpr void decrement_leaf_count(std::size_t leaf_size) noexcept {
     decrease_memory_use(leaf_size);
 
-    assert(node_counts[as_i<node_type::LEAF>] > 0);
+    UNODB_DETAIL_ASSERT(node_counts[as_i<node_type::LEAF>] > 0);
     --node_counts[as_i<node_type::LEAF>];
   }
 

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -4,7 +4,6 @@
 
 #include "global.hpp"  // IWYU pragma: keep
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -65,7 +64,7 @@ struct [[nodiscard]] basic_art_key final {
 
   [[nodiscard, gnu::pure]] constexpr auto operator[](
       std::size_t index) const noexcept {
-    assert(index < size);
+    UNODB_DETAIL_ASSERT(index < size);
     // cppcheck-suppress objectIndex
     return (reinterpret_cast<const std::byte *>(&key))[index];
   }
@@ -102,24 +101,24 @@ class [[nodiscard]] tree_depth final {
 
   explicit constexpr tree_depth(value_type value_ = 0) noexcept
       : value{value_} {
-    assert(value <= art_key::size);
+    UNODB_DETAIL_ASSERT(value <= art_key::size);
   }
 
   // NOLINTNEXTLINE(google-explicit-constructor)
   [[nodiscard, gnu::pure]] constexpr operator value_type() const noexcept {
-    assert(value <= art_key::size);
+    UNODB_DETAIL_ASSERT(value <= art_key::size);
     return value;
   }
 
   constexpr tree_depth &operator++() noexcept {
     ++value;
-    assert(value <= art_key::size);
+    UNODB_DETAIL_ASSERT(value <= art_key::size);
     return *this;
   }
 
   constexpr void operator+=(value_type delta) noexcept {
     value += delta;
-    assert(value <= art_key::size);
+    UNODB_DETAIL_ASSERT(value <= art_key::size);
   }
 
  private:
@@ -209,7 +208,7 @@ class [[nodiscard]] basic_node_ptr {
     const auto uintptr = reinterpret_cast<std::uintptr_t>(ptr_);
     const auto result =
         uintptr | static_cast<std::underlying_type_t<decltype(tag)>>(tag);
-    assert((result & ptr_bit_mask) == uintptr);
+    UNODB_DETAIL_ASSERT((result & ptr_bit_mask) == uintptr);
     return result;
   }
 

--- a/benchmark/micro_benchmark_key_prefix.cpp
+++ b/benchmark/micro_benchmark_key_prefix.cpp
@@ -3,7 +3,6 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <algorithm>
-#include <cassert>
 #include <cstdint>
 #include <random>
 #include <vector>
@@ -202,18 +201,20 @@ void unpredictable_leaf_key_prefix_split(benchmark::State &state) {
     const auto first_key = static_cast<std::uint64_t>(top_byte) << 56U;
 
     // Quadratic but debug build only
-    assert(std::find(prepare_keys.cbegin(), prepare_keys.cend(), first_key) ==
-           prepare_keys.cend());
-    assert(std::find(benchmark_keys.cbegin(), benchmark_keys.cend(),
-                     first_key) == benchmark_keys.cend());
+    UNODB_DETAIL_ASSERT(std::find(prepare_keys.cbegin(), prepare_keys.cend(),
+                                  first_key) == prepare_keys.cend());
+    UNODB_DETAIL_ASSERT(std::find(benchmark_keys.cbegin(),
+                                  benchmark_keys.cend(),
+                                  first_key) == benchmark_keys.cend());
     prepare_keys.push_back(first_key);
 
     const auto second_key = first_key | (1ULL << (top_byte % stride_len * 8U));
     // Quadratic but debug build only
-    assert(std::find(prepare_keys.cbegin(), prepare_keys.cend(), second_key) ==
-           prepare_keys.cend());
-    assert(std::find(benchmark_keys.cbegin(), benchmark_keys.cend(),
-                     second_key) == benchmark_keys.cend());
+    UNODB_DETAIL_ASSERT(std::find(prepare_keys.cbegin(), prepare_keys.cend(),
+                                  second_key) == prepare_keys.cend());
+    UNODB_DETAIL_ASSERT(std::find(benchmark_keys.cbegin(),
+                                  benchmark_keys.cend(),
+                                  second_key) == benchmark_keys.cend());
     benchmark_keys.push_back(second_key);
   }
 

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -5,9 +5,6 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <array>
-#ifndef NDEBUG
-#include <cassert>
-#endif
 #include <cstddef>
 #ifndef NDEBUG
 #include <iostream>
@@ -67,7 +64,7 @@ void do_insert_key(Db &db, unodb::key k, unodb::value_view v) {
     ::unodb::detail::dump_key(std::cerr, k);
     std::cerr << "\nCurrent tree:";
     db.dump(std::cerr);
-    assert(result);
+    UNODB_DETAIL_ASSERT(result);
   }
 #endif
   ::benchmark::DoNotOptimize(result);
@@ -117,7 +114,7 @@ void do_delete_key(Db &db, unodb::key k) {
     ::unodb::detail::dump_key(std::cerr, k);
     std::cerr << "\nTree:";
     db.dump(std::cerr);
-    assert(result);
+    UNODB_DETAIL_ASSERT(result);
   }
 #endif
   ::benchmark::DoNotOptimize(result);
@@ -167,7 +164,7 @@ void do_get_existing_key(const Db &db, unodb::key k) {
     ::unodb::detail::dump_key(std::cerr, k);
     std::cerr << "\nTree:";
     db.dump(std::cerr);
-    assert(false);
+    UNODB_DETAIL_CRASH();
   }
 #endif
   ::benchmark::DoNotOptimize(result);

--- a/heap.hpp
+++ b/heap.hpp
@@ -5,7 +5,6 @@
 #include "global.hpp"
 
 #include <algorithm>
-#include <cassert>
 #include <cstdlib>
 
 #if defined(__SANITIZE_ADDRESS__)
@@ -46,7 +45,7 @@ template <typename T>
   void* result;
   int err = posix_memalign(&result, alignment, size);
 
-  assert(err != EINVAL);
+  UNODB_DETAIL_ASSERT(err != EINVAL);
   if (UNODB_DETAIL_UNLIKELY(err == ENOMEM)) throw std::bad_alloc{};
 
   return result;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <atomic>
-#include <cassert>
 #include <cstddef>  // IWYU pragma: keep
 #include <cstdint>
 #include <iostream>
@@ -173,7 +172,7 @@ class olc_db final {
     const auto UNODB_DETAIL_USED_IN_DEBUG old_leaf_count =
         node_counts[as_i<node_type::LEAF>].fetch_sub(1,
                                                      std::memory_order_relaxed);
-    assert(old_leaf_count > 0);
+    UNODB_DETAIL_ASSERT(old_leaf_count > 0);
   }
 
   template <class INode>

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <atomic>
-#include <cassert>
 #include <cstddef>  // IWYU pragma: keep
 #include <cstdint>
 #ifndef NDEBUG
@@ -136,7 +135,7 @@ class qsbr final {
                                 dealloc_debug_callback debug_callback
 #endif
   ) {
-    assert(!unodb::current_thread_reclamator().is_paused());
+    UNODB_DETAIL_ASSERT(!unodb::current_thread_reclamator().is_paused());
 
     bool deallocate_immediately = false;
     {
@@ -255,20 +254,20 @@ class qsbr final {
     // Copy-paste-tweak with expect_idle_qsbr, but not clear how to fix this:
     // here we are asserting over internals, over there we are using Google Test
     // EXPECT macros with the public interface.
-    assert(previous_interval_deallocation_requests.empty());
-    assert(previous_interval_total_dealloc_size.load(
-               std::memory_order_relaxed) == 0);
-    assert(current_interval_deallocation_requests.empty());
-    assert(current_interval_total_dealloc_size.load(
-               std::memory_order_relaxed) == 0);
+    UNODB_DETAIL_ASSERT(previous_interval_deallocation_requests.empty());
+    UNODB_DETAIL_ASSERT(previous_interval_total_dealloc_size.load(
+                            std::memory_order_relaxed) == 0);
+    UNODB_DETAIL_ASSERT(current_interval_deallocation_requests.empty());
+    UNODB_DETAIL_ASSERT(current_interval_total_dealloc_size.load(
+                            std::memory_order_relaxed) == 0);
     if (threads.empty()) {
-      assert(reserved_thread_capacity == 0);
-      assert(threads_in_previous_epoch == 0);
+      UNODB_DETAIL_ASSERT(reserved_thread_capacity == 0);
+      UNODB_DETAIL_ASSERT(threads_in_previous_epoch == 0);
     } else if (threads.size() == 1) {
-      assert(reserved_thread_capacity == 1);
-      assert(threads_in_previous_epoch == 1);
+      UNODB_DETAIL_ASSERT(reserved_thread_capacity == 1);
+      UNODB_DETAIL_ASSERT(threads_in_previous_epoch == 1);
     } else {
-      assert(threads.size() < 2);
+      UNODB_DETAIL_ASSERT(threads.size() < 2);
     }
 #endif
   }
@@ -303,9 +302,9 @@ class qsbr final {
     ) const noexcept {
       // TODO(laurynas): count deallocation request instances, assert 0 in QSBR
       // dtor
-      assert(dealloc_epoch == request_epoch + 2 ||
-             (dealloc_epoch_single_thread_mode &&
-              dealloc_epoch == request_epoch + 1));
+      UNODB_DETAIL_ASSERT(dealloc_epoch == request_epoch + 2 ||
+                          (dealloc_epoch_single_thread_mode &&
+                           dealloc_epoch == request_epoch + 1));
 
       qsbr::deallocate(pointer
 #ifndef NDEBUG
@@ -430,27 +429,27 @@ class qsbr final {
 };
 
 inline qsbr_per_thread::qsbr_per_thread() noexcept {
-  assert(paused);
+  UNODB_DETAIL_ASSERT(paused);
   qsbr::instance().register_prepared_thread(thread_id);
   paused = false;
 }
 
 inline void qsbr_per_thread::quiescent_state() const noexcept {
-  assert(!paused);
-  assert(active_ptrs.empty());
+  UNODB_DETAIL_ASSERT(!paused);
+  UNODB_DETAIL_ASSERT(active_ptrs.empty());
   qsbr::instance().quiescent_state(thread_id);
 }
 
 inline void qsbr_per_thread::pause() {
-  assert(!paused);
-  assert(active_ptrs.empty());
+  UNODB_DETAIL_ASSERT(!paused);
+  UNODB_DETAIL_ASSERT(active_ptrs.empty());
   qsbr::instance().unregister_thread(thread_id);
   paused = true;
 }
 
 inline void qsbr_per_thread::resume() {
-  assert(paused);
-  assert(active_ptrs.empty());
+  UNODB_DETAIL_ASSERT(paused);
+  UNODB_DETAIL_ASSERT(active_ptrs.empty());
   qsbr::instance().register_new_thread(thread_id);
   paused = false;
 }

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -58,12 +57,12 @@ template <class Db>
 void assert_value_eq(const typename Db::get_result &result,
                      unodb::value_view expected) {
   if constexpr (std::is_same_v<Db, unodb::mutex_db>) {
-    assert(result.second.owns_lock());
-    assert(result.first.has_value());
+    UNODB_DETAIL_ASSERT(result.second.owns_lock());
+    UNODB_DETAIL_ASSERT(result.first.has_value());
     ASSERT_TRUE(std::equal(result.first->cbegin(), result.first->cend(),
                            expected.cbegin(), expected.cend()));
   } else {
-    assert(result.has_value());
+    UNODB_DETAIL_ASSERT(result.has_value());
     ASSERT_TRUE(std::equal(result->cbegin(), result->cend(), expected.cbegin(),
                            expected.cend()));
   }

--- a/thread_sync.hpp
+++ b/thread_sync.hpp
@@ -4,7 +4,6 @@
 
 #include "global.hpp"
 
-#include <cassert>
 #include <condition_variable>
 #include <mutex>
 
@@ -13,7 +12,7 @@ namespace unodb::detail {
 class [[nodiscard]] thread_sync final {
  public:
   thread_sync() noexcept = default;
-  ~thread_sync() noexcept { assert(is_reset()); }
+  ~thread_sync() noexcept { UNODB_DETAIL_ASSERT(is_reset()); }
 
   [[nodiscard]] bool is_reset() const noexcept {
     std::lock_guard lock{sync_mutex};


### PR DESCRIPTION
For that, no longer use the standard assert macro, but roll out
UNODB_DETAIL_ASSERT instead.

Replace one instance of "assert(false)" with the also newly-introduced
UNODB_DETAIL_CRASH.