### PR TITLE
Split out assert.hpp out of global.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,7 @@ endfunction()
 add_library(unodb_util INTERFACE)
 # Move to add_library itself once CMake minimum version is 3.13
 target_sources(unodb_util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/global.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/assert.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/thread_sync.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/heap.hpp)
 target_include_directories(unodb_util INTERFACE ".")

--- a/art.cpp
+++ b/art.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -9,6 +9,7 @@
 #include <utility>  // IWYU pragma: keep
 
 #include "art_internal_impl.hpp"
+#include "assert.hpp"
 #include "in_fake_critical_section.hpp"
 #include "node_type.hpp"
 

--- a/art.hpp
+++ b/art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_ART_HPP
 #define UNODB_DETAIL_ART_HPP
 
@@ -11,6 +11,7 @@
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
+#include "assert.hpp"
 #include "node_type.hpp"
 
 namespace unodb {

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_ART_INTERNAL_HPP
 #define UNODB_DETAIL_ART_INTERNAL_HPP
 
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "art_common.hpp"
+#include "assert.hpp"
 #include "node_type.hpp"
 
 namespace unodb::detail {

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -23,6 +23,7 @@
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
+#include "assert.hpp"
 #include "heap.hpp"
 #include "node_type.hpp"
 

--- a/assert.hpp
+++ b/assert.hpp
@@ -1,0 +1,87 @@
+// Copyright 2022 Laurynas Biveinis
+#ifndef UNODB_DETAIL_ASSERT_HPP
+#define UNODB_DETAIL_ASSERT_HPP
+
+#include "global.hpp"
+
+#ifndef NDEBUG
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#if defined(__linux__) && !defined(__clang__)
+#define BOOST_STACKTRACE_USE_BACKTRACE
+#elif defined(__APPLE__)
+#define BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED
+#endif
+#include <boost/stacktrace.hpp>
+
+namespace unodb::detail {
+
+// LCOV_EXCL_START
+
+[[noreturn, gnu::cold, gnu::noinline]] inline void msg_stacktrace_abort(
+    const std::string &msg) noexcept {
+  std::ostringstream buf;
+  buf << msg << boost::stacktrace::stacktrace();
+  std::cerr << buf.str();
+  std::abort();
+}
+
+[[noreturn, gnu::cold, gnu::noinline]] inline void assert_failure(
+    const char *file, int line, const char *func, const char *condition) {
+  std::ostringstream buf;
+  buf << "Assertion \"" << condition << "\" failed at " << file << ':' << line
+      << ", function \"" << func << "\", thread " << std::this_thread::get_id()
+      << '\n';
+  msg_stacktrace_abort(buf.str());
+}
+
+[[noreturn, gnu::cold, gnu::noinline]] inline void crash(const char *file,
+                                                         int line,
+                                                         const char *func) {
+  std::ostringstream buf;
+  buf << "Crash requested at " << file << ':' << line << ", function \"" << func
+      << "\", thread " << std::this_thread::get_id() << '\n';
+  msg_stacktrace_abort(buf.str());
+}
+
+[[noreturn]] inline void cannot_happen(const char *file, int line,
+                                       const char *func) {
+  std::ostringstream buf;
+  buf << "Execution reached an unreachable point at " << file << ':' << line
+      << ": function \"" << func << "\", thread " << std::this_thread::get_id()
+      << '\n';
+  msg_stacktrace_abort(buf.str());
+}
+
+#define UNODB_DETAIL_ASSERT(condition)                                      \
+  UNODB_DETAIL_UNLIKELY(!(condition))                                       \
+  ? unodb::detail::assert_failure(__FILE__, __LINE__, __func__, #condition) \
+  : ((void)0)
+
+}  // namespace unodb::detail
+
+#else  // #ifndef NDEBUG
+
+namespace unodb::detail {
+
+[[noreturn]] inline void cannot_happen(const char *, int, const char *) {
+  __builtin_unreachable();
+}
+
+}  // namespace unodb::detail
+
+#define UNODB_DETAIL_ASSERT(condition) ((void)0)
+
+#endif  // #ifndef NDEBUG
+
+#define UNODB_DETAIL_CANNOT_HAPPEN() \
+  unodb::detail::cannot_happen(__FILE__, __LINE__, __func__)
+
+#define UNODB_DETAIL_CRASH() unodb::detail::crash(__FILE__, __LINE__, __func__)
+
+// LCOV_EXCL_STOP
+
+#endif

--- a/benchmark/micro_benchmark_key_prefix.cpp
+++ b/benchmark/micro_benchmark_key_prefix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Laurynas Biveinis
+// Copyright 2020-2022 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -11,6 +11,7 @@
 
 #include "art.hpp"
 #include "art_common.hpp"
+#include "assert.hpp"
 #include "micro_benchmark_utils.hpp"
 #include "mutex_art.hpp"
 #include "olc_art.hpp"

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -19,6 +19,7 @@
 #include <benchmark/benchmark.h>
 
 #include "art_common.hpp"
+#include "assert.hpp"
 #include "micro_benchmark_utils.hpp"
 #include "node_type.hpp"
 

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 
@@ -14,6 +14,7 @@
 #include <benchmark/benchmark.h>
 
 #include "art_common.hpp"
+#include "assert.hpp"
 #include "olc_art.hpp"
 #include "qsbr.hpp"
 

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Laurynas Biveinis
+// Copyright 2021-2022 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -14,6 +14,7 @@
 
 #include <deepstate/DeepState.hpp>
 
+#include "assert.hpp"
 #include "deepstate_utils.hpp"
 #include "heap.hpp"
 #include "qsbr.hpp"

--- a/heap.hpp
+++ b/heap.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Laurynas Biveinis
+// Copyright 2020-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_HEAP_HPP
 #define UNODB_DETAIL_HEAP_HPP
 
@@ -14,6 +14,8 @@
 #include <sanitizer/asan_interface.h>
 #endif
 #endif
+
+#include "assert.hpp"
 
 #ifndef ASAN_POISON_MEMORY_REGION
 

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Laurynas Biveinis
+// Copyright 2021-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_NODE_TYPE_HPP
 #define UNODB_DETAIL_NODE_TYPE_HPP
 
@@ -7,6 +7,8 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+
+#include "assert.hpp"
 
 namespace unodb {
 

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 
 #include "art_internal.hpp"
 #include "global.hpp"
@@ -12,6 +12,7 @@
 #include <utility>  // IWYU pragma: keep
 
 #include "art_internal_impl.hpp"
+#include "assert.hpp"
 #include "node_type.hpp"
 #include "optimistic_lock.hpp"
 #include "qsbr.hpp"

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_OLC_ART_HPP
 #define UNODB_DETAIL_OLC_ART_HPP
 
@@ -13,6 +13,7 @@
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
+#include "assert.hpp"
 #include "node_type.hpp"
 #include "optimistic_lock.hpp"
 #include "qsbr_ptr.hpp"

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 Laurynas Biveinis
+// Copyright (C) 2019-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_OPTIMISTIC_LOCK_HPP
 #define UNODB_DETAIL_OPTIMISTIC_LOCK_HPP
 
@@ -16,6 +16,8 @@
 #include <optional>
 #include <thread>
 #include <type_traits>
+
+#include "assert.hpp"
 
 namespace unodb {
 

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -8,6 +8,8 @@
 #include <sanitizer/tsan_interface.h>
 #endif
 
+#include "assert.hpp"
+
 namespace {
 
 struct run_tls_ctor_in_main_thread {

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -28,6 +28,7 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
 
+#include "assert.hpp"
 #include "heap.hpp"
 
 namespace unodb {

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Laurynas Biveinis
+// Copyright 2019-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_DB_TEST_UTILS_HPP
 #define UNODB_DETAIL_DB_TEST_UTILS_HPP
 
@@ -19,6 +19,7 @@
 
 #include "art.hpp"
 #include "art_common.hpp"
+#include "assert.hpp"
 #include "mutex_art.hpp"
 #include "node_type.hpp"
 #include "olc_art.hpp"

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Laurynas Biveinis
+// Copyright 2021-2022 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>  // IWYU pragma: keep
 
 #include "art_common.hpp"
+#include "assert.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "mutex_art.hpp"  // IWYU pragma: keep

--- a/thread_sync.hpp
+++ b/thread_sync.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Laurynas Biveinis
+// Copyright 2020-2022 Laurynas Biveinis
 #ifndef UNODB_DETAIL_THREAD_SYNC_HPP
 #define UNODB_DETAIL_THREAD_SYNC_HPP
 
@@ -7,6 +7,8 @@
 #include <array>
 #include <condition_variable>
 #include <mutex>
+
+#include "assert.hpp"
 
 namespace unodb::detail {
 


### PR DESCRIPTION
Not every source file asserts, so maybe this is a compilation speedup for them,
since asserts use Boost.Stacktrace