### PR TITLE
Lock-free QSBR step 2: remove the QSBR thread set

### DIFF
--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -578,7 +578,6 @@ TEST(QSBR, DeepStateFuzz) {
     dump_sink << unodb::qsbr::instance().get_mean_backlog_bytes();
     dump_sink << unodb::qsbr::instance().previous_interval_size();
     dump_sink << unodb::qsbr::instance().current_interval_size();
-    dump_sink << unodb::qsbr::instance().get_reserved_thread_capacity();
   }
 
   for (std::size_t i = 0; i < threads.size(); ++i) {

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -18,10 +18,8 @@ void expect_idle_qsbr() {
   EXPECT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
   EXPECT_EQ(unodb::qsbr::instance().current_interval_size(), 0);
   if (unodb::qsbr::instance().number_of_threads() == 0) {
-    EXPECT_EQ(unodb::qsbr::instance().get_reserved_thread_capacity(), 0);
     EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 0);
   } else if (unodb::qsbr::instance().number_of_threads() == 1) {
-    EXPECT_EQ(unodb::qsbr::instance().get_reserved_thread_capacity(), 1);
     EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 1);
   } else {
     EXPECT_LE(unodb::qsbr::instance().number_of_threads(), 1);


### PR DESCRIPTION
After making q states thread-local, the map of thread ids to q states became the
set of thread ids, whose only function was to provide its size, and to check
whether register/unregister calls are balanced. Drop the latter, and replace the
set with a registered thread count.

This allows huge simplification of code due to removing the need of reserving
the set capacity beforehand during thread registration where any thrown
exception could be caught.