### PR TITLE
Make basic_node_ptr::ptr method templated on its return type

### DIFF
--- a/art.cpp
+++ b/art.cpp
@@ -204,7 +204,7 @@ std::optional<detail::node_ptr *> impl_helpers::remove_or_choose_subtree(
   if (child_ptr_val.type() != node_type::LEAF)
     return reinterpret_cast<detail::node_ptr *>(child_ptr);
 
-  const auto *const leaf{static_cast<::leaf *>(child_ptr_val.ptr())};
+  const auto *const leaf{child_ptr_val.template ptr<::leaf *>()};
   if (!leaf->matches(k)) return {};
 
   if (UNODB_DETAIL_UNLIKELY(inode.is_min_size())) {
@@ -277,14 +277,14 @@ db::get_result db::get(key search_key) const noexcept {
   while (true) {
     const auto node_type = node.type();
     if (node_type == node_type::LEAF) {
-      const auto *const leaf{static_cast<::leaf *>(node.ptr())};
+      const auto *const leaf{node.ptr<::leaf *>()};
       if (leaf->matches(k)) return leaf->get_value_view();
       return {};
     }
 
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
 
-    auto *const inode{static_cast<::inode *>(node.ptr())};
+    auto *const inode{node.ptr<::inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     if (key_prefix.get_shared_length(remaining_key) < key_prefix_length)
@@ -315,7 +315,7 @@ bool db::insert(key insert_key, value_view v) {
   while (true) {
     const auto node_type = node->type();
     if (node_type == node_type::LEAF) {
-      auto *const leaf{static_cast<::leaf *>(node->ptr())};
+      auto *const leaf{node->ptr<::leaf *>()};
       const auto existing_key{leaf->get_key()};
       if (UNODB_DETAIL_UNLIKELY(k == existing_key)) return false;
 
@@ -330,7 +330,7 @@ bool db::insert(key insert_key, value_view v) {
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
     UNODB_DETAIL_ASSERT(depth < detail::art_key::size);
 
-    auto *const inode{static_cast<::inode *>(node->ptr())};
+    auto *const inode{node->ptr<::inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
@@ -366,7 +366,7 @@ bool db::remove(key remove_key) {
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) return false;
 
   if (root.type() == node_type::LEAF) {
-    auto *const root_leaf{static_cast<leaf *>(root.ptr())};
+    auto *const root_leaf{root.ptr<leaf *>()};
     if (root_leaf->matches(k)) {
       const auto r{art_policy::reclaim_leaf_on_scope_exit(root_leaf, *this)};
       root = nullptr;
@@ -384,7 +384,7 @@ bool db::remove(key remove_key) {
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
     UNODB_DETAIL_ASSERT(depth < detail::art_key::size);
 
-    auto *const inode{static_cast<::inode *>(node->ptr())};
+    auto *const inode{node->ptr<::inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -169,8 +169,10 @@ class [[nodiscard]] basic_node_ptr {
     return tagged_ptr;
   }
 
+  template <class T>
   [[nodiscard, gnu::pure]] auto *ptr() const noexcept {
-    return reinterpret_cast<Header *>(tagged_ptr & ptr_bit_mask);
+    return static_cast<T>(
+        reinterpret_cast<Header *>(tagged_ptr & ptr_bit_mask));
   }
 
   [[nodiscard, gnu::pure]] auto operator==(std::nullptr_t) const noexcept {

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -271,27 +271,27 @@ struct basic_art_policy final {
       switch (node_ptr.type()) {
         case node_type::LEAF: {
           const auto r{
-              make_db_leaf_ptr(db, static_cast<leaf_type *>(node_ptr.ptr()))};
+              make_db_leaf_ptr(db, node_ptr.template ptr<leaf_type *>())};
           return;
         }
         case node_type::I4: {
           const auto r{make_db_inode_unique_ptr(
-              db, static_cast<inode4_type *>(node_ptr.ptr()))};
+              db, node_ptr.template ptr<inode4_type *>())};
           return;
         }
         case node_type::I16: {
           const auto r{make_db_inode_unique_ptr(
-              db, static_cast<inode16_type *>(node_ptr.ptr()))};
+              db, node_ptr.template ptr<inode16_type *>())};
           return;
         }
         case node_type::I48: {
           const auto r{make_db_inode_unique_ptr(
-              db, static_cast<inode48_type *>(node_ptr.ptr()))};
+              db, node_ptr.template ptr<inode48_type *>())};
           return;
         }
         case node_type::I256: {
           const auto r{make_db_inode_unique_ptr(
-              db, static_cast<inode256_type *>(node_ptr.ptr()))};
+              db, node_ptr.template ptr<inode256_type *>())};
           return;
         }
       }
@@ -318,22 +318,22 @@ struct basic_art_policy final {
       case node_type::LEAF:
         return;
       case node_type::I4: {
-        auto *const subtree_ptr{static_cast<inode4_type *>(node.ptr())};
+        auto *const subtree_ptr{node.template ptr<inode4_type *>()};
         subtree_ptr->delete_subtree(db_instance);
         return;
       }
       case node_type::I16: {
-        auto *const subtree_ptr{static_cast<inode16_type *>(node.ptr())};
+        auto *const subtree_ptr{node.template ptr<inode16_type *>()};
         subtree_ptr->delete_subtree(db_instance);
         return;
       }
       case node_type::I48: {
-        auto *const subtree_ptr{static_cast<inode48_type *>(node.ptr())};
+        auto *const subtree_ptr{node.template ptr<inode48_type *>()};
         subtree_ptr->delete_subtree(db_instance);
         return;
       }
       case node_type::I256: {
-        auto *const subtree_ptr{static_cast<inode256_type *>(node.ptr())};
+        auto *const subtree_ptr{node.template ptr<inode256_type *>()};
         subtree_ptr->delete_subtree(db_instance);
         return;
       }
@@ -342,8 +342,8 @@ struct basic_art_policy final {
 
   [[gnu::cold]] UNODB_DETAIL_NOINLINE static void dump_node(
       std::ostream &os, const NodePtr &node) {
-    os << "node at: " << node.ptr() << ", tagged ptr = 0x" << std::hex
-       << node.raw_val() << std::dec;
+    os << "node at: " << node.template ptr<void *>() << ", tagged ptr = 0x"
+       << std::hex << node.raw_val() << std::dec;
     if (node == nullptr) {
       os << '\n';
       return;
@@ -352,23 +352,23 @@ struct basic_art_policy final {
     switch (node.type()) {
       case node_type::LEAF:
         os << "LEAF";
-        static_cast<leaf_type *>(node.ptr())->dump(os);
+        node.template ptr<leaf_type *>()->dump(os);
         break;
       case node_type::I4:
         os << "I4";
-        static_cast<inode4_type *>(node.ptr())->dump(os);
+        node.template ptr<inode4_type *>()->dump(os);
         break;
       case node_type::I16:
         os << "I16";
-        static_cast<inode16_type *>(node.ptr())->dump(os);
+        node.template ptr<inode16_type *>()->dump(os);
         break;
       case node_type::I48:
         os << "I48";
-        static_cast<inode48_type *>(node.ptr())->dump(os);
+        node.template ptr<inode48_type *>()->dump(os);
         break;
       case node_type::I256:
         os << "I256";
-        static_cast<inode256_type *>(node.ptr())->dump(os);
+        node.template ptr<inode256_type *>()->dump(os);
         break;
     }
   }
@@ -855,8 +855,8 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
 
   constexpr basic_inode_4(node_ptr source_node, unsigned len, tree_depth depth,
                           db_leaf_unique_ptr &&child1) noexcept
-      : parent_class{len, *static_cast<inode_type *>(source_node.ptr())} {
-    auto *const source_inode{static_cast<inode_type *>(source_node.ptr())};
+      : parent_class{len, *source_node.template ptr<inode_type *>()} {
+    auto *const source_inode{source_node.template ptr<inode_type *>()};
     auto &source_key_prefix = source_inode->get_key_prefix();
     UNODB_DETAIL_ASSERT(len < source_key_prefix.length());
 
@@ -886,7 +886,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     }
 
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        static_cast<leaf_type *>(source_children_itr->load().ptr()),
+        source_children_itr->load().template ptr<leaf_type *>(),
         source_node.get_deleter().get_db())};
 
     ++source_keys_itr;
@@ -953,8 +953,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
         keys.byte_array.cbegin(), keys.byte_array.cbegin() + children_count_));
 
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        static_cast<leaf_type *>(children[child_index].load().ptr()),
-        db_instance)};
+        children[child_index].load().template ptr<leaf_type *>(), db_instance)};
 
     typename decltype(keys.byte_array)::size_type i = child_index;
     for (; i < static_cast<unsigned>(children_count_ - 1); ++i) {
@@ -979,7 +978,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     UNODB_DETAIL_ASSERT(child_to_delete == 0 || child_to_delete == 1);
 
     auto *const child_to_delete_ptr{
-        static_cast<leaf_type *>(children[child_to_delete].load().ptr())};
+        children[child_to_delete].load().template ptr<leaf_type *>()};
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(child_to_delete_ptr,
                                                        db_instance)};
 
@@ -987,7 +986,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     const auto child_to_leave_ptr = children[child_to_leave].load();
     if (child_to_leave_ptr.type() != node_type::LEAF) {
       auto *const inode_to_leave_ptr{
-          static_cast<inode_type *>(child_to_leave_ptr.ptr())};
+          child_to_leave_ptr.template ptr<inode_type *>()};
       inode_to_leave_ptr->get_key_prefix().prepend(
           this->get_key_prefix(), keys.byte_array[child_to_leave]);
     }
@@ -1259,8 +1258,7 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
         keys.byte_array.cbegin(), keys.byte_array.cbegin() + children_count_));
 
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        static_cast<leaf_type *>(children[child_index].load().ptr()),
-        db_instance)};
+        children[child_index].load().template ptr<leaf_type *>(), db_instance)};
 
     for (unsigned i = child_index + 1; i < children_count_; ++i) {
       keys.byte_array[i - 1] = keys.byte_array[i];
@@ -1438,8 +1436,9 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
     auto *const __restrict source_node_ptr = source_node.get();
 
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        static_cast<leaf_type *>(
-            source_node_ptr->children[child_to_delete].load().ptr()),
+        source_node_ptr->children[child_to_delete]
+            .load()
+            .template ptr<leaf_type *>(),
         source_node.get_deleter().get_db())};
 
     source_node_ptr->children[child_to_delete] = node_ptr{nullptr};
@@ -1586,8 +1585,7 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
     UNODB_DETAIL_ASSERT(children_i != empty_child);
 
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        static_cast<leaf_type *>(
-            children.pointer_array[children_i].load().ptr()),
+        children.pointer_array[children_i].load().template ptr<leaf_type *>(),
         db_instance)};
   }
 
@@ -1735,8 +1733,7 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
 
   constexpr void remove(std::uint8_t child_index, db &db_instance) noexcept {
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        static_cast<leaf_type *>(children[child_index].load().ptr()),
-        db_instance)};
+        children[child_index].load().template ptr<leaf_type *>(), db_instance)};
 
     children[child_index] = node_ptr{nullptr};
     --this->children_count;

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -130,7 +130,7 @@ class olc_inode : public olc_inode_base {};
 
 [[nodiscard]] auto &node_ptr_lock(
     const unodb::detail::olc_node_ptr &node) noexcept {
-  return node.ptr()->lock();
+  return node.ptr<unodb::detail::olc_node_header *>()->lock();
 }
 
 #ifndef NDEBUG
@@ -720,7 +720,7 @@ template <class INode>
     return true;
   }
 
-  const auto *const leaf{static_cast<::leaf *>(child->ptr())};
+  const auto *const leaf{child->ptr<::leaf *>()};
   if (!leaf->matches(k)) {
     if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
       return {};  // LCOV_EXCL_LINE
@@ -878,7 +878,7 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
     const auto node_type = node.type();
 
     if (node_type == node_type::LEAF) {
-      const auto *const leaf{static_cast<::leaf *>(node.ptr())};
+      const auto *const leaf{node.ptr<::leaf *>()};
       if (leaf->matches(k)) {
         const auto val_view{leaf->get_value_view()};
         if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
@@ -890,7 +890,7 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
       return std::make_optional<get_result>(std::nullopt);
     }
 
-    auto *const inode{static_cast<olc_inode *>(node.ptr())};
+    auto *const inode{node.ptr<olc_inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_key_prefix_length{
@@ -981,7 +981,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
     const auto node_type = node.type();
 
     if (node_type == node_type::LEAF) {
-      auto *const leaf{static_cast<::leaf *>(node.ptr())};
+      auto *const leaf{node.ptr<::leaf *>()};
       const auto existing_key{leaf->get_key()};
       if (UNODB_DETAIL_UNLIKELY(k == existing_key)) {
         if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
@@ -1014,7 +1014,7 @@ olc_db::try_update_result_type olc_db::try_insert(detail::art_key k,
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
     UNODB_DETAIL_ASSERT(depth < detail::art_key::size);
 
-    auto *const inode{static_cast<olc_inode *>(node.ptr())};
+    auto *const inode{node.ptr<olc_inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_length{
@@ -1111,7 +1111,7 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
   auto node_type = node.type();
 
   if (node_type == node_type::LEAF) {
-    auto *const leaf{static_cast<::leaf *>(node.ptr())};
+    auto *const leaf{node.ptr<::leaf *>()};
     if (leaf->matches(k)) {
       optimistic_lock::write_guard parent_guard{
           std::move(parent_critical_section)};
@@ -1143,7 +1143,7 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
     UNODB_DETAIL_ASSERT(depth < detail::art_key::size);
 
-    auto *const inode{static_cast<olc_inode *>(node.ptr())};
+    auto *const inode{node.ptr<olc_inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_length{


### PR DESCRIPTION
Previously, the ptr method returned Header *, which most callers cast to one of
the node types. Make the method return the desired type instead, saving the
cast.