### PR TITLE
For local vars, make UNODB_DETAIL_USED_IN_DEBUG come after identifier

### DIFF
--- a/heap.hpp
+++ b/heap.hpp
@@ -55,7 +55,7 @@ template <typename T>
     std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
   void* result;
 #ifndef _MSC_VER
-  const auto UNODB_DETAIL_USED_IN_DEBUG err =
+  const auto err UNODB_DETAIL_USED_IN_DEBUG =
       posix_memalign(&result, alignment, size);
 #else
   result = _aligned_malloc(size, alignment);

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -815,7 +815,7 @@ template <class INode>
 constexpr void olc_db::decrement_inode_count() noexcept {
   static_assert(olc_inode_defs::is_inode<INode>());
 
-  const auto UNODB_DETAIL_USED_IN_DEBUG old_inode_count =
+  const auto old_inode_count UNODB_DETAIL_USED_IN_DEBUG =
       node_counts[as_i<INode::type>].fetch_sub(1, std::memory_order_relaxed);
   UNODB_DETAIL_ASSERT(old_inode_count > 0);
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -171,7 +171,7 @@ class olc_db final {
   void decrement_leaf_count(std::size_t leaf_size) noexcept {
     decrease_memory_use(leaf_size);
 
-    const auto UNODB_DETAIL_USED_IN_DEBUG old_leaf_count =
+    const auto old_leaf_count UNODB_DETAIL_USED_IN_DEBUG =
         node_counts[as_i<node_type::LEAF>].fetch_sub(1,
                                                      std::memory_order_relaxed);
     UNODB_DETAIL_ASSERT(old_leaf_count > 0);


### PR DESCRIPTION
This fixes an MSVC warning that an attribute is ignored in the former position.
This warning is not enabled by /W4 by default.