### PR TITLE
Introduce UNODB_DETAIL_X86_64 macro

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -39,7 +39,7 @@ namespace unodb::detail {
 template <>
 [[nodiscard, gnu::const]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC std::uint64_t
 basic_art_key<std::uint64_t>::make_binary_comparable(std::uint64_t k) noexcept {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifdef UNODB_DETAIL_LITTLE_ENDIAN
   return bswap(k);
 #else
 #error Needs implementing

--- a/global.hpp
+++ b/global.hpp
@@ -38,8 +38,17 @@
 
 // Architecture
 
-#if defined(__x86_64) || (defined(_MSC_VER) && defined(_M_X64))
+#if defined(_MSC_VER) && defined(_M_X64)
+#define UNODB_DETAIL_MSVC_X86_64
+#endif
+
+#if defined(__x86_64) || defined(UNODB_DETAIL_MSVC_X86_64)
 #define UNODB_DETAIL_X86_64
+#endif
+
+#if defined(UNODB_DETAIL_X86_64) || \
+    defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define UNODB_DETAIL_LITTLE_ENDIAN
 #endif
 
 // Compiler


### PR DESCRIPTION
Apparently MSVC does not define __BYTE_ORDER__ and related macros