### PR TITLE
Add MSVC static analysis support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ set(MSVC_CLANG_CXX_FLAGS "/arch:AVX")
 # cl flags that clang-cl does not understand
 set(MSVC_CXX_FLAGS "/external:anglebrackets" "/external:W0")
 
+set(MSVC_STATIC_ANALYSIS_FLAGS "/analyze" "/analyze:external-")
+
 option(COVERAGE "Enable code coverage reporting")
 if(COVERAGE)
   if(MSVC)
@@ -466,7 +468,10 @@ function(COMMON_TARGET_PROPERTIES TARGET)
       set_target_properties(${TARGET} PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "${DO_IWYU}")
     endif()
     if(STATIC_ANALYSIS)
-      target_compile_options(${TARGET} PRIVATE "-fanalyzer")
+      # The condition below is incorrect due to clang-cl having clang compiler
+      # ID but taking MSVC flags. Change to CMAKE_CXX_COMPILER_FRONTEND_VARIANT 
+      # on 3.14.
+      target_compile_options(${TARGET} PRIVATE "$<IF:$<CXX_COMPILER_ID:MSVC>,${MSVC_STATIC_ANALYSIS_FLAGS},-fanalyzer>")
       # GCC 11 -fanalyzer not fully ready for C++ yet
       target_compile_options(${TARGET} PRIVATE
         "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,11.0>>:-Wno-analyzer-possible-null-dereference>")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -331,6 +331,22 @@
                 "base-msvc-llvm",
                 "release"
             ]
+        },
+        {
+            "name": "msvc-static-analysis-debug",
+            "inherits": [
+                "base-msvc",
+                "debug",
+                "static-analysis"
+            ]
+        },
+        {
+            "name": "msvc-static-analysis-release",
+            "inherits": [
+                "base-msvc",
+                "release",
+                "static-analysis"
+            ]
         }
     ],
     "buildPresets": [
@@ -497,6 +513,16 @@
         {
             "name": "msvc-llvm-release",
             "configurePreset": "msvc-llvm-release",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-static-analysis-debug",
+            "configurePreset": "msvc-static-analysis-debug",
+            "inherits": "base"
+        },
+        {
+            "name": "msvc-static-analysis-release",
+            "configurePreset": "msvc-static-analysis-release",
             "inherits": "base"
         }
     ],

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -956,7 +956,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
       children[i] = children[i + 1];
     }
 #ifndef UNODB_DETAIL_X86_64
-    keys.byte_array[i] = empty_child;
+    keys.byte_array[i] = unused_key_byte;
 #endif
 
     --children_count_;
@@ -1061,8 +1061,8 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     keys.byte_array[key2_i] = key2;
     children[key2_i] = node_ptr{child2.release(), node_type::LEAF};
 #ifndef UNODB_DETAIL_X86_64
-    keys.byte_array[2] = empty_child;
-    keys.byte_array[3] = empty_child;
+    keys.byte_array[2] = unused_key_byte;
+    keys.byte_array[3] = unused_key_byte;
 #endif
 
     UNODB_DETAIL_ASSERT(
@@ -1108,8 +1108,9 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     return detail::popcount(bit_field);
   }
 #else
-  // Non-x86_64 implementation reads children bytes past current node size
-  static constexpr std::byte empty_child{0xFF};
+  // The baseline implementation compares key bytes with less-than past the
+  // current node size
+  static constexpr std::byte unused_key_byte{0xFF};
 #endif
 
   template <class>

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2020-2022 Laurynas Biveinis
 
 set(micro_benchmark_key_prefix_quick_arg "") # Benchmark is quick as-is
-set(micro_benchmark_n4_quick_arg "--benchmark_filter=\"/16|/25|/100\"")
+set(micro_benchmark_n4_quick_arg "--benchmark_filter=\"/16$$|/25|/100\"")
 set(micro_benchmark_n16_quick_arg "--benchmark_filter=\"/64\"")
 set(micro_benchmark_n48_quick_arg "--benchmark_filter=\"/8$$|/128|/192\"")
 set(micro_benchmark_n256_quick_arg "--benchmark_filter=\"/8|/128|/192\"")

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -235,6 +235,9 @@ template <typename NumberToKeyFn>
   return result;
 }
 
+// warning C6001: Using uninitialized memory 'constructed_key'
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6001)
+
 template <std::uint8_t NumByteValues>
 [[nodiscard]] std::vector<unodb::key>
 generate_random_keys_over_full_smaller_tree(unodb::key key_limit) {
@@ -286,6 +289,8 @@ generate_random_keys_over_full_smaller_tree(unodb::key key_limit) {
   }
   UNODB_DETAIL_CANNOT_HAPPEN();
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 }  // namespace detail
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -54,6 +54,9 @@ namespace detail {
 // [-Wused-but-marked-unused]
 UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wused-but-marked-unused")
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 template <class Db>
 void assert_value_eq(const typename Db::get_result &result,
                      unodb::value_view expected) {
@@ -68,6 +71,8 @@ void assert_value_eq(const typename Db::get_result &result,
                            expected.cend()));
   }
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 template <class Db>
 void do_assert_result_eq(const Db &db, unodb::key key,
@@ -113,6 +118,9 @@ inline void assert_result_eq(const unodb::olc_db &db, unodb::key key,
 template <class Db>
 class [[nodiscard]] tree_verifier final {
  private:
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
   void do_insert(unodb::key k, unodb::value_view v) {
     ASSERT_TRUE(test_db.insert(k, v));
   }
@@ -152,6 +160,8 @@ class [[nodiscard]] tree_verifier final {
     ASSERT_FALSE(test_db.remove(absent_key));
   }
 
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
  public:
   explicit constexpr tree_verifier(bool parallel_test_ = false) noexcept
       : parallel_test{parallel_test_} {
@@ -160,6 +170,9 @@ class [[nodiscard]] tree_verifier final {
     assert_shrinking_inodes({0, 0, 0, 0});
     assert_key_prefix_splits(0);
   }
+
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
   void insert(unodb::key k, unodb::value_view v, bool bypass_verifier = false) {
     const auto mem_use_before =
@@ -193,6 +206,8 @@ class [[nodiscard]] tree_verifier final {
     }
   }
 
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
   void insert_key_range(unodb::key start_key, std::size_t count,
                         bool bypass_verifier = false) {
     for (auto key = start_key; key < start_key + count; ++key) {
@@ -204,6 +219,9 @@ class [[nodiscard]] tree_verifier final {
     (void)test_db.insert(k, v);
   }
 
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
   void preinsert_key_range_to_verifier_only(unodb::key start_key,
                                             std::size_t count) {
     for (auto key = start_key; key < start_key + count; ++key) {
@@ -212,6 +230,8 @@ class [[nodiscard]] tree_verifier final {
       ASSERT_TRUE(insert_succeeded);
     }
   }
+
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   void insert_preinserted_key_range(unodb::key start_key, std::size_t count) {
     for (auto key = start_key; key < start_key + count; ++key) {
@@ -224,6 +244,9 @@ class [[nodiscard]] tree_verifier final {
   }
 
   void try_remove(unodb::key k) { (void)test_db.remove(k); }
+
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
   void attempt_remove_missing_keys(
       std::initializer_list<unodb::key> absent_keys) noexcept {
@@ -240,6 +263,8 @@ class [[nodiscard]] tree_verifier final {
     }
   }
 
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
   void try_get(unodb::key k) const noexcept { (void)test_db.get(k); }
 
   void check_present_values() const noexcept {
@@ -247,6 +272,9 @@ class [[nodiscard]] tree_verifier final {
       ASSERT_VALUE_FOR_KEY(test_db, key, value);
     }
   }
+
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
   void check_absent_keys(
       std::initializer_list<unodb::key> absent_keys) const noexcept {
@@ -256,6 +284,8 @@ class [[nodiscard]] tree_verifier final {
     }
   }
 
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
   constexpr void assert_empty() const noexcept {
     ASSERT_TRUE(test_db.empty());
 
@@ -263,6 +293,9 @@ class [[nodiscard]] tree_verifier final {
 
     assert_node_counts({0, 0, 0, 0, 0});
   }
+
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
   void assert_node_counts(
       const node_type_counter_array &expected_node_counts) const noexcept {
@@ -275,6 +308,8 @@ class [[nodiscard]] tree_verifier final {
     ASSERT_THAT(actual_node_counts,
                 ::testing::ElementsAreArray(expected_node_counts));
   }
+
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   constexpr void assert_growing_inodes(
       const inode_type_counter_array &expected_growing_inode_counts)
@@ -313,12 +348,17 @@ class [[nodiscard]] tree_verifier final {
   const bool parallel_test;
 };
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 template <>
 inline void tree_verifier<unodb::olc_db>::do_insert(unodb::key k,
                                                     unodb::value_view v) {
   quiescent_state_on_scope_exit qsbr_after_get{};
   ASSERT_TRUE(test_db.insert(k, v));
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 template <>
 inline void tree_verifier<unodb::olc_db>::remove(unodb::key k,
@@ -333,12 +373,17 @@ inline void tree_verifier<unodb::olc_db>::try_remove(unodb::key k) {
   (void)test_db.remove(k);
 }
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 template <>
 inline void tree_verifier<unodb::olc_db>::do_try_remove_missing_key(
     unodb::key absent_key) {
   quiescent_state_on_scope_exit qsbr_after_get{};
   ASSERT_FALSE(test_db.remove(absent_key));
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 template <>
 inline void tree_verifier<unodb::olc_db>::try_get(unodb::key k) const noexcept {

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -10,6 +10,9 @@
 
 namespace unodb::test {
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 void expect_idle_qsbr() {
   const auto state = unodb::qsbr::instance().get_state();
   EXPECT_TRUE(qsbr_state::single_thread_mode(state));
@@ -23,5 +26,7 @@ void expect_idle_qsbr() {
   EXPECT_EQ(thread_count, 1);
   EXPECT_EQ(threads_in_previous_epoch, 1);
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 }  // namespace unodb::test

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -55,6 +55,9 @@ TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeNonemptyValue) {
   verifier.check_absent_keys({0, 2});
 }
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 TYPED_TEST(ARTCorrectnessTest, TooLongValue) {
   std::byte fake_val{0x00};
   unodb::value_view too_long{
@@ -71,6 +74,8 @@ TYPED_TEST(ARTCorrectnessTest, TooLongValue) {
   verifier.assert_growing_inodes({0, 0, 0, 0});
 }
 
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
 TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
@@ -86,6 +91,9 @@ TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
   verifier.check_absent_keys({2});
 }
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
@@ -100,6 +108,8 @@ TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
   verifier.assert_growing_inodes({0, 0, 0, 0});
   verifier.check_present_values();
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 TYPED_TEST(ARTCorrectnessTest, InsertToFullNode4) {
   unodb::test::tree_verifier<TypeParam> verifier;
@@ -688,6 +698,9 @@ TYPED_TEST(ARTCorrectnessTest, MissingKeyMatchingInodePath) {
   verifier.attempt_remove_missing_keys({0x0101, 0x0202});
 }
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 TYPED_TEST(ARTCorrectnessTest, MemoryAccountingDuplicateKeyInsert) {
   unodb::test::tree_verifier<TypeParam> verifier;
   verifier.insert(0, unodb::test::test_values[0]);
@@ -695,6 +708,8 @@ TYPED_TEST(ARTCorrectnessTest, MemoryAccountingDuplicateKeyInsert) {
   verifier.remove(0);
   ASSERT_EQ(verifier.get_db().get_current_memory_use(), 0);
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 TYPED_TEST(ARTCorrectnessTest, Node48InsertIntoDeletedSlot) {
   unodb::test::tree_verifier<TypeParam> verifier;

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -43,6 +43,9 @@ class QSBR : public ::testing::Test {
         unodb::qsbr_state::get_epoch(unodb::qsbr::instance().get_state());
   }
 
+  // warning C6326: Potential comparison of a constant with another constant.
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
   void check_epoch_advanced() {
     const auto current_epoch =
         unodb::qsbr_state::get_epoch(unodb::qsbr::instance().get_state());
@@ -55,6 +58,8 @@ class QSBR : public ::testing::Test {
         unodb::qsbr_state::get_epoch(unodb::qsbr::instance().get_state());
     EXPECT_EQ(last_epoch, current_epoch);
   }
+
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   // Allocation and deallocation
 
@@ -112,6 +117,9 @@ void active_pointer_ops(void *raw_ptr) noexcept {
   active_ptr2 = std::move(active_ptr3);  // -V1001
 }
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 TEST_F(QSBR, SingleThreadQuitPaused) {
   ASSERT_FALSE(unodb::this_thread().is_qsbr_paused());
   unodb::this_thread().qsbr_pause();
@@ -134,10 +142,15 @@ TEST_F(QSBR, TwoThreads) {
   ASSERT_EQ(get_qsbr_thread_count(), 1);
 }
 
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
 TEST_F(QSBR, TwoThreadsSecondQuitPaused) {
   unodb::qsbr_thread second_thread([] { unodb::this_thread().qsbr_pause(); });
   second_thread.join();
 }
+
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
 TEST_F(QSBR, TwoThreadsSecondPaused) {
   unodb::qsbr_thread second_thread([] {
@@ -259,6 +272,8 @@ TEST_F(QSBR, ThreeThreadsInitialPaused) {
   ASSERT_EQ(get_qsbr_thread_count(), 1);
 }
 
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
 TEST_F(QSBR, SingleThreadOneAllocation) {
   auto *ptr = static_cast<char *>(allocate());
   touch_memory(ptr);
@@ -297,12 +312,17 @@ TEST_F(QSBR, ActivePointersBeforePause) {
 
 #ifndef NDEBUG
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 TEST_F(QSBRDeathTest, ActivePointersDuringQuiescentState) {
   auto *ptr = allocate();
   unodb::qsbr_ptr<void> active_ptr{ptr};
   UNODB_ASSERT_DEATH({ unodb::this_thread().quiescent(); }, "");
   qsbr_deallocate(ptr);
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 #endif
 
@@ -786,6 +806,9 @@ TEST_F(QSBR, ThreeDeallocationRequestSets) {
   second_thread.join();
 }
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+
 TEST_F(QSBR, ReacquireLivePtrAfterQuiescentState) {
   mark_epoch();
   auto *const ptr = static_cast<char *>(allocate());
@@ -894,6 +917,8 @@ TEST_F(QSBR, GettersConcurrentWithQuiescentState) {
 
   second_thread.join();
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 // TODO(laurynas): stat tests
 // TODO(laurynas): quiescent_state_on_scope_exit tests?

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -25,6 +25,8 @@ const gsl::span<const char> gsl_span{two_chars};
 const std::array<const char, 3> three_chars = {'C', 'D', 'E'};
 const gsl::span<const char> gsl_span2{three_chars};
 
+// warning C6326: Potential comparison of a constant with another constant.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 TEST(QSBRPtr, Ctor) {
   unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   ASSERT_EQ(*ptr, x);
@@ -203,5 +205,6 @@ TEST(QSBRPtrSpan, Cend) {
   // Do not write &two_chars[2] directly or the libstdc++ debug assertions fire
   ASSERT_EQ(span.cend().get(), &two_chars[1] + 1);
 }
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 }  // namespace


### PR DESCRIPTION
- Provide the flags in CMake, add two new presets
- Disable some instances of what appear to be false positive warnings