### PR TITLE
Group QSBR fields by usage pattern and align to reduce false sharing

### DIFF
--- a/global.hpp
+++ b/global.hpp
@@ -95,10 +95,33 @@
 #define UNODB_DETAIL_RELEASE_EXPLICIT
 #endif
 
+#include <cstdlib>
+#include <new>
+
+#if !defined(__cpp_lib_hardware_interference_size) || \
+    __cpp_lib_hardware_interference_size < 201703
+
+namespace unodb::detail {
+
+#ifdef __x86_64
+inline constexpr std::size_t hardware_constructive_interference_size = 64;
+inline constexpr std::size_t hardware_destructive_interference_size = 64;
+#else
+#error Needs porting
+#endif
+
+}  // namespace unodb::detail
+
+#else
+
+using std::hardware_constructive_interference_size;
+using std::hardware_destructive_interference_size;
+
+#endif
+
 #ifndef NDEBUG
 #include <execinfo.h>
 #include <unistd.h>
-#include <cstdlib>
 #include <iostream>
 #include <sstream>
 #include <thread>

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -667,7 +667,8 @@ class qsbr final {
         std::memory_order_relaxed);
   }
 
-  std::atomic<qsbr_state::type> state;
+  alignas(detail::hardware_destructive_interference_size)
+      std::atomic<qsbr_state::type> state;
 
   std::atomic<std::uint64_t> epoch_change_count;
 
@@ -677,7 +678,13 @@ class qsbr final {
   std::atomic<detail::dealloc_vector_list_node *>
       orphaned_current_interval_dealloc_requests;
 
-  std::mutex dealloc_stats_lock;
+  static_assert(sizeof(state) + sizeof(epoch_change_count) +
+                    sizeof(orphaned_previous_interval_dealloc_requests) +
+                    sizeof(orphaned_current_interval_dealloc_requests) <=
+                detail::hardware_constructive_interference_size);
+
+  alignas(detail::hardware_destructive_interference_size) std::mutex
+      dealloc_stats_lock;
 
   // TODO(laurynas): more interesting callback stats?
   boost_acc::accumulator_set<
@@ -695,7 +702,8 @@ class qsbr final {
   std::atomic<double> deallocation_size_per_thread_mean;
   std::atomic<double> deallocation_size_per_thread_variance;
 
-  std::mutex quiescent_state_stats_lock;
+  alignas(detail::hardware_destructive_interference_size) std::mutex
+      quiescent_state_stats_lock;
 
   boost_acc::accumulator_set<std::uint64_t,
                              boost_acc::stats<boost_acc::tag::mean>>


### PR DESCRIPTION
I'd use std::hardware_constructive_interference_size and
std::hardware_destructive_interference_size but they are not available
universally. Thus declare my own ones.