### PR TITLE
Lock-free QSBR: make current_epoch number atomic

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -43,7 +43,7 @@ qsbr_epoch qsbr::register_thread() noexcept {
 
   ++thread_count;
   ++threads_in_previous_epoch;
-  return current_epoch;
+  return get_current_epoch_locked();
 }
 
 void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
@@ -54,32 +54,37 @@ void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
   {
     std::lock_guard guard{qsbr_rwlock};
 
+    const auto current_global_epoch = get_current_epoch_locked();
 #ifndef NDEBUG
-    UNODB_DETAIL_ASSERT(thread_epoch == current_epoch ||
-                        thread_epoch + 1 == current_epoch);
+    UNODB_DETAIL_ASSERT(thread_epoch == current_global_epoch ||
+                        thread_epoch + 1 == current_global_epoch);
     thread_count_changed_in_current_epoch = true;
 #endif
 
-    const auto epoch_changed =
-        ((thread_epoch + 1 == current_epoch) ||
+    const auto new_global_epoch =
+        ((thread_epoch + 1 == current_global_epoch) ||
          (quiescent_states_since_epoch_change == 0))
-            ? remove_thread_from_previous_epoch_locked(requests_to_deallocate
+            ? remove_thread_from_previous_epoch_locked(current_global_epoch,
+                                                       requests_to_deallocate
 #ifndef NDEBUG
                                                        ,
                                                        thread_epoch
 #endif
                                                        )
-            : false;
+            : current_global_epoch;
+    UNODB_DETAIL_ASSERT(current_global_epoch == new_global_epoch ||
+                        current_global_epoch + 1 == new_global_epoch);
 
     --thread_count;
-    if (epoch_changed) {
+
+    if (current_global_epoch < new_global_epoch) {
       // The epoch change marked this thread as not-quiescent again, and
       // included it in threads_in_previous_epoch
       --threads_in_previous_epoch;
     }
 #ifndef NDEBUG
     requests_to_deallocate.update_single_thread_mode();
-    single_threaded_mode_start_epoch = get_current_epoch_locked();
+    single_threaded_mode_start_epoch = new_global_epoch;
 #endif
 
     // If we became single-threaded, we still cannot deallocate neither previous
@@ -130,54 +135,64 @@ void qsbr::dump(std::ostream &out) const {
       << threads_in_previous_epoch << '\n';
 }
 
-bool qsbr::remove_thread_from_previous_epoch(
+qsbr_epoch qsbr::remove_thread_from_previous_epoch(
 #ifndef NDEBUG
     qsbr_epoch thread_epoch
 #endif
     ) noexcept {
   deferred_requests to_deallocate;
-  bool epoch_changed = false;
+  qsbr_epoch result;
   {
     std::lock_guard guard{qsbr_rwlock};
 
-    UNODB_DETAIL_ASSERT(thread_epoch == current_epoch ||
-                        thread_epoch + 1 == current_epoch);
+    const auto current_global_epoch = get_current_epoch_locked();
+    UNODB_DETAIL_ASSERT(thread_epoch == current_global_epoch ||
+                        thread_epoch + 1 == current_global_epoch);
 
-    epoch_changed = remove_thread_from_previous_epoch_locked(to_deallocate
+    const auto new_global_epoch = remove_thread_from_previous_epoch_locked(
+        current_global_epoch, to_deallocate
 #ifndef NDEBUG
-                                                             ,
-                                                             thread_epoch
+        ,
+        thread_epoch
 #endif
     );
+    UNODB_DETAIL_ASSERT(new_global_epoch == current_global_epoch ||
+                        new_global_epoch == current_global_epoch + 1);
+    result = new_global_epoch;
   }
-  return epoch_changed;
+  return result;
 }
 
-bool qsbr::remove_thread_from_previous_epoch_locked(
-    qsbr::deferred_requests &requests
+qsbr_epoch qsbr::remove_thread_from_previous_epoch_locked(
+    qsbr_epoch current_global_epoch, qsbr::deferred_requests &requests
 #ifndef NDEBUG
     ,
     qsbr_epoch thread_epoch
 #endif
     ) noexcept {
-  UNODB_DETAIL_ASSERT(thread_epoch == current_epoch ||
-                      thread_epoch + 1 == current_epoch);
+#ifndef NDEBUG
+  UNODB_DETAIL_ASSERT(thread_epoch == current_global_epoch ||
+                      thread_epoch + 1 == current_global_epoch);
   assert_invariants();
+#endif
 
   UNODB_DETAIL_ASSERT(threads_in_previous_epoch > 0);
   --threads_in_previous_epoch;
 
-  if (threads_in_previous_epoch > 0) return false;
+  if (threads_in_previous_epoch > 0) return current_global_epoch;
 
-  requests = change_epoch();
+  const auto new_epoch = change_epoch(current_global_epoch, requests);
 
-  UNODB_DETAIL_ASSERT(thread_epoch + 1 == current_epoch ||
-                      thread_epoch + 2 == current_epoch);
-  return true;
+  UNODB_DETAIL_ASSERT(current_global_epoch + 1 == new_epoch);
+
+  return new_epoch;
 }
 
-qsbr::deferred_requests qsbr::change_epoch() noexcept {
-  ++current_epoch;
+qsbr_epoch qsbr::change_epoch(qsbr_epoch current_global_epoch,
+                              qsbr::deferred_requests &requests) noexcept {
+  const auto result = current_global_epoch + 1;
+  UNODB_DETAIL_ASSERT(get_current_epoch_locked() + 1 == result);
+  current_epoch.store(result, std::memory_order_relaxed);
 
   deallocation_size_stats(
       current_interval_total_dealloc_size.load(std::memory_order_relaxed));
@@ -186,8 +201,8 @@ qsbr::deferred_requests qsbr::change_epoch() noexcept {
   epoch_callback_stats(previous_interval_deallocation_requests.size());
   publish_epoch_callback_stats();
 
-  deferred_requests result{make_deferred_requests()};
-  result.requests[0] = std::move(previous_interval_deallocation_requests);
+  requests = make_deferred_requests();
+  requests.requests[0] = std::move(previous_interval_deallocation_requests);
 
   if (UNODB_DETAIL_LIKELY(!single_thread_mode_locked())) {
     previous_interval_deallocation_requests =
@@ -198,7 +213,7 @@ qsbr::deferred_requests qsbr::change_epoch() noexcept {
   } else {
     previous_interval_deallocation_requests.clear();
     previous_interval_total_dealloc_size.store(0, std::memory_order_relaxed);
-    result.requests[1] = std::move(current_interval_deallocation_requests);
+    requests.requests[1] = std::move(current_interval_deallocation_requests);
   }
   current_interval_deallocation_requests.clear();
   current_interval_total_dealloc_size.store(0, std::memory_order_relaxed);


### PR DESCRIPTION
This reduces qsbr_rwlock write locking in the critical quiescent state path. To
avoid multiple re-reads of its value in the algorithms, read it only when
necessary and pass it around / return on the stack. This also clarifies
per-thread global epoch view.