### PR TITLE
Use std::ignore = foo instead of (void)foo

### DIFF
--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -12,6 +12,7 @@
 #include <iterator>
 #include <optional>
 #include <thread>
+#include <tuple>
 #include <type_traits>
 
 #ifdef UNODB_DETAIL_X86_64
@@ -117,7 +118,7 @@ class [[nodiscard]] optimistic_lock final {
     // moved-from lock fields in the move and write_guard constructors.
     ~read_critical_section() {
 #ifndef NDEBUG
-      if (lock != nullptr) (void)lock->try_read_unlock(version);
+      if (lock != nullptr) std::ignore = lock->try_read_unlock(version);
 #endif
     }
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <mutex>  // IWYU pragma: keep
 #include <thread>
+#include <tuple>
 #include <type_traits>
 #ifndef NDEBUG
 #include <unordered_set>
@@ -497,7 +498,7 @@ class [[nodiscard]] qsbr_per_thread final {
 
 inline void construct_current_thread_reclamator() {
   // An ODR-use ensures that the constructor gets called
-  (void)this_thread();
+  std::ignore = this_thread();
 }
 
 namespace boost_acc = boost::accumulators;

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -11,6 +11,7 @@
 #include <initializer_list>
 #include <iostream>
 #include <thread>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 
@@ -216,7 +217,7 @@ class [[nodiscard]] tree_verifier final {
   }
 
   void try_insert(unodb::key k, unodb::value_view v) {
-    (void)test_db.insert(k, v);
+    std::ignore = test_db.insert(k, v);
   }
 
   // warning C6326: Potential comparison of a constant with another constant.
@@ -243,7 +244,7 @@ class [[nodiscard]] tree_verifier final {
     do_remove(k, bypass_verifier);
   }
 
-  void try_remove(unodb::key k) { (void)test_db.remove(k); }
+  void try_remove(unodb::key k) { std::ignore = test_db.remove(k); }
 
   // warning C6326: Potential comparison of a constant with another constant.
   UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
@@ -265,7 +266,7 @@ class [[nodiscard]] tree_verifier final {
 
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-  void try_get(unodb::key k) const noexcept { (void)test_db.get(k); }
+  void try_get(unodb::key k) const noexcept { std::ignore = test_db.get(k); }
 
   void check_present_values() const noexcept {
     for (const auto &[key, value] : values) {
@@ -370,7 +371,7 @@ inline void tree_verifier<unodb::olc_db>::remove(unodb::key k,
 template <>
 inline void tree_verifier<unodb::olc_db>::try_remove(unodb::key k) {
   quiescent_state_on_scope_exit qsbr_after_get{};
-  (void)test_db.remove(k);
+  std::ignore = test_db.remove(k);
 }
 
 // warning C6326: Potential comparison of a constant with another constant.
@@ -388,7 +389,7 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 template <>
 inline void tree_verifier<unodb::olc_db>::try_get(unodb::key k) const noexcept {
   quiescent_state_on_scope_exit qsbr_after_get{};
-  (void)test_db.get(k);
+  std::ignore = test_db.get(k);
 }
 
 extern template class tree_verifier<unodb::db>;

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -67,7 +67,8 @@ TYPED_TEST(ARTCorrectnessTest, TooLongValue) {
 
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  ASSERT_THROW((void)verifier.get_db().insert(1, too_long), std::length_error);
+  ASSERT_THROW(std::ignore = verifier.get_db().insert(1, too_long),
+               std::length_error);
 
   verifier.check_absent_keys({1});
   verifier.assert_empty();


### PR DESCRIPTION
Suggested by MSVC static analyser