### PR TITLE
Assorted QSBR cleanups from lock-free QSBR work

### DIFF
--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -11,9 +11,6 @@
 namespace unodb::test {
 
 void expect_idle_qsbr() {
-  // Copy-paste-tweak with qsbr::assert_idle_locked, but not clear how to fix
-  // this: here we are using Google Test macros with the public interface, over
-  // there we are asserting over internals.
   const auto state = unodb::qsbr::instance().get_state();
   EXPECT_TRUE(qsbr_state::single_thread_mode(state));
   EXPECT_EQ(unodb::qsbr::instance().get_previous_interval_dealloc_count(), 0);
@@ -21,13 +18,8 @@ void expect_idle_qsbr() {
   const auto thread_count = qsbr_state::get_thread_count(state);
   const auto threads_in_previous_epoch =
       qsbr_state::get_threads_in_previous_epoch(state);
-  if (thread_count == 0) {
-    EXPECT_EQ(threads_in_previous_epoch, 0);
-  } else if (thread_count == 1) {
-    EXPECT_EQ(threads_in_previous_epoch, 1);
-  } else {
-    EXPECT_LE(thread_count, 1);
-  }
+  EXPECT_EQ(thread_count, 1);
+  EXPECT_EQ(threads_in_previous_epoch, 1);
 }
 
 }  // namespace unodb::test

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -25,7 +25,11 @@ class QSBR : public ::testing::Test {
     unodb::qsbr::instance().reset_stats();
   }
 
-  ~QSBR() noexcept override { unodb::test::expect_idle_qsbr(); }
+  ~QSBR() noexcept override {
+    if (unodb::this_thread().is_qsbr_paused())
+      unodb::this_thread().qsbr_resume();
+    unodb::test::expect_idle_qsbr();
+  }
 
   [[nodiscard]] static auto get_qsbr_thread_count() noexcept {
     return unodb::qsbr_state::get_thread_count(


### PR DESCRIPTION
- Remove qsbr::make_deferred_requests, now being a no-op wrapper
- Assert thread count too in qsbr::assert_idle
- Accept exactly one thread in unodb::test::expect_idle_qsbr, resume the main
  thread in test harness destructor if needed