### PR TITLE
Add support for MSVC AddressSanitizer

### DIFF
--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -13,6 +13,9 @@ jobs:
           - name: MSVC Release
             preset: "msvc-release"
 
+          - name: MSVC Release with ASan
+            preset: "msvc-release-asan"
+
           - name: MSVC Debug
             preset: "msvc-debug"
 
@@ -41,4 +44,4 @@ jobs:
         run: cmake --build --preset "${{ matrix.preset }}"
 
       - name: Test
-        run: ctest --preset "${{ matrix.preset }}"
+        run: ctest -V --preset "${{ matrix.preset }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,13 @@ if(MSVC)
   # Remove it once CMake minimum is bumped to 3.15 or greater
   string(REGEX REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
-
-# For MSVC, disable the following warnings:
-# - "warning C4324: '...': structure was padded due to alignment specifier"
-# - "warning C5030: attribute '...' is not recognized"
-set(MSVC_CXX_WARNING_FLAGS "/W4" "/wd4324" "/wd5030")
+  
+# Disable the following warnings for MSVC:
+# - "C4324: '...': structure was padded due to alignment specifier"
+# - "C5030: attribute '...' is not recognized"
+# - "C5072, ASAN enabled without debug information emission" - triggered by
+# msvc-release-asan preset
+set(MSVC_CXX_WARNING_FLAGS "/W4" "/wd4324" "/wd5030" "/wd5072")
 
 set(MSVC_CXX_FLAGS "/external:anglebrackets" "/external:W0" "/arch:AVX")
 
@@ -135,24 +137,29 @@ macro(ADD_TO_GNU_SANITIZER_FLAGS)
 endmacro()
 
 macro(SET_COMMON_SANITIZER_FLAGS)
-  list(APPEND SANITIZER_CXX_FLAGS "-fno-omit-frame-pointer"
-    "-fno-optimize-sibling-calls")
+  if(NOT MSVC)
+    list(APPEND SANITIZER_CXX_FLAGS "-fno-omit-frame-pointer"
+        "-fno-optimize-sibling-calls")
+  endif()
 endmacro()
 
 option(SANITIZE_ADDRESS "Enable AddressSanitizer runtime checks")
 if(SANITIZE_ADDRESS)
   set_common_sanitizer_flags()
-  list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=address")
-  list(APPEND SANITIZER_LD_FLAGS "-fsanitize=address")
-  add_to_gnu_sanitizer_flags("-fsanitize=leak"
-    "-fsanitize-address-use-after-scope" "-fsanitize=pointer-compare"
-    "-fsanitize=pointer-subtract")
+  if(MSVC)
+    list(APPEND SANITIZER_CXX_FLAGS "/fsanitize=address")
+  else()
+    list(APPEND SANITIZER_CXX_FLAGS "-fsanitize=address")
+    list(APPEND SANITIZER_LD_FLAGS "-fsanitize=address")
+    add_to_gnu_sanitizer_flags("-fsanitize=leak"
+        "-fsanitize-address-use-after-scope" "-fsanitize=pointer-compare"
+        "-fsanitize=pointer-subtract")
+  endif()
   string(CONCAT ASAN_ENV "ASAN_OPTIONS="
     "check_initialization_order=true:detect_stack_use_after_return=true:"
     "alloc_dealloc_mismatch=true:strict_string_checks=true")
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
-      OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    # Not for GCC, up to version 10 at least, because:
+  if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # Not for GCC, up to version 11 at least, because:
     # 1) AddressSanitizer CHECK failed:
     # ../../../../src/libsanitizer/asan/asan_thread.cpp:369 "((bottom)) != (0)"
     # (0x0, 0x0)
@@ -164,7 +171,8 @@ if(SANITIZE_ADDRESS)
     # /usr/include/c++/8/sstream:173
     string(APPEND ASAN_ENV ":detect_invalid_pointer_pairs=2")
   endif()
-  if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"
+      OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     string(APPEND ASAN_ENV ":detect_leaks=1")
   endif()
   set(SANITIZER_ENV ${ASAN_ENV})
@@ -199,8 +207,17 @@ find_package(Threads REQUIRED)
 
 find_package(Boost REQUIRED)
 
+set(ORIG_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+set(ORIG_CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+set(ORIG_CMAKE_MODULE_LINKER_FLAGS ${CMAKE_MODULE_LINKER_FLAGS})
+set(ORIG_CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
+
 string(REPLACE ";" " " CXX_FLAGS_FOR_SUBDIR_STR "${SANITIZER_CXX_FLAGS}")
 string(APPEND CMAKE_CXX_FLAGS ${CXX_FLAGS_FOR_SUBDIR_STR})
+if(MSVC)
+  string(REPLACE ";" " " WARNING_FLAGS_FOR_SUBDIR_STR "${MSVC_CXX_WARNING_FLAGS}")
+  string(APPEND CMAKE_CXX_FLAGS " " ${WARNING_FLAGS_FOR_SUBDIR_STR})
+endif()
 string(REPLACE ";" " " LD_FLAGS_FOR_SUBDIR_STR "${SANITIZER_LD_FLAGS}")
 string(APPEND CMAKE_EXE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
 string(APPEND CMAKE_MODULE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
@@ -208,6 +225,11 @@ string(APPEND CMAKE_SHARED_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory(3rd_party/googletest)
+
+set(CMAKE_CXX_FLAGS ${ORIG_CMAKE_CXX_FLAGS})
+set(CMAKE_EXE_LINKER_FLAGS ${ORIG_CMAKE_EXE_LINKER_FLAGS})
+set(CMAKE_MODULE_LINKER_FLAGS ${ORIG_CMAKE_MODULE_LINKER_FLAGS})
+set(CMAKE_SHARED_LINKER_FLAGS ${ORIG_CMAKE_SHARED_LINKER_FLAGS})
 
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Suppressing Google Benchmark tests"
   FORCE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -276,11 +276,33 @@
         },
         {
             "name": "msvc-debug",
-            "inherits": [ "base-msvc", "debug" ]
+            "inherits": [
+                "base-msvc",
+                "debug"
+            ]
         },
         {
             "name": "msvc-release",
-            "inherits": [ "base-msvc", "release" ]
+            "inherits": [
+                "base-msvc",
+                "release"
+            ]
+        },
+        {
+            "name": "msvc-debug-asan",
+            "inherits": [
+                "base-msvc",
+                "debug",
+                "asan"
+            ]
+        },
+        {
+            "name": "msvc-release-asan",
+            "inherits": [
+                "base-msvc",
+                "release",
+                "asan"
+            ]
         }
     ],
     "buildPresets": [
@@ -427,6 +449,16 @@
         {
             "name": "msvc-release",
             "configurePreset": "msvc-release",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-debug-asan",
+            "configurePreset": "msvc-debug-asan",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-release-asan",
+            "configurePreset": "msvc-release-asan",
             "inherits": "base"
         }
     ],
@@ -576,6 +608,16 @@
         {
             "name": "msvc-release",
             "configurePreset": "msvc-release",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-debug-asan",
+            "configurePreset": "msvc-debug-asan",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-release-asan",
+            "configurePreset": "msvc-release-asan",
             "inherits": "base"
         }
     ]

--- a/global.hpp
+++ b/global.hpp
@@ -28,6 +28,12 @@
 
 #ifdef _MSC_VER
 #define NOMINMAX
+#if !defined(NDEBUG) && defined(__SANITIZE_ADDRESS__)
+// Workaround bug of _aligned_free not being hooked for ASan under MSVC debug
+// build -
+// https://developercommunity.visualstudio.com/t/asan-check-failed-using-aligned-free-in-debug-buil/1406956
+#undef _CRTDBG_MAP_ALLOC
+#endif
 #endif
 
 // Architecture

--- a/heap.hpp
+++ b/heap.hpp
@@ -11,6 +11,10 @@
 #include <malloc.h>
 #endif
 
+// Do not try to use ASan interface under MSVC until the headers are added to
+// the default search paths:
+// https://developercommunity.visualstudio.com/t/ASan-API-headers-not-in-include-path-whe/1517192
+#ifndef _MSC_VER
 #if defined(__SANITIZE_ADDRESS__)
 #include <sanitizer/asan_interface.h>
 #elif defined(__has_feature)
@@ -18,8 +22,7 @@
 #include <sanitizer/asan_interface.h>
 #endif
 #endif
-
-#include "assert.hpp"
+#endif
 
 #ifndef ASAN_POISON_MEMORY_REGION
 
@@ -36,6 +39,8 @@
 #define VALGRIND_FREELIKE_BLOCK(addr, rzB)
 #define VALGRIND_MAKE_MEM_UNDEFINED(_qzz_addr, _qzz_len)
 #endif
+
+#include "assert.hpp"
 
 namespace unodb::detail {
 


### PR DESCRIPTION
- CMake plumbing
- New CMake presets msvc-debug-asan and msvc-release-asan
- Disable ASan user requests under MSVC until https://developercommunity.visualstudio.com/t/ASan-API-headers-not-in-include-path-whe/1517192 is fixed
- New matrix entries for MSVC build GitHub Action