### PR TITLE
QSBR: pass the previously-read global epoch instead of re-reading

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -127,7 +127,9 @@ void qsbr::dump(std::ostream &out) const {
 }
 
 qsbr_epoch qsbr::remove_thread_from_previous_epoch(
+    qsbr_epoch current_global_epoch
 #ifndef NDEBUG
+    ,
     qsbr_epoch thread_epoch
 #endif
     ) noexcept {
@@ -138,7 +140,10 @@ qsbr_epoch qsbr::remove_thread_from_previous_epoch(
 
     assert_invariants_locked();
 
-    const auto current_global_epoch = get_current_epoch_locked();
+    // The global epoch could not have advanced since the passed in value was
+    // read because this thread is passing through the quiescent state for the
+    // first time in this epoch.
+    UNODB_DETAIL_ASSERT(current_global_epoch == get_current_epoch_locked());
     UNODB_DETAIL_ASSERT(thread_epoch == current_global_epoch ||
                         thread_epoch + 1 == current_global_epoch);
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -171,7 +171,9 @@ class qsbr final {
   }
 
   [[nodiscard]] qsbr_epoch remove_thread_from_previous_epoch(
+      qsbr_epoch current_global_epoch
 #ifndef NDEBUG
+      ,
       qsbr_epoch thread_epoch
 #endif
       ) noexcept;
@@ -497,9 +499,10 @@ inline void qsbr_per_thread::quiescent() noexcept {
   UNODB_DETAIL_ASSERT(current_global_epoch == last_seen_epoch);
   if (quiescent_states_since_epoch_change == 0) {
     const auto new_global_epoch =
-        qsbr::instance().remove_thread_from_previous_epoch(
+        qsbr::instance().remove_thread_from_previous_epoch(current_global_epoch
 #ifndef NDEBUG
-            last_seen_epoch
+                                                           ,
+                                                           last_seen_epoch
 #endif
         );
     UNODB_DETAIL_ASSERT(new_global_epoch == last_seen_epoch ||


### PR DESCRIPTION
in remove_thread_from_previous_epoch method. This is safe because the global
epoch could not have advanced since that read, as the thread is passing through
the quiescent state for the first time in this epoch.