### PR TITLE
Cleanup exception handling in qsbr_per_thread constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,9 +450,9 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   # Change to target_link_options on 3.13 minimum CMake version
   target_link_libraries(${TARGET} PRIVATE "${SANITIZER_LD_FLAGS}")
   target_link_libraries(${TARGET} INTERFACE "$<$<BOOL:${COVERAGE}>:--coverage>")
-  target_link_libraries(${TARGET} PRIVATE "$<$<AND:$<CONFIG:Debug>,$<PLATFORM_ID:Linux>>:${CMAKE_DL_LIBS}>")
+  target_link_libraries(${TARGET} PRIVATE "$<$<PLATFORM_ID:Linux>:${CMAKE_DL_LIBS}>")
   target_link_libraries(${TARGET} PRIVATE
-    "$<$<AND:$<CONFIG:Debug>,$<PLATFORM_ID:Linux>,$<CXX_COMPILER_ID:GNU>>:backtrace>")
+    "$<$<AND:$<PLATFORM_ID:Linux>,$<CXX_COMPILER_ID:GNU>>:backtrace>")
   if(IPO_SUPPORTED)
     set_target_properties(${TARGET} PROPERTIES
       INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -4,6 +4,8 @@
 
 #include "qsbr.hpp"
 
+#include <iostream>
+
 #ifdef UNODB_DETAIL_THREAD_SANITIZER
 #include <sanitizer/tsan_interface.h>
 #endif
@@ -14,7 +16,21 @@ namespace {
 
 struct run_tls_ctor_in_main_thread {
   run_tls_ctor_in_main_thread() noexcept {
-    unodb::construct_current_thread_reclamator();
+    try {
+      unodb::construct_current_thread_reclamator();
+    }
+    // LCOV_EXCL_START
+    catch (const std::bad_alloc &e) {
+      std::cerr << "Allocation failure: " << e.what() << '\n';
+      UNODB_DETAIL_CRASH();
+    } catch (const std::exception &e) {
+      std::cerr << "Unexpected exception: " << e.what() << '\n';
+      UNODB_DETAIL_CRASH();
+    } catch (...) {
+      std::cerr << "Unexpected exception\n";
+      UNODB_DETAIL_CRASH();
+    }
+    // LCOV_EXCL_STOP
   }
 };
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -419,7 +419,7 @@ class [[nodiscard]] deferred_requests final {
 
 class [[nodiscard]] qsbr_per_thread final {
  public:
-  qsbr_per_thread() noexcept;
+  qsbr_per_thread();
 
   ~qsbr_per_thread() {
     if (!is_qsbr_paused()) qsbr_pause();
@@ -491,12 +491,12 @@ class [[nodiscard]] qsbr_per_thread final {
 #endif
 };
 
-[[nodiscard]] inline qsbr_per_thread &this_thread() noexcept {
+[[nodiscard]] inline qsbr_per_thread &this_thread() {
   thread_local static qsbr_per_thread current_thread_reclamator_instance;
   return current_thread_reclamator_instance;
 }
 
-inline void construct_current_thread_reclamator() noexcept {
+inline void construct_current_thread_reclamator() {
   // An ODR-use ensures that the constructor gets called
   std::ignore = this_thread();
 }
@@ -719,7 +719,7 @@ static_assert(std::atomic<std::size_t>::is_always_lock_free);
 static_assert(std::atomic<double>::is_always_lock_free);
 
 // cppcheck-suppress uninitMemberVar
-inline qsbr_per_thread::qsbr_per_thread() noexcept
+inline qsbr_per_thread::qsbr_per_thread()
     : last_seen_quiescent_state_epoch{qsbr::instance().register_thread()},
       last_seen_epoch{last_seen_quiescent_state_epoch},
       previous_interval_dealloc_requests{
@@ -951,8 +951,8 @@ class [[nodiscard]] qsbr_thread : public std::thread {
   template <typename Function, typename... Args,
             class = std::enable_if_t<
                 !std::is_same_v<remove_cvref_t<Function>, qsbr_thread>>>
-  explicit qsbr_thread(Function &&f, Args &&...args) noexcept
-      : std::thread{[](auto &&f2, auto &&...args2) noexcept {
+  explicit qsbr_thread(Function &&f, Args &&...args)
+      : std::thread{[](auto &&f2, auto &&...args2) {
                       construct_current_thread_reclamator();
                       f2(std::forward<Args>(args2)...);
                     },


### PR DESCRIPTION
- Do not mark qsbr_per_thread::qsbr_per_thread as noexcept because it does
  memory allocations.
- The removal of this noexcept propagates to this_thread and
  qsbr_thread::qsbr_thread.
- It, however, stops at run_tls_ctor_in_main_thread. Add an exception handler
  there.