### PR TITLE
MSVC port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@
 
 # CMake preset user config
 /CMakeUserPresets.json
+
+# MSVC
+/.vs
+/out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,20 @@ set(GCC_GE_11_CXX_WARNING_FLAGS
   "-Wctad-maybe-unsupported" "-Wdeprecated-enum-enum-conversion"
   "-Wdeprecated-enum-float-conversion" "-Wvexing-parse")
 
-list(APPEND CXX_FLAGS "-g" "-msse4.1")
+set(GCC_CLANG_CXX_FLAGS "-g" "-msse4.1")
+
+if(MSVC)
+  string(REGEX REPLACE "/Zi" "/ZI /INCREMENTAL" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  # Remove it once CMake minimum is bumped to 3.15 or greater
+  string(REGEX REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endif()
+
+# For MSVC, disable the following warnings:
+# - "warning C4324: '...': structure was padded due to alignment specifier"
+# - "warning C5030: attribute '...' is not recognized"
+set(MSVC_CXX_WARNING_FLAGS "/W4" "/wd4324" "/wd5030")
+
+set(MSVC_CXX_FLAGS "/external:anglebrackets" "/external:W0" "/arch:AVX")
 
 option(COVERAGE "Enable code coverage reporting")
 if(COVERAGE)
@@ -192,6 +205,8 @@ string(REPLACE ";" " " LD_FLAGS_FOR_SUBDIR_STR "${SANITIZER_LD_FLAGS}")
 string(APPEND CMAKE_EXE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
 string(APPEND CMAKE_MODULE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
 string(APPEND CMAKE_SHARED_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(3rd_party/googletest)
 
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Suppressing Google Benchmark tests"
@@ -216,10 +231,11 @@ endif()
 
 add_subdirectory(3rd_party/benchmark)
 
-# Do not build DeepState with GCC under macOS due to
-# https://github.com/trailofbits/deepstate/issues/374
+# Do not build DeepState:
+# - under MSVC as it's not supported
+# - with GCC under macOS due to https://github.com/trailofbits/deepstate/issues/374
 if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_SYSTEM_NAME}"
-      STREQUAL "Darwin"))
+      STREQUAL "Darwin") AND NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC"))
   # ThreadSanitizer is not compatible with libfuzzer and LLVM 11 linker crashes
   # on libfuzzer release build
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT("${CMAKE_BUILD_TYPE}"
@@ -246,7 +262,7 @@ if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_SYSTEM_NAME}"
   add_dependencies(deepstate 3rd_party_deepstate)
   target_include_directories(deepstate INTERFACE "${SOURCE_DIR}/src/include/")
   set_target_properties(deepstate PROPERTIES IMPORTED_LOCATION
-    "${BINARY_DIR}/libdeepstate.a")
+    "${BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}deepstate${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
   if(LIBFUZZER_AVAILABLE)
     add_library(deepstate_lf STATIC IMPORTED)
@@ -350,14 +366,17 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   target_compile_definitions(${TARGET} PRIVATE
     "$<$<AND:$<CONFIG:Debug>,$<BOOL:${VALGRIND_CLIENT}>>:VALGRIND_CLIENT_REQUESTS>")
   target_compile_options(${TARGET} PRIVATE
-    "$<$<BOOL:${FATAL_WARNINGS}>:-Werror>"
+    "$<$<CXX_COMPILER_ID:MSVC>:${MSVC_CXX_FLAGS}>"
+    "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:${GCC_CLANG_CXX_FLAGS}>"
+    "$<$<BOOL:${FATAL_WARNINGS}>:$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>>"
+    "$<$<CXX_COMPILER_ID:MSVC>:${MSVC_CXX_WARNING_FLAGS}>"
     "$<$<CXX_COMPILER_ID:AppleClang,Clang>:${CLANG_CXX_WARNING_FLAGS}>"
     "$<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,13.0>>:${CLANG_LT_13_CXX_WARNING_FLAGS}>"
     "$<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,13.0>>:${CLANG_GE_13_CXX_WARNING_FLAGS}>"
     "$<$<CXX_COMPILER_ID:GNU>:${GCC_CXX_WARNING_FLAGS}>"
     "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11.0>>:${GCC_GE_11_CXX_WARNING_FLAGS}>"
-    "$<$<CONFIG:Debug>:-O0>"
-    "$<$<CONFIG:Release>:$<IF:$<BOOL:${COVERAGE}>,-O0,-O3>>"
+    "$<$<CONFIG:Debug>:$<IF:$<CXX_COMPILER_ID:MSVC>,/Od,-O0>>"
+    "$<$<AND:$<CONFIG:Release>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:$<IF:$<BOOL:${COVERAGE}>,-O0,-O3>>"
     "$<$<BOOL:${COVERAGE}>:--coverage>")
   target_compile_options(${TARGET} PRIVATE "${CXX_FLAGS}")
   target_compile_options(${TARGET} PRIVATE "${SANITIZER_CXX_FLAGS}")
@@ -460,6 +479,12 @@ if(TARGET deepstate)
 endif()
 add_subdirectory(test)
 
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-  ${CMAKE_BINARY_DIR}/compile_commands.json
-  ${CMAKE_SOURCE_DIR}/compile_commands.json)
+if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json)
+else()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,13 +7,24 @@
     },
     "configurePresets": [
         {
-            "name": "base-unix",
+            "name": "base",
             "hidden": true,
-            "generator": "Unix Makefiles",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "FATAL_WARNINGS": "ON"
             }
+        },
+        {
+            "name": "base-unix",
+            "hidden": true,
+            "inherits": "base",
+            "generator": "Unix Makefiles"
+        },
+        {
+            "name": "base-msvc",
+            "hidden": true,
+            "inherits": "base",
+            "generator": "Ninja"
         },
         {
             "name": "asan",
@@ -262,6 +273,14 @@
                 "gcc",
                 "static-analysis"
             ]
+        },
+        {
+            "name": "msvc-debug",
+            "inherits": [ "base-msvc", "debug" ]
+        },
+        {
+            "name": "msvc-release",
+            "inherits": [ "base-msvc", "release" ]
         }
     ],
     "buildPresets": [
@@ -398,6 +417,16 @@
         {
             "name": "gcc-static-analysis-release",
             "configurePreset": "gcc-static-analysis-release",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-debug",
+            "configurePreset": "msvc-debug",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-release",
+            "configurePreset": "msvc-release",
             "inherits": "base"
         }
     ],
@@ -537,6 +566,16 @@
         {
             "name": "gcc-static-analysis-release",
             "configurePreset": "gcc-static-analysis-release",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-debug",
+            "configurePreset": "msvc-debug",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-release",
+            "configurePreset": "msvc-release",
             "inherits": "base"
         }
     ]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ and I am trying to describe some of the things I learned at my [blog](https://of
 
 ## Requirements
 
-The source code is C++17, using SSE4.1 intrinsics (Nehalem and higher). This is
-in contrast to the original ART paper needing SSE2 only.
+The source code is C++17, using SSE4.1 intrinsics (Nehalem and higher) or AVX
+in the case of MSVC. This is in contrast to the original ART paper needing SSE2
+only.
 
 Note: since this is my personal project, it only supports GCC 10, 11, LLVM 11 to
 13, and XCode 12.2 compilers. Drop me a note if you want to try this and need a

--- a/art.cpp
+++ b/art.cpp
@@ -92,7 +92,13 @@ class [[nodiscard]] inode_4 final
   }
 };
 
+#ifndef _MSC_VER
 static_assert(sizeof(inode_4) == 48);
+#else
+// MSVC pads the first field to 8 byte boundary even though its natural
+// alignment is 4 bytes, maybe due to parent class sizeof
+static_assert(sizeof(inode_4) == 56);
+#endif
 
 class [[nodiscard]] inode_16 final
     : public unodb::detail::basic_inode_16<art_policy> {

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -27,12 +27,12 @@ class [[nodiscard]] basic_db_leaf_deleter;
 // Internal ART key in binary-comparable format
 template <typename KeyType>
 struct [[nodiscard]] basic_art_key final {
-  [[nodiscard, gnu::const]] static constexpr KeyType make_binary_comparable(
-      KeyType key) noexcept;
+  [[nodiscard, gnu::const]] static UNODB_DETAIL_CONSTEXPR_NOT_MSVC KeyType
+  make_binary_comparable(KeyType key) noexcept;
 
   constexpr basic_art_key() noexcept = default;
 
-  constexpr explicit basic_art_key(KeyType key_) noexcept
+  UNODB_DETAIL_CONSTEXPR_NOT_MSVC explicit basic_art_key(KeyType key_) noexcept
       : key{make_binary_comparable(key_)} {}
 
   // NOLINTNEXTLINE(modernize-avoid-c-arrays)

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -36,7 +36,7 @@ class olc_db;
 namespace unodb::detail {
 
 template <>
-[[nodiscard, gnu::const]] inline constexpr std::uint64_t
+[[nodiscard, gnu::const]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC std::uint64_t
 basic_art_key<std::uint64_t>::make_binary_comparable(std::uint64_t k) noexcept {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return bswap(k);

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -307,12 +307,20 @@ class [[nodiscard]] olc_inode_4 final
   }
 };
 
-// 48 == sizeof(inode_4)
+// 48 (or 56) == sizeof(inode_4)
+#ifndef _MSC_VER
 #ifdef NDEBUG
 static_assert(sizeof(olc_inode_4) == 48 + 8);
 #else
 static_assert(sizeof(olc_inode_4) == 48 + 24);
 #endif
+#else  // #ifndef _MSC_VER
+#ifdef NDEBUG
+static_assert(sizeof(olc_inode_4) == 56 + 8);
+#else
+static_assert(sizeof(olc_inode_4) == 56 + 24);
+#endif
+#endif  // #ifndef _MSC_VER
 
 class [[nodiscard]] olc_inode_16 final
     : public unodb::detail::basic_inode_16<olc_art_policy> {
@@ -766,6 +774,8 @@ template <class INode>
 
 namespace unodb {
 
+// FIXME(laurynas): why UNODB_DETAIL_USED_IN_DEBUG does not work?
+UNODB_DETAIL_DISABLE_MSVC_WARNING(4189)
 template <class INode>
 constexpr void olc_db::decrement_inode_count() noexcept {
   static_assert(olc_inode_defs::is_inode<INode>());
@@ -776,6 +786,7 @@ constexpr void olc_db::decrement_inode_count() noexcept {
 
   decrease_memory_use(sizeof(INode));
 }
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 template <node_type NodeType>
 constexpr void olc_db::account_growing_inode() noexcept {

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -86,6 +86,8 @@ class olc_db final {
     return node_counts[as_i<NodeType>].load(std::memory_order_relaxed);
   }
 
+  // warning C4701: potentially uninitialized local variable '...' used
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(4701)
   [[nodiscard]] auto get_node_counts() const noexcept {
     node_type_counter_array result;
     for (decltype(node_counts)::size_type i = 0; i < node_counts.size(); ++i) {
@@ -93,6 +95,7 @@ class olc_db final {
     }
     return result;
   }
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   template <node_type NodeType>
   [[nodiscard]] auto get_growing_inode_count() const noexcept {
@@ -100,6 +103,8 @@ class olc_db final {
         std::memory_order_relaxed);
   }
 
+  // warning C4701: potentially uninitialized local variable '...' used
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(4701)
   [[nodiscard]] auto get_growing_inode_counts() const noexcept {
     inode_type_counter_array result;
     for (decltype(growing_inode_counts)::size_type i = 0;
@@ -108,6 +113,7 @@ class olc_db final {
     }
     return result;
   }
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   template <node_type NodeType>
   [[nodiscard]] auto get_shrinking_inode_count() const noexcept {
@@ -115,6 +121,8 @@ class olc_db final {
         std::memory_order_relaxed);
   }
 
+  // warning C4701: potentially uninitialized local variable '...' used
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(4701)
   [[nodiscard]] auto get_shrinking_inode_counts() const noexcept {
     inode_type_counter_array result;
     for (decltype(shrinking_inode_counts)::size_type i = 0;
@@ -123,6 +131,7 @@ class olc_db final {
     }
     return result;
   }
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   [[nodiscard]] auto get_key_prefix_splits() const noexcept {
     return key_prefix_splits.load(std::memory_order_relaxed);
@@ -167,6 +176,8 @@ class olc_db final {
     node_counts[as_i<node_type::LEAF>].fetch_add(1, std::memory_order_relaxed);
   }
 
+  // FIXME(laurynas): why UNODB_DETAIL_USED_IN_DEBUG does not work?
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(4189)
   void decrement_leaf_count(std::size_t leaf_size) noexcept {
     decrease_memory_use(leaf_size);
 
@@ -175,6 +186,7 @@ class olc_db final {
                                                      std::memory_order_relaxed);
     UNODB_DETAIL_ASSERT(old_leaf_count > 0);
   }
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   template <class INode>
   constexpr void increment_inode_count() noexcept;

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -6,22 +6,51 @@
 
 #include <cstdint>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#include <gsl/gsl_util>
+#endif
+
 namespace unodb::detail {
 
-[[nodiscard, gnu::pure]] constexpr auto bswap(std::uint64_t x) noexcept {
+[[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC std::uint64_t bswap(
+    std::uint64_t x) noexcept {
+#ifndef _MSC_VER
   return __builtin_bswap64(x);
+#else
+  return _byteswap_uint64(x);
+#endif
 }
 
-[[nodiscard, gnu::pure]] constexpr unsigned ctz(unsigned x) noexcept {
+[[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned ctz(
+    unsigned x) noexcept {
+#ifndef _MSC_VER
   return static_cast<unsigned>(__builtin_ctz(x));
+#else
+  unsigned long result;  // NOLINT(runtime/int)
+  _BitScanForward(&result, x);
+  return gsl::narrow_cast<unsigned>(result);
+#endif
 }
 
-[[nodiscard, gnu::pure]] constexpr unsigned ctz64(std::uint64_t x) noexcept {
+[[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned ctz64(
+    std::uint64_t x) noexcept {
+#ifndef _MSC_VER
   return static_cast<unsigned>(__builtin_ctzll(x));
+#else
+  unsigned long result;  // NOLINT(runtime/int)
+  _BitScanForward64(&result, x);
+  return gsl::narrow_cast<unsigned>(result);
+#endif
 }
 
-[[nodiscard, gnu::pure]] constexpr unsigned popcount(unsigned x) noexcept {
+[[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned popcount(
+    unsigned x) noexcept {
+#ifndef _MSC_VER
   return static_cast<unsigned>(__builtin_popcount(x));
+#else
+  return static_cast<unsigned>(__popcnt(x));
+#endif
 }
 
 }  // namespace unodb::detail


### PR DESCRIPTION
- Add CMake compilation flags, use copy instead of symlink on Windows
- Add msvc-debug and msvc-release CMake presets
- Provide MSVC builtins, warning suppressions, aligned allocation, etc.
- Assert different Node4 sizes in the case of MSVC
- add MSVC entries to .gitgnore