### PR TITLE
QSBR: make debug variable single_threaded_mode_start_epoch atomic

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -76,7 +76,6 @@ void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
     }
 #ifndef NDEBUG
     requests_to_deallocate.update_single_thread_mode();
-    single_threaded_mode_start_epoch = new_global_epoch;
 #endif
 
     // If we became single-threaded, we still cannot deallocate neither previous

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -387,10 +387,6 @@ class qsbr final {
       UNODB_DETAIL_ASSERT(current_interval_total_dealloc_size.load(
                               std::memory_order_relaxed) == 0);
     }
-
-    if (single_thread_mode_locked() &&
-        get_current_epoch_locked() > single_threaded_mode_start_epoch)
-      UNODB_DETAIL_ASSERT(previous_interval_deallocation_requests.empty());
 #endif
   }
 
@@ -445,11 +441,6 @@ class qsbr final {
 
   // Protected by qsbr_rwlock
   std::uint64_t threads_in_previous_epoch{0};
-
-#ifndef NDEBUG
-  // Protected by qsbr_rwlock
-  qsbr_epoch single_threaded_mode_start_epoch{0};
-#endif
 
   // TODO(laurynas): atomic but mostly manipulated in qsbr_rwlock critical
   // sections. See if can move it out.


### PR DESCRIPTION
- Move its update out of qsbr_rwlock critical section
- Introduce a QSBR invariant that must hold at all times regardless of
  qsbr_rwlock. Check it everywhere.
- Rename the old QSBR invariant to assert_invariants_locked, call it more
  consistently. Move it to the header file because some of its callers are
  there.