### PR TITLE
Basic ARM port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,9 +279,11 @@ add_subdirectory(3rd_party/benchmark)
 
 # Do not build DeepState:
 # - under Windows as it's not supported
+# - on ARM
 # - with GCC under macOS due to https://github.com/trailofbits/deepstate/issues/374
 if(NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND "${CMAKE_SYSTEM_NAME}"
-      STREQUAL "Darwin") AND NOT ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows"))
+      STREQUAL "Darwin") AND NOT ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    AND NOT ("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64"))
   # ThreadSanitizer is not compatible with libfuzzer and LLVM 11 linker crashes
   # on libfuzzer release build
   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT("${CMAKE_BUILD_TYPE}"

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1273,7 +1273,11 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
     }
     return std::make_pair(0xFF, nullptr);
 #else
-#error Needs porting
+    for (size_t i = 0; i < this->children_count.load(); ++i)
+      if (key_byte == keys.byte_array[i])
+        return std::make_pair(
+            i, static_cast<critical_section_policy<node_ptr> *>(&children[i]));
+    return std::make_pair(0xFF, nullptr);
 #endif
   }
 

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -396,12 +396,21 @@ class [[nodiscard]] olc_inode_16 final
   }
 };
 
+// TODO(laurynas): why ARM is different?
 // 160 == sizeof(inode_16)
 #ifdef NDEBUG
+#ifdef __aarch64__
+static_assert(sizeof(olc_inode_16) == 160 + 8);
+#else   // #ifdef __aarch64__
 static_assert(sizeof(olc_inode_16) == 160 + 16);
-#else
+#endif  // #ifdef __aarch64__
+#else   // #ifdef NDEBUG
+#ifdef __aarch64__
+static_assert(sizeof(olc_inode_16) == 160 + 24);
+#else   // #ifdef __aarch64__
 static_assert(sizeof(olc_inode_16) == 160 + 32);
-#endif
+#endif  // #ifdef __aarch64__
+#endif  // #ifdef NDEBUG
 
 olc_inode_4::olc_inode_4(
     db_inode16_reclaimable_ptr &&source_node,
@@ -490,11 +499,20 @@ class [[nodiscard]] olc_inode_48 final
   }
 };
 
+// TODO(laurynas): why ARM is different?
 // 656 == sizeof(inode_48)
 #ifdef NDEBUG
+#ifdef __aarch64__
+static_assert(sizeof(olc_inode_48) == 656 + 8);
+#else   // #ifdef __aarch64__
 static_assert(sizeof(olc_inode_48) == 656 + 16);
+#endif  // #ifdef __aarch64__
 #else
+#ifdef __aarch64__
+static_assert(sizeof(olc_inode_48) == 656 + 24);
+#else   // #ifdef __aarch64__
 static_assert(sizeof(olc_inode_48) == 656 + 32);
+#endif  // #ifdef __aarch64__
 #endif
 
 [[nodiscard]] inline olc_inode_16::db_inode16_unique_ptr olc_inode_16::create(

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -29,6 +29,8 @@ inline void spin_wait_loop_body() noexcept {
 #elif defined(UNODB_DETAIL_X86_64)
   // Dear reader, please don't make fun of this just yet
   _mm_pause();
+#elif defined(__aarch64__)
+  __asm__ __volatile__("yield\n");
 #else
 #error Needs porting
 #endif

--- a/portability_stdlib.hpp
+++ b/portability_stdlib.hpp
@@ -17,6 +17,9 @@ inline constexpr std::size_t hardware_constructive_interference_size = 64;
 // Two cache lines for destructive interference due to Intel fetching cache
 // lines in pairs
 inline constexpr std::size_t hardware_destructive_interference_size = 128;
+#elif defined(__aarch64__)
+inline constexpr std::size_t hardware_constructive_interference_size = 64;
+inline constexpr std::size_t hardware_destructive_interference_size = 64;
 #else
 #error Needs porting
 #endif


### PR DESCRIPTION
- Define hardware constructive and destructive interference sizes
- Add trivial baseline non-SIMD implementations for SIMD code
- Guard x86_64-specific compilation flags in CMake