### PR TITLE
QSBR: introduce atomic vars for interval allocation counts

### DIFF
--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -404,13 +404,13 @@ void reset_stats() {
     deallocate_pointer(main_thread_i);
     return;
   }
-  if (unodb::qsbr::instance().previous_interval_size() > 0) {
+  if (unodb::qsbr::instance().get_previous_interval_dealloc_count() > 0) {
     LOG(TRACE) << "Previous interval non-empty, going through qstate instead "
                   "of resetting stats";
     quiescent_state(main_thread_i);
     return;
   }
-  if (unodb::qsbr::instance().current_interval_size() > 0) {
+  if (unodb::qsbr::instance().get_current_interval_dealloc_count() > 0) {
     LOG(TRACE) << "Current interval non-empty, going through qstate instead of "
                   "resetting stats";
     quiescent_state(main_thread_i);
@@ -580,8 +580,8 @@ TEST(QSBR, DeepStateFuzz) {
     dump_sink << unodb::qsbr::instance().get_epoch_change_count();
     dump_sink << unodb::qsbr::instance().get_max_backlog_bytes();
     dump_sink << unodb::qsbr::instance().get_mean_backlog_bytes();
-    dump_sink << unodb::qsbr::instance().previous_interval_size();
-    dump_sink << unodb::qsbr::instance().current_interval_size();
+    dump_sink << unodb::qsbr::instance().get_previous_interval_dealloc_count();
+    dump_sink << unodb::qsbr::instance().get_current_interval_dealloc_count();
   }
 
   for (std::size_t i = 0; i < threads.size(); ++i) {

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -16,8 +16,8 @@ void expect_idle_qsbr() {
   // there we are asserting over internals.
   const auto state = unodb::qsbr::instance().get_state();
   EXPECT_TRUE(qsbr_state::single_thread_mode(state));
-  EXPECT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
-  EXPECT_EQ(unodb::qsbr::instance().current_interval_size(), 0);
+  EXPECT_EQ(unodb::qsbr::instance().get_previous_interval_dealloc_count(), 0);
+  EXPECT_EQ(unodb::qsbr::instance().get_current_interval_dealloc_count(), 0);
   const auto thread_count = qsbr_state::get_thread_count(state);
   const auto threads_in_previous_epoch =
       qsbr_state::get_threads_in_previous_epoch(state);

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -871,8 +871,8 @@ TEST_F(QSBR, GettersConcurrentWithQuiescentState) {
     volatile auto force_load [[maybe_unused]] =
         unodb::qsbr::instance()
             .get_mean_quiescent_states_per_thread_between_epoch_changes();
-    ASSERT_EQ(unodb::qsbr::instance().previous_interval_size(), 0);
-    ASSERT_EQ(unodb::qsbr::instance().current_interval_size(), 0);
+    ASSERT_EQ(unodb::qsbr::instance().get_previous_interval_dealloc_count(), 0);
+    ASSERT_EQ(unodb::qsbr::instance().get_current_interval_dealloc_count(), 0);
     const auto current_qsbr_state = unodb::qsbr::instance().get_state();
     ASSERT_LE(
         unodb::qsbr_state::get_threads_in_previous_epoch(current_qsbr_state),


### PR DESCRIPTION
Previously, the interval allocation containers were directly queried for size()
under a lock. Now, maintain separate atomic variables for their sizes. This also
allows weakining qsbr_rwlock to a regular mutex qsbr_lock.