### PR TITLE
Assorted diff minimization refactorings from lock-free QSBR

### DIFF
--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -17,12 +17,15 @@ void expect_idle_qsbr() {
   EXPECT_TRUE(unodb::qsbr::instance().single_thread_mode());
   EXPECT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
   EXPECT_EQ(unodb::qsbr::instance().current_interval_size(), 0);
-  if (unodb::qsbr::instance().number_of_threads() == 0) {
-    EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 0);
-  } else if (unodb::qsbr::instance().number_of_threads() == 1) {
-    EXPECT_EQ(unodb::qsbr::instance().get_threads_in_previous_epoch(), 1);
+  const auto thread_count = unodb::qsbr::instance().number_of_threads();
+  const auto threads_in_previous_epoch =
+      unodb::qsbr::instance().get_threads_in_previous_epoch();
+  if (thread_count == 0) {
+    EXPECT_EQ(threads_in_previous_epoch, 0);
+  } else if (thread_count == 1) {
+    EXPECT_EQ(threads_in_previous_epoch, 1);
   } else {
-    EXPECT_LE(unodb::qsbr::instance().number_of_threads(), 1);
+    EXPECT_LE(thread_count, 1);
   }
 }
 


### PR DESCRIPTION
- Inline and remove qsbr::remove_thread_from_previous_epoch_locked
- Split out qsbr::epoch_change_update_requests from qsbr::change_epoch
- Move qsbr::make_deferred_requests and qsbr::assert_idle_locked definitions
  from header to source
- Cache QSBR getter results in unodb::test::expect_idle_qsbr
- New helper test_qsbr.cpp:QSBR::get_qsbr_thread_count, use it in tests
- Make __tsan_acquire / __tsan_release use the QSBR singleton object itself