### PR TITLE
Rename unodb::current_thread_reclamator to unodb::this_thread

### DIFF
--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -20,7 +20,7 @@ class [[nodiscard]] concurrent_benchmark_olc final
   }
 
   void end_workload_in_main_thread() override {
-    unodb::current_thread_reclamator().quiescent_state();
+    unodb::this_thread().quiescent();
   }
 
   void teardown() override { unodb::qsbr::instance().assert_idle(); }

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -30,14 +30,14 @@ namespace unodb {
 
 void qsbr_per_thread::register_active_ptr(const void *ptr) {
   UNODB_DETAIL_ASSERT(ptr != nullptr);
-  UNODB_DETAIL_ASSERT(!is_paused());
+  UNODB_DETAIL_ASSERT(!is_qsbr_paused());
 
   active_ptrs.insert(ptr);
 }
 
 void qsbr_per_thread::unregister_active_ptr(const void *ptr) {
   UNODB_DETAIL_ASSERT(ptr != nullptr);
-  UNODB_DETAIL_ASSERT(!is_paused());
+  UNODB_DETAIL_ASSERT(!is_qsbr_paused());
 
   const auto itr = active_ptrs.find(ptr);
   UNODB_DETAIL_ASSERT(itr != active_ptrs.end());

--- a/qsbr_ptr.cpp
+++ b/qsbr_ptr.cpp
@@ -13,11 +13,11 @@ namespace unodb::detail {
 #ifndef NDEBUG
 
 void qsbr_ptr_base::register_active_ptr(const void *ptr) {
-  if (ptr != nullptr) current_thread_reclamator().register_active_ptr(ptr);
+  if (ptr != nullptr) this_thread().register_active_ptr(ptr);
 }
 
 void qsbr_ptr_base::unregister_active_ptr(const void *ptr) {
-  if (ptr != nullptr) current_thread_reclamator().unregister_active_ptr(ptr);
+  if (ptr != nullptr) this_thread().unregister_active_ptr(ptr);
 }
 
 #endif

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -34,7 +34,7 @@ class ARTConcurrencyTest : public ::testing::Test {
   template <std::size_t ThreadCount, std::size_t OpsPerThread, typename TestFn>
   void parallel_test(TestFn test_function) {
     if constexpr (std::is_same_v<Db, unodb::olc_db>)
-      unodb::current_thread_reclamator().pause();
+      unodb::this_thread().qsbr_pause();
 
     std::array<unodb::test::thread<Db>, ThreadCount> threads;
     for (decltype(ThreadCount) i = 0; i < ThreadCount; ++i) {
@@ -46,7 +46,7 @@ class ARTConcurrencyTest : public ::testing::Test {
     }
 
     if constexpr (std::is_same_v<Db, unodb::olc_db>)
-      unodb::current_thread_reclamator().resume();
+      unodb::this_thread().qsbr_resume();
   }
 
   template <unsigned PreinsertLimit, std::size_t ThreadCount,


### PR DESCRIPTION
Makes everything shorter, and makes me to consider merging unodb_thread and
unodb_per_thread classes, which will be done later.

At the same time rename qsbr_per_thread methods: is_paused to is_qsbr_paused,
quiescent_state to quiescent, pause to qsbr_pause, & resume to qsbr_resume.