### PR TITLE
Make unodb::detail::ctz return std::uint8_t instead of unsigned

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1365,8 +1365,9 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
     const auto mask = (1U << children_count_) - 1;
     const auto bit_field =
         static_cast<unsigned>(_mm_movemask_epi8(lesser_key_positions)) & mask;
-    const auto result = static_cast<std::uint8_t>(
-        (bit_field != 0) ? detail::ctz(bit_field) : children_count_);
+    const auto result = (bit_field != 0)
+                            ? detail::ctz(bit_field)
+                            : gsl::narrow_cast<std::uint8_t>(children_count_);
 #else
     // This is also the best current ARM implementation, same reasoning as with
     // basic_inode_4::add_to_nonfull.

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -6,9 +6,10 @@
 
 #include <cstdint>
 
+#include <gsl/util>
+
 #ifdef UNODB_DETAIL_MSVC
 #include <intrin.h>
-#include <gsl/util>
 #endif
 
 namespace unodb::detail {
@@ -22,14 +23,14 @@ namespace unodb::detail {
 #endif
 }
 
-[[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned ctz(
+[[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC auto ctz(
     unsigned x) noexcept {
 #ifndef UNODB_DETAIL_MSVC
-  return static_cast<unsigned>(__builtin_ctz(x));
+  return gsl::narrow_cast<std::uint8_t>(__builtin_ctz(x));
 #else
   unsigned long result;  // NOLINT(runtime/int)
   _BitScanForward(&result, x);
-  return gsl::narrow_cast<unsigned>(result);
+  return gsl::narrow_cast<std::uint8_t>(result);
 #endif
 }
 


### PR DESCRIPTION
This matches how the callers use it, fixing an MSVC warning that is not enabled
at /W4 by default.