### PR TITLE
Fix QSBR epoch change counter race

### DIFF
--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -708,12 +708,14 @@ class qsbr final {
 
   static void thread_epoch_change_barrier() noexcept;
 
-  void epoch_change_update_requests(bool single_thread_mode
+  void bump_epoch_change_count() noexcept;
+
+  void epoch_change_barrier_and_handle_orphans(bool single_thread_mode
 #ifndef NDEBUG
-                                    ,
-                                    qsbr_epoch dealloc_epoch
+                                               ,
+                                               qsbr_epoch dealloc_epoch
 #endif
-                                    ) noexcept;
+                                               ) noexcept;
 
   qsbr_epoch change_epoch(qsbr_epoch current_global_epoch,
                           bool single_thread_mode) noexcept;


### PR DESCRIPTION
Previously, if thread unregistration would try to advance the epoch, the change
counter would be bumped before the attempt – even if it failed. To fix, split
qsbr::bump_epoch_change_count method out of epoch_change_update_requests. Rename
the latter to epoch_change_barrier_and_handle_orphans. Remove incorrect assert
in it which tried to assert orphaned request deallocation epoch being in the
past – it is impossible to have it correct with a two-bit epoch counter because
the orphaned request epoch lag is unbounded.