### PR TITLE
Implement lock-free statistics and use it for QSBR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,9 +216,8 @@ jobs:
             echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main' \
             | sudo tee -a /etc/apt/sources.list
           fi
-          sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
           sudo apt-get update
-          sudo apt-get install -y boost1.74 libc6-dev-i386
+          sudo apt-get install -y libc6-dev-i386
           if [[ $SANITIZE_ADDRESS != "ON" && $SANITIZE_THREAD != "ON" \
               && $SANITIZE_UB != "ON" && $STATIC_ANALYSIS != "ON" ]]; then
             sudo apt-get install -y valgrind
@@ -257,7 +256,6 @@ jobs:
           if [[ $CPPCHECK == "ON" ]]; then
             brew install cppcheck
           fi
-          brew install boost
         if: runner.os == 'macOS'
 
       - name: Create build environment

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,9 +45,8 @@ jobs:
 
     - name: Setup dependencies for Linux
       run: |
-        sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
         sudo apt-get update
-        sudo apt-get install -y boost1.74 libc6-dev-i386
+        sudo apt-get install -y libc6-dev-i386
         sudo ln -sf /usr/bin/g++-10 /usr/bin/g++
         sudo ln -sf /usr/bin/gcc-10 /usr/bin/gcc
 

--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up dependencies for macOS
         run: |
           brew update
-          brew install boost cppcheck iwyu
+          brew install cppcheck iwyu
 
       - name: Create build environment
         run: mkdir ${{github.workspace}}/build

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -201,9 +201,8 @@ jobs:
             echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${VERSION} main" \
               | sudo tee -a /etc/apt/sources.list
           fi
-          sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
           sudo apt-get update
-          sudo apt-get install -y boost1.74 libc6-dev-i386
+          sudo apt-get install -y libc6-dev-i386
           if [[ $COMPILER == "gcc" ]]; then
             sudo apt-get install -y gcc-${VERSION}
           else

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,12 +31,6 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better
           # relevancy of analysis
 
-      - name: Setup dependencies
-        run: |
-          sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
-          sudo apt-get update
-          sudo apt-get install -y boost1.74
-
       - name: Produce Compilation Database
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set(GCC_GE_11_CXX_WARNING_FLAGS
   "-Wctad-maybe-unsupported" "-Wdeprecated-enum-enum-conversion"
   "-Wdeprecated-enum-float-conversion" "-Wvexing-parse")
 
-list(APPEND CXX_FLAGS "-g" "-msse4.1")
+list(APPEND CXX_FLAGS "-g" "-msse4.1" "-mcx16")
 
 option(COVERAGE "Enable code coverage reporting")
 if(COVERAGE)
@@ -183,8 +183,6 @@ option(STATIC_ANALYSIS "Enable compiler static analysis")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
-
-find_package(Boost REQUIRED)
 
 string(REPLACE ";" " " CXX_FLAGS_FOR_SUBDIR_STR "${SANITIZER_CXX_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS ${CXX_FLAGS_FOR_SUBDIR_STR})
@@ -417,13 +415,10 @@ function(ADD_UNODB_LIBRARY LIB)
   endif()
 endfunction()
 
-add_unodb_library(unodb_qsbr qsbr.cpp qsbr.hpp qsbr_ptr.cpp qsbr_ptr.hpp)
-target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
-target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
+add_unodb_library(unodb_qsbr qsbr.cpp qsbr.hpp qsbr_ptr.cpp qsbr_ptr.hpp
+  lock_free_stats.hpp)
 target_link_libraries(unodb_qsbr PUBLIC Threads::Threads)
 if(LIBFUZZER_AVAILABLE)
-  target_include_directories(unodb_qsbr_lf SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
-  target_link_libraries(unodb_qsbr_lf PRIVATE "${Boost_LIBRARIES}")
   target_link_libraries(unodb_qsbr_lf PUBLIC Threads::Threads)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ C++ tools and ideas. I am trying to describe some of the things I learned at my
 
 ## Requirements
 
-The source code is C++17, using SSE4.1 intrinsics (Nehalem and higher). This is
-in contrast to the original ART paper needing SSE2 only.
+The source code is C++17, using SSE4.1 intrinsics and CMPXCHG16B instruction
+(Nehalem and higher). This is in contrast to the original ART paper needing SSE2
+only.
 
 Note: since this is my personal project, it only supports GCC 10, 11, LLVM 11 to
 13, and XCode 12.2 compilers. Drop me a note if you want to try this and need a
@@ -83,7 +84,6 @@ Any macros starting with `UNODB_DETAIL_` are internal and should not be used.
 ## Dependencies
 
 * CMake, at least 3.12
-* Boost library. Currently tested with versions 1.74 and 1.75.
 * Guidelines Support Library for gsl::span, bundled as a git submodule.
 * Google Test for tests, bundled as a git submodule.
 * Google Benchmark for microbenchmarks, bundled, as a git submodule.

--- a/global.hpp
+++ b/global.hpp
@@ -77,6 +77,16 @@
 #define UNODB_DETAIL_LIKELY(x) __builtin_expect(x, 1)
 #define UNODB_DETAIL_UNLIKELY(x) __builtin_expect(x, 0)
 
+#ifndef __clang__
+#define UNODB_DETAIL_ASSUME(x)                                \
+  do {                                                        \
+    UNODB_DETAIL_ASSERT(x);                                   \
+    if (UNODB_DETAIL_UNLIKELY(!(x))) __builtin_unreachable(); \
+  } while (0)
+#else
+#define UNODB_DETAIL_ASSUME(x) __builtin_assume(x)
+#endif
+
 #ifdef NDEBUG
 // Cannot do [[gnu::unused]], as that does not play well with structured
 // bindings when compiling with GCC.

--- a/lock_free_stats.hpp
+++ b/lock_free_stats.hpp
@@ -1,0 +1,170 @@
+// Copyright (C) 2021 Laurynas Biveinis
+#ifndef UNODB_DETAIL_LOCK_FREE_STATS_HPP
+#define UNODB_DETAIL_LOCK_FREE_STATS_HPP
+
+#include "global.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <limits>
+
+namespace unodb {
+
+// TODO(laurynas): unit tests
+
+// The first data point is always 0, to reduce branching. The maximum allowed
+// value is 2^63, which is also the maximum allowed number of values.
+class [[nodiscard]] lock_free_stats {
+ public:
+  lock_free_stats() noexcept { count_and_mean.reset(); }
+
+  void add_value(std::uint64_t value) noexcept {
+    double double_value;
+    double delta;
+    double new_mean;
+    do_add_value(value, double_value, delta, new_mean);
+  }
+
+  void reset() noexcept {
+    count_and_mean.reset();
+    std::atomic_thread_fence(std::memory_order_release);
+  }
+
+  [[nodiscard]] double get_mean() const noexcept {
+    return count_and_mean.f.mean.load(std::memory_order_acquire);
+  }
+
+ protected:
+  static constexpr auto max_allowed_val =
+      std::numeric_limits<std::int64_t>::max();
+
+  static double to_double_fast(std::uint64_t x) noexcept {
+    // On x86_64, std::uint64_t conversion to double has to special-case inputs
+    // with the highest bit set, avoid this.
+    UNODB_DETAIL_ASSUME(x <= max_allowed_val);
+    return static_cast<double>(x);
+  }
+
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  void do_add_value(std::uint64_t value, double &double_value, double &delta,
+                    double &new_mean) noexcept {
+#ifdef __x86_64
+    // The implementation uses the deprecated __sync GCC builtins because they
+    // are the only ones that compile directly to LOCK CMPXCHG16B with GCC.
+    double_value = to_double_fast(value);
+
+    auto seen_count = count_and_mean.f.count.load(std::memory_order_relaxed);
+    auto seen_mean = count_and_mean.f.mean.load(std::memory_order_relaxed);
+    while (true) {
+      const auto new_count = seen_count + 1;
+      delta = double_value - seen_mean;
+      new_mean = seen_mean + delta / to_double_fast(new_count);
+
+      count_and_mean_dword old_count_and_mean;
+      old_count_and_mean.f.count.store(seen_count, std::memory_order_relaxed);
+      old_count_and_mean.f.mean.store(seen_mean, std::memory_order_relaxed);
+
+      count_and_mean_dword new_count_and_mean;
+      new_count_and_mean.f.count.store(new_count, std::memory_order_relaxed);
+      new_count_and_mean.f.mean.store(new_mean, std::memory_order_relaxed);
+
+      count_and_mean_dword actual_old_count_and_mean;
+      UNODB_DETAIL_DISABLE_CLANG_WARNING("-Watomic-implicit-seq-cst")
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+      actual_old_count_and_mean.dword = __sync_val_compare_and_swap(
+          &count_and_mean.dword, old_count_and_mean.dword,
+          new_count_and_mean.dword);
+      UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
+
+      const auto actual_old_count =
+          actual_old_count_and_mean.f.count.load(std::memory_order_relaxed);
+
+      if (UNODB_DETAIL_LIKELY(actual_old_count == seen_count)) {
+        break;
+      }
+
+      seen_count = actual_old_count;
+      seen_mean =
+          actual_old_count_and_mean.f.mean.load(std::memory_order_relaxed);
+    }
+#endif
+  }
+
+  [[nodiscard]] std::uint64_t get_count() const noexcept {
+    return count_and_mean.f.count.load(std::memory_order_acquire);
+  }
+
+ private:
+  // This implementation uses DWCAS
+  union count_and_mean_dword {
+    __extension__ __int128 dword;
+    struct {
+      std::atomic<std::uint64_t> count;
+      std::atomic<double> mean;
+    } f;
+
+    count_and_mean_dword() noexcept {}
+
+    void reset() noexcept {
+      f.count.store(1, std::memory_order_relaxed);
+      f.mean.store(0.0, std::memory_order_relaxed);
+    }
+  } count_and_mean;
+  static_assert(sizeof(count_and_mean) == 16);
+};
+
+class [[nodiscard]] lock_free_max_variance_stats : public lock_free_stats {
+ public:
+  void add_value(std::uint64_t value) noexcept {
+    double double_value;
+    double delta;
+    double new_mean;
+
+    do_add_value(value, double_value, delta, new_mean);
+
+    const auto msq_delta = delta * (double_value - new_mean);
+    auto current_msq = msq.load(std::memory_order_acquire);
+    while (true) {
+      const auto new_msq = current_msq + msq_delta;
+      if (UNODB_DETAIL_LIKELY(msq.compare_exchange_weak(
+              current_msq, new_msq, std::memory_order_acq_rel,
+              std::memory_order_acquire)))
+        break;
+    }
+
+    auto current_max = max.load(std::memory_order_acquire);
+    while (true) {
+      if (value <= current_max) break;
+      if (UNODB_DETAIL_LIKELY(max.compare_exchange_weak(
+              current_max, value, std::memory_order_acq_rel,
+              std::memory_order_acquire)))
+        break;
+    }
+  }
+
+  void reset() noexcept {
+    max.store(0, std::memory_order_relaxed);
+    msq.store(0.0, std::memory_order_relaxed);
+    // The parent reset will fence the above stores
+    lock_free_stats::reset();
+  }
+
+  [[nodiscard]] std::uint64_t get_max() const noexcept {
+    return max.load(std::memory_order_acquire);
+  }
+
+  [[nodiscard]] double get_variance() const noexcept {
+    const auto count = get_count();
+    // Replace NaN with 0
+    if (UNODB_DETAIL_UNLIKELY(count == 1)) return 0.0;
+    return msq.load(std::memory_order_acquire) / (to_double_fast(count) - 1);
+  }
+
+ private:
+  std::atomic<std::uint64_t> max{0};
+  std::atomic<double> msq{0.0};
+};
+
+}  // namespace unodb
+
+#endif  // UNODB_DETAIL_CLOK_FREE_STATS_HPP

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -276,22 +276,9 @@ void qsbr::reset_stats() noexcept {
   // prevents to leaving idle state at any time
   assert_idle();
 
-  {
-    std::lock_guard guard{dealloc_stats_lock};
-
-    epoch_dealloc_per_thread_count_stats = {};
-    publish_epoch_callback_stats();
-
-    deallocation_size_per_thread_stats = {};
-    publish_deallocation_size_stats();
-  }
-
-  {
-    std::lock_guard guard{quiescent_state_stats_lock};
-
-    quiescent_states_per_thread_between_epoch_change_stats = {};
-    publish_quiescent_states_per_thread_between_epoch_change_stats();
-  }
+  quiescent_states_per_thread_between_epoch_change_stats.reset();
+  epoch_dealloc_per_thread_count_stats.reset();
+  deallocation_size_per_thread_stats.reset();
 }
 
 // Some GCC versions suggest cold attribute on already cold-marked functions

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -11,7 +11,6 @@
 #include <functional>  // IWYU pragma: keep
 #endif
 #include <iostream>
-#include <mutex>  // IWYU pragma: keep
 #include <thread>
 #include <type_traits>
 #ifndef NDEBUG
@@ -22,13 +21,8 @@
 
 #include <gsl/gsl_util>
 
-#include <boost/accumulators/accumulators.hpp>  // IWYU pragma: keep
-#include <boost/accumulators/statistics/max.hpp>
-#include <boost/accumulators/statistics/mean.hpp>
-#include <boost/accumulators/statistics/stats.hpp>
-#include <boost/accumulators/statistics/variance.hpp>
-
 #include "heap.hpp"
+#include "lock_free_stats.hpp"
 
 namespace unodb {
 
@@ -497,8 +491,6 @@ inline void construct_current_thread_reclamator() {
   (void)this_thread();
 }
 
-namespace boost_acc = boost::accumulators;
-
 namespace detail {
 
 struct dealloc_vector_list_node;
@@ -555,34 +547,27 @@ class qsbr final {
 
   void register_quiescent_states_per_thread_between_epoch_changes(
       std::uint64_t states) noexcept {
-    std::lock_guard guard{quiescent_state_stats_lock};
-    quiescent_states_per_thread_between_epoch_change_stats(states);
-    publish_quiescent_states_per_thread_between_epoch_change_stats();
+    quiescent_states_per_thread_between_epoch_change_stats.add_value(states);
   }
 
   void register_dealloc_stats_per_thread_between_epoch_changes(
       // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
       std::size_t total_size, std::size_t count) noexcept {
-    std::lock_guard guard{dealloc_stats_lock};
-    deallocation_size_per_thread_stats(total_size);
-    publish_deallocation_size_stats();
-    epoch_dealloc_per_thread_count_stats(count);
-    publish_epoch_callback_stats();
+    deallocation_size_per_thread_stats.add_value(total_size);
+    epoch_dealloc_per_thread_count_stats.add_value(count);
   }
 
   [[nodiscard]] auto get_epoch_callback_count_max() const noexcept {
-    return epoch_dealloc_per_thread_count_max.load(std::memory_order_acquire);
+    return epoch_dealloc_per_thread_count_stats.get_max();
   }
 
   [[nodiscard]] auto get_epoch_callback_count_variance() const noexcept {
-    return epoch_dealloc_per_thread_count_variance.load(
-        std::memory_order_acquire);
+    return epoch_dealloc_per_thread_count_stats.get_variance();
   }
 
   [[nodiscard]] auto
   get_mean_quiescent_states_per_thread_between_epoch_changes() const noexcept {
-    return quiescent_states_per_thread_between_epoch_change_mean.load(
-        std::memory_order_acquire);
+    return quiescent_states_per_thread_between_epoch_change_stats.get_mean();
   }
 
   [[nodiscard]] std::uint64_t get_epoch_change_count() const noexcept {
@@ -590,11 +575,11 @@ class qsbr final {
   }
 
   [[nodiscard]] auto get_max_backlog_bytes() const noexcept {
-    return deallocation_size_per_thread_max.load(std::memory_order_acquire);
+    return deallocation_size_per_thread_stats.get_max();
   }
 
   [[nodiscard]] auto get_mean_backlog_bytes() const noexcept {
-    return deallocation_size_per_thread_mean.load(std::memory_order_acquire);
+    return deallocation_size_per_thread_stats.get_mean();
   }
 
   // Made public for tests and asserts
@@ -639,36 +624,7 @@ class qsbr final {
   qsbr_epoch change_epoch(qsbr_epoch current_global_epoch,
                           bool single_thread_mode) noexcept;
 
-  void publish_deallocation_size_stats() noexcept {
-    deallocation_size_per_thread_max.store(
-        boost_acc::max(deallocation_size_per_thread_stats),
-        std::memory_order_relaxed);
-    deallocation_size_per_thread_mean.store(
-        boost_acc::mean(deallocation_size_per_thread_stats),
-        std::memory_order_relaxed);
-    deallocation_size_per_thread_variance.store(
-        boost_acc::variance(deallocation_size_per_thread_stats),
-        std::memory_order_relaxed);
-  }
-
-  void publish_epoch_callback_stats() noexcept {
-    epoch_dealloc_per_thread_count_max.store(
-        boost_acc::max(epoch_dealloc_per_thread_count_stats),
-        std::memory_order_relaxed);
-    epoch_dealloc_per_thread_count_variance.store(
-        boost_acc::variance(epoch_dealloc_per_thread_count_stats),
-        std::memory_order_relaxed);
-  }
-
-  void
-  publish_quiescent_states_per_thread_between_epoch_change_stats() noexcept {
-    quiescent_states_per_thread_between_epoch_change_mean.store(
-        boost_acc::mean(quiescent_states_per_thread_between_epoch_change_stats),
-        std::memory_order_relaxed);
-  }
-
-  alignas(detail::hardware_destructive_interference_size)
-      std::atomic<qsbr_state::type> state;
+  std::atomic<qsbr_state::type> state;
 
   std::atomic<std::uint64_t> epoch_change_count;
 
@@ -683,32 +639,14 @@ class qsbr final {
                     sizeof(orphaned_current_interval_dealloc_requests) <=
                 detail::hardware_constructive_interference_size);
 
-  alignas(detail::hardware_destructive_interference_size) std::mutex
-      dealloc_stats_lock;
-
   // TODO(laurynas): more interesting callback stats?
-  boost_acc::accumulator_set<
-      std::size_t,
-      boost_acc::stats<boost_acc::tag::max, boost_acc::tag::variance>>
-      epoch_dealloc_per_thread_count_stats;
-  std::atomic<std::size_t> epoch_dealloc_per_thread_count_max;
-  std::atomic<double> epoch_dealloc_per_thread_count_variance;
+  alignas(detail::hardware_destructive_interference_size)
+      lock_free_max_variance_stats epoch_dealloc_per_thread_count_stats;
 
-  boost_acc::accumulator_set<
-      std::uint64_t,
-      boost_acc::stats<boost_acc::tag::max, boost_acc::tag::variance>>
-      deallocation_size_per_thread_stats;
-  std::atomic<std::uint64_t> deallocation_size_per_thread_max;
-  std::atomic<double> deallocation_size_per_thread_mean;
-  std::atomic<double> deallocation_size_per_thread_variance;
+  lock_free_max_variance_stats deallocation_size_per_thread_stats;
 
-  alignas(detail::hardware_destructive_interference_size) std::mutex
-      quiescent_state_stats_lock;
-
-  boost_acc::accumulator_set<std::uint64_t,
-                             boost_acc::stats<boost_acc::tag::mean>>
-      quiescent_states_per_thread_between_epoch_change_stats;
-  std::atomic<double> quiescent_states_per_thread_between_epoch_change_mean;
+  alignas(detail::hardware_destructive_interference_size)
+      lock_free_stats quiescent_states_per_thread_between_epoch_change_stats;
 };
 
 static_assert(std::atomic<std::size_t>::is_always_lock_free);

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -845,12 +845,14 @@ TEST_F(QSBR, ResetStats) {
   second_thread.join();
 
   ASSERT_EQ(unodb::qsbr::instance().get_max_backlog_bytes(), 2);
-  ASSERT_EQ(unodb::qsbr::instance().get_mean_backlog_bytes(), 1);
+  ASSERT_NEAR(unodb::qsbr::instance().get_mean_backlog_bytes(), 0.666667,
+              0.00001);
   ASSERT_EQ(unodb::qsbr::instance().get_epoch_callback_count_max(), 2);
-  ASSERT_EQ(unodb::qsbr::instance().get_epoch_callback_count_variance(), 1);
-  ASSERT_EQ(unodb::qsbr::instance()
-                .get_mean_quiescent_states_per_thread_between_epoch_changes(),
-            1.0);
+  ASSERT_NEAR(unodb::qsbr::instance().get_epoch_callback_count_variance(),
+              1.333333, 0.00001);
+  ASSERT_NEAR(unodb::qsbr::instance()
+                  .get_mean_quiescent_states_per_thread_between_epoch_changes(),
+              0.666667, 0.00001);
 
   unodb::qsbr::instance().reset_stats();
 
@@ -858,9 +860,9 @@ TEST_F(QSBR, ResetStats) {
   ASSERT_EQ(unodb::qsbr::instance().get_mean_backlog_bytes(), 0);
   ASSERT_EQ(unodb::qsbr::instance().get_epoch_callback_count_max(), 0);
   ASSERT_EQ(unodb::qsbr::instance().get_epoch_callback_count_variance(), 0);
-  ASSERT_TRUE(std::isnan(
-      unodb::qsbr::instance()
-          .get_mean_quiescent_states_per_thread_between_epoch_changes()));
+  ASSERT_EQ(unodb::qsbr::instance()
+                .get_mean_quiescent_states_per_thread_between_epoch_changes(),
+            0);
 }
 
 TEST_F(QSBR, GettersConcurrentWithQuiescentState) {


### PR DESCRIPTION
Implement lock-free statistics that use DWCAS to atomically update count and
mean. Additional optional stats of maximum and variance are implemented on the
top of that. Replace QSBR stats from Boost.Accumulator to this. The
implementation requires for x86_64, thus add -mcx16 compilation flag. This also
removes Boost dependency.

- Remove Boost dependency