### PR TITLE
Make QSBR epoch a two-bit wrapping around counter

### DIFF
--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -29,8 +29,8 @@ class [[nodiscard]] concurrent_benchmark_olc final
 concurrent_benchmark_olc benchmark_fixture;
 
 void set_common_qsbr_counters(benchmark::State &state) {
-  state.counters["epoch changes"] =
-      unodb::benchmark::to_counter(unodb::qsbr::instance().get_current_epoch());
+  state.counters["epoch changes"] = unodb::benchmark::to_counter(
+      unodb::qsbr::instance().get_epoch_change_count());
   state.counters["mean qstates before epoch change"] = benchmark::Counter(
       unodb::qsbr::instance()
           .get_mean_quiescent_states_per_thread_between_epoch_changes());

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -574,6 +574,7 @@ TEST(QSBR, DeepStateFuzz) {
         << unodb::qsbr::instance()
                .get_mean_quiescent_states_per_thread_between_epoch_changes();
     dump_sink << unodb::qsbr::instance().get_current_epoch();
+    dump_sink << unodb::qsbr::instance().get_epoch_change_count();
     dump_sink << unodb::qsbr::instance().get_max_backlog_bytes();
     dump_sink << unodb::qsbr::instance().get_mean_backlog_bytes();
     dump_sink << unodb::qsbr::instance().previous_interval_size();


### PR DESCRIPTION
This prepares storing it in the atomic QSBR state word for lock-free QSBR. At
the same time make a value class for the epoch, preventing undesirable
arithmetic operations and comparisons.

Since the epoch number no longer tells how many times the epoch advanced,
introduce a separate counter for that.