### PR TITLE
Work towards fixing strong exception safety for node growing/shrinking

### DIFF
--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -232,6 +232,28 @@ TYPED_TEST(ARTOOMTest, DbInsertNodeRecursion) {
       });
 }
 
+TYPED_TEST(ARTOOMTest, Node16) {
+  oom_test<TypeParam>(
+      3,
+      [](unodb::test::tree_verifier<TypeParam>& verifier) {
+        verifier.insert_key_range(0, 4);
+      },
+      [](unodb::test::tree_verifier<TypeParam>& verifier) {
+        verifier.insert(5, unodb::test::test_values[0], true);
+      },
+      [](unodb::test::tree_verifier<TypeParam>& verifier) {
+        verifier.check_present_values();
+        verifier.assert_node_counts({4, 1, 0, 0, 0});
+        verifier.assert_growing_inodes({1, 0, 0, 0});
+        verifier.check_absent_keys({5});
+      },
+      [](unodb::test::tree_verifier<TypeParam>& verifier) {
+        verifier.check_present_values();
+        verifier.assert_node_counts({5, 0, 1, 0, 0});
+        verifier.assert_growing_inodes({1, 1, 0, 0});
+      });
+}
+
 }  // namespace
 
 #endif  // #ifndef NDEBUG


### PR DESCRIPTION
Previously, the old node, which was about to be replaced with a larger one, was
put into a reclaimable pointer too early, before the new node was allocated
successfully. Thus, if that allocation fails, the old node was still reclaimed
even if it remained a part of the tree.

Fix by moving the responsibility of reclaiming such old nodes from the
add/remove tree algorithm implementation to the new node constructors. For that,
make them accept lvalue references to the old nodes instead of reclaimable
unique pointers. For the constructors to be able to reclaim, move
make_db_inode_reclaimable_ptr from olc_art.cpp to basic_art_policy in
art_internal_impl.hpp.

Cleanup some unused declarations.

Add a test case.