### PR TITLE
Update GSL to 4.0.0

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -20,7 +20,7 @@
 #include <smmintrin.h>
 #endif
 
-#include <gsl/gsl_util>
+#include <gsl/util>
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
@@ -78,7 +78,7 @@ class [[nodiscard]] basic_leaf final : public Header {
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26495)
   constexpr basic_leaf(art_key k, value_view v) noexcept
       : key{k}, value_size{gsl::narrow_cast<value_size_type>(v.size())} {
-    UNODB_DETAIL_ASSERT(static_cast<std::size_t>(v.size()) <= max_value_size);
+    UNODB_DETAIL_ASSERT(v.size() <= max_value_size);
 
     if (!v.empty()) std::memcpy(&value_start[0], &v[0], value_size);
   }
@@ -123,8 +123,7 @@ template <class Header, class Db>
 [[nodiscard]] auto make_db_leaf_ptr(art_key k, value_view v, Db &db) {
   using leaf_type = basic_leaf<Header>;
 
-  if (UNODB_DETAIL_UNLIKELY(static_cast<std::size_t>(v.size()) >
-                            leaf_type::max_value_size)) {
+  if (UNODB_DETAIL_UNLIKELY(v.size() > leaf_type::max_value_size)) {
     throw std::length_error("Value length must fit in std::uint32_t");
   }
 

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include <deepstate/DeepState.hpp>
-#include <gsl/gsl_util>
+#include <gsl/util>
 
 #include "art.hpp"
 #include "art_common.hpp"
@@ -153,9 +153,10 @@ TEST(ART, DeepStateFuzz) {
             ASSERT(!test_db.empty());
             ASSERT(oracle_search_result != oracle.cend())
                 << "If search found a key, oracle must contain that key";
-            ASSERT(std::equal(search_result->cbegin(), search_result->cend(),
-                              oracle_search_result->second.cbegin(),
-                              oracle_search_result->second.cend()))
+            ASSERT(std::equal(std::cbegin(*search_result),
+                              std::cend(*search_result),
+                              std::cbegin(oracle_search_result->second),
+                              std::cend(oracle_search_result->second)))
                 << "Values stored in ART and in oracle must match";
           } else {
             ASSERT(oracle_search_result == oracle.cend())

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -8,7 +8,7 @@
 
 #ifdef UNODB_DETAIL_MSVC
 #include <intrin.h>
-#include <gsl/gsl_util>
+#include <gsl/util>
 #endif
 
 namespace unodb::detail {

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -24,7 +24,7 @@
 #include <utility>  // IWYU pragma: keep
 #include <vector>
 
-#include <gsl/gsl_util>
+#include <gsl/util>
 
 #include <boost/accumulators/accumulators.hpp>  // IWYU pragma: keep
 #include <boost/accumulators/statistics/max.hpp>

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -173,13 +173,13 @@ class qsbr_ptr_span {
   UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(
       qsbr_ptr_span<T> &&) noexcept = default;
 
-  [[nodiscard, gnu::pure]] constexpr qsbr_ptr<const T> cbegin() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr qsbr_ptr<T> begin() const noexcept {
     return start;
   }
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
-  [[nodiscard, gnu::pure]] constexpr qsbr_ptr<const T> cend() const noexcept {
-    return qsbr_ptr<const T>{start.get() + length};
+  [[nodiscard, gnu::pure]] constexpr qsbr_ptr<T> end() const noexcept {
+    return qsbr_ptr<T>{start.get() + length};
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -62,12 +62,13 @@ void assert_value_eq(const typename Db::get_result &result,
   if constexpr (std::is_same_v<Db, unodb::mutex_db>) {
     UNODB_DETAIL_ASSERT(result.second.owns_lock());
     UNODB_DETAIL_ASSERT(result.first.has_value());
-    UNODB_ASSERT_TRUE(std::equal(result.first->cbegin(), result.first->cend(),
-                                 expected.cbegin(), expected.cend()));
+    UNODB_ASSERT_TRUE(std::equal(std::cbegin(*result.first),
+                                 std::cend(*result.first),
+                                 std::cbegin(expected), std::cend(expected)));
   } else {
     UNODB_DETAIL_ASSERT(result.has_value());
-    UNODB_ASSERT_TRUE(std::equal(result->cbegin(), result->cend(),
-                                 expected.cbegin(), expected.cend()));
+    UNODB_ASSERT_TRUE(std::equal(std::cbegin(*result), std::cend(*result),
+                                 std::cbegin(expected), std::cend(expected)));
   }
 }
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -148,25 +148,25 @@ TEST(QSBRPtr, Get) {
 TEST(QSBRPtrSpan, CopyGslSpanCtor) {
   unodb::qsbr_ptr_span span{gsl_span};
 
-  UNODB_ASSERT_TRUE(std::equal(span.cbegin(), span.cend(), gsl_span.cbegin(),
-                               gsl_span.cend()));
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span), std::cend(span),
+                               std::cbegin(gsl_span), std::cend(gsl_span)));
 }
 
 TEST(QSBRPtrSpan, CopyCtor) {
   unodb::qsbr_ptr_span span{gsl_span};
   unodb::qsbr_ptr_span span2{span};
 
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span.cbegin(),
-                               gsl_span.cend()));
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span), std::cend(gsl_span)));
 }
 
 TEST(QSBRPtrSpan, MoveCtor) {
   unodb::qsbr_ptr_span span{gsl_span};
   unodb::qsbr_ptr_span span2{std::move(span)};
 
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span.cbegin(),
-                               gsl_span.cend()));
-  UNODB_ASSERT_EQ(span.cbegin().get(), nullptr);
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
 }
 
 UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
@@ -174,15 +174,15 @@ TEST(QSBRPtrSpan, CopyAssignment) {
   unodb::qsbr_ptr_span span{gsl_span};
   unodb::qsbr_ptr_span span2{gsl_span2};
 
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span2.cbegin(),
-                               gsl_span2.cend()));
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span2), std::cend(gsl_span2)));
   span2 = span;
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span.cbegin(),
-                               gsl_span.cend()));
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span), std::cend(gsl_span)));
 
   span2 = span2;  // -V570
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span.cbegin(),
-                               gsl_span.cend()));
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span), std::cend(gsl_span)));
 }
 UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
@@ -190,23 +190,23 @@ TEST(QSBRPtrSpan, MoveAssignment) {
   unodb::qsbr_ptr_span span{gsl_span};
   unodb::qsbr_ptr_span span2{gsl_span2};
 
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span2.cbegin(),
-                               gsl_span2.cend()));
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span2), std::cend(gsl_span2)));
   span2 = std::move(span);
-  UNODB_ASSERT_TRUE(std::equal(span2.cbegin(), span2.cend(), gsl_span.cbegin(),
-                               gsl_span.cend()));
-  UNODB_ASSERT_EQ(span.cbegin().get(), nullptr);
+  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
+                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
 }
 
 TEST(QSBRPtrSpan, Cbegin) {
   unodb::qsbr_ptr_span span{gsl_span};
-  UNODB_ASSERT_EQ(span.cbegin().get(), &two_chars[0]);
+  UNODB_ASSERT_EQ(std::cbegin(span).get(), &two_chars[0]);
 }
 
 TEST(QSBRPtrSpan, Cend) {
   unodb::qsbr_ptr_span span{gsl_span};
   // Do not write &two_chars[2] directly or the libstdc++ debug assertions fire
-  UNODB_ASSERT_EQ(span.cend().get(), &two_chars[1] + 1);
+  UNODB_ASSERT_EQ(std::cend(span).get(), &two_chars[1] + 1);
 }
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 


### PR DESCRIPTION
Remove cbegin and cend from qsbr_ptr_span to match gsl::span and std::span.
Introduce begin and end instead, and in callers use std::cbegin and std::cend.