### PR TITLE
QSBR thread unregistration: make sure the unregistering thread saw th…

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -282,6 +282,9 @@ void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
     if (UNODB_DETAIL_LIKELY(state.compare_exchange_weak(
             old_state, new_state, std::memory_order_acq_rel,
             std::memory_order_acquire))) {
+      // Might be the first time the quitting thread saw the old epoch too, if a
+      // second-to-last thread quit before, advancing the epoch.
+      qsbr_thread.advance_last_seen_epoch(old_single_thread_mode, old_epoch);
       if (UNODB_DETAIL_UNLIKELY(advance_epoch)) {
         bump_epoch_change_count();
         qsbr_thread.update_requests(old_single_thread_mode,

--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -58,6 +58,14 @@
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   } while (0)
 
+#define UNODB_ASSERT_NEAR(x, y, e)           \
+  do {                                       \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)  \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
+    ASSERT_NEAR((x), (y), (e));              \
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+  } while (0)
+
 #define UNODB_ASSERT_FALSE(cond)             \
   do {                                       \
     UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -869,10 +869,11 @@ TEST_F(QSBR, ResetStats) {
   second_thread.join();
 
   UNODB_ASSERT_EQ(unodb::qsbr::instance().get_max_backlog_bytes(), 2);
-  UNODB_ASSERT_EQ(unodb::qsbr::instance().get_mean_backlog_bytes(), 1);
+  UNODB_ASSERT_NEAR(unodb::qsbr::instance().get_mean_backlog_bytes(), 0.666667,
+                    0.00001);
   UNODB_ASSERT_EQ(unodb::qsbr::instance().get_epoch_callback_count_max(), 2);
-  UNODB_ASSERT_EQ(unodb::qsbr::instance().get_epoch_callback_count_variance(),
-                  1);
+  UNODB_ASSERT_NEAR(unodb::qsbr::instance().get_epoch_callback_count_variance(),
+                    0.888889, 0.00001);
   UNODB_ASSERT_EQ(
       unodb::qsbr::instance()
           .get_mean_quiescent_states_per_thread_between_epoch_changes(),


### PR DESCRIPTION
…e old epoch too

Previously, it saw the new epoch, potentially skipping the old one, and not
updating requests accordingly. This might have resulted in requests being
orphaned when they could have been executed.

Make the asserts stricter.