### PR TITLE
Fix broken minimal_tree_random_gets benchmarks for N48 and N256

### DIFF
--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -1003,7 +1003,7 @@ void minimal_tree_random_gets(::benchmark::State &state) {
       key_limit);
   const auto tree_size = test_db.get_current_memory_use();
   batched_prng random_key_positions{
-      node_count * detail::node_capacity_to_minimum_size<16>() - 1};
+      node_count * detail::node_capacity_to_minimum_size<NodeSize>() - 1};
   std::int64_t items_processed = 0;
 
   for (auto _ : state) {


### PR DESCRIPTION
Due to a type only N16 random key positions were used! Thank you MSVC static
analysis for not pointing out this bug but for showing something else close to
the hardcoded 16, so finally noticed it.