### PR TITLE
Clean up qsbr_per_thread exception handling

### DIFF
--- a/assert.hpp
+++ b/assert.hpp
@@ -62,6 +62,8 @@ namespace unodb::detail {
   ? unodb::detail::assert_failure(__FILE__, __LINE__, __func__, #condition) \
   : ((void)0)
 
+#define UNODB_DETAIL_DEBUG_CRASH() UNODB_DETAIL_CRASH()
+
 #else  // #ifndef NDEBUG
 
 [[noreturn]] inline void cannot_happen(const char *, int,
@@ -70,6 +72,8 @@ namespace unodb::detail {
 }
 
 #define UNODB_DETAIL_ASSERT(condition) ((void)0)
+
+#define UNODB_DETAIL_DEBUG_CRASH()
 
 #endif  // #ifndef NDEBUG
 

--- a/fuzz_deepstate/CMakeLists.txt
+++ b/fuzz_deepstate/CMakeLists.txt
@@ -22,7 +22,7 @@ set(DEEPSTATE_OPTIONS "--fuzz" "--no_fork" "--output_test_dir"
 # The shortest run is special in that it is a smoke test, and a part of the
 # default testsuite. On a completely broken code stop immediately instead of
 # accumulating millions of testcases.
-set(DEEPSTATE_2S_OPTIONS "--exit_on_fail" ${DEEPSTATE_OPTIONS})
+set(DEEPSTATE_2S_OPTIONS "--abort_on_fail" ${DEEPSTATE_OPTIONS})
 
 if(LIBFUZZER_AVAILABLE)
   set(DEEPSTATE_LF_OPTIONS "-use_value_profile=1" "-detect_leaks=0")


### PR DESCRIPTION
- Try to handle qsbr_per_thread construction errors (only std::bad_alloc seems
  to be possible) in the qsbr_thread constructor by diagnosing and quitting the
  thread instead of crashing. Handle other exceptions too, even if impossible.
- Make destructor noexcept. For that, make qsbr_pause as non-throwing as
  possible by not allocating any memory. To avoid that, 1) preallocate QSBR
  orphan list nodes in constructor and qsbr_resume; 2) do not bother creating
  new deallocation request lists in the case of thread quitting. This leaves the
  only possible exception to be std::system_error by a failed QSBR stats mutex
  lock attempt. Handle it by logging and eating instead of crashing. Eat other,
  seemingly impossible exceptions, by eating them too.
- New helper UNODB_DETAIL_DEBUG_CRASH
- Tweak DeepState 2s run crashing option from --exit_on_fail to --abort_on_fail
  to try to avoid millions of testcases in the case of broken code