### PR TITLE
Introduce UNODB_DETAIL_ASSUME macro

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1165,6 +1165,8 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
       children[i] = source_node->children[i];
     }
 
+    UNODB_DETAIL_ASSUME(i < parent_class::capacity);
+
     keys.byte_array[i] = static_cast<std::byte>(key_byte);
     children[i] = node_ptr{child.release(), node_type::LEAF};
     ++i;
@@ -1402,7 +1404,10 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
 
     const auto key_byte =
         static_cast<std::uint8_t>(child_ptr->get_key()[depth]);
+
     UNODB_DETAIL_ASSERT(child_indexes[key_byte] == empty_child);
+    UNODB_DETAIL_ASSUME(i < parent_class::capacity);
+
     child_indexes[key_byte] = i;
     children.pointer_array[i] = node_ptr{child_ptr, node_type::LEAF};
     for (i = this->children_count; i < basic_inode_48::capacity; i++) {

--- a/assert.hpp
+++ b/assert.hpp
@@ -5,6 +5,7 @@
 #include "global.hpp"
 
 #ifndef NDEBUG
+
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -75,6 +76,12 @@ namespace unodb::detail {
 #define UNODB_DETAIL_ASSERT(condition) ((void)0)
 
 #endif  // #ifndef NDEBUG
+
+#define UNODB_DETAIL_ASSUME(x)      \
+  do {                              \
+    UNODB_DETAIL_ASSERT(x);         \
+    UNODB_DETAIL_BUILTIN_ASSUME(x); \
+  } while (0)
 
 #define UNODB_DETAIL_CANNOT_HAPPEN() \
   unodb::detail::cannot_happen(__FILE__, __LINE__, __func__)

--- a/global.hpp
+++ b/global.hpp
@@ -51,6 +51,19 @@
 
 #ifndef UNODB_DETAIL_MSVC
 
+#ifdef __clang__
+
+#define UNODB_DETAIL_BUILTIN_ASSUME(x) __builtin_assume(x)
+
+#else
+
+#define UNODB_DETAIL_BUILTIN_ASSUME(x) \
+  do {                                 \
+    if (!(x)) __builtin_unreachable(); \
+  } while (0)
+
+#endif
+
 #define UNODB_DETAIL_LIKELY(x) __builtin_expect(x, 1)
 #define UNODB_DETAIL_UNLIKELY(x) __builtin_expect(x, 0)
 // Cannot do [[gnu::unused]], as that does not play well with structured
@@ -63,6 +76,7 @@
 
 #else  // #ifndef UNODB_DETAIL_MSVC
 
+#define UNODB_DETAIL_BUILTIN_ASSUME(x) __assume(x)
 #define UNODB_DETAIL_LIKELY(x) (!!(x))
 #define UNODB_DETAIL_UNLIKELY(x) (!!(x))
 #define UNODB_DETAIL_UNUSED [[maybe_unused]]


### PR DESCRIPTION
It also does UNODB_DETAIL_ASSERT.

To be used in two cases:
- when it helps the optimizer;
- when it helps static analysis.

Add two uses where it helps the MSVC static analyzer.