### PR TITLE
Fix [[maybe_unused]] placement warnings for MSVC

### DIFF
--- a/global.hpp
+++ b/global.hpp
@@ -79,9 +79,7 @@
 
 #define UNODB_DETAIL_LIKELY(x) __builtin_expect(x, 1)
 #define UNODB_DETAIL_UNLIKELY(x) __builtin_expect(x, 0)
-// Cannot do [[gnu::unused]], as that does not play well with structured
-// bindings when compiling with GCC.
-#define UNODB_DETAIL_UNUSED __attribute__((unused))
+#define UNODB_DETAIL_UNUSED [[gnu::unused]]
 #define UNODB_DETAIL_FORCE_INLINE __attribute__((always_inline))
 #define UNODB_DETAIL_NOINLINE __attribute__((noinline))
 #define UNODB_DETAIL_UNREACHABLE() __builtin_unreachable()

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -212,8 +212,8 @@ class [[nodiscard]] tree_verifier final {
       UNODB_ASSERT_EQ(leaf_count_after, leaf_count_before + 1);
 
     if (!bypass_verifier) {
-      const auto UNODB_DETAIL_UNUSED[pos, insert_succeeded] =
-          values.try_emplace(k, v);
+      const auto [pos, insert_succeeded] = values.try_emplace(k, v);
+      (void)pos;
       UNODB_ASSERT_TRUE(insert_succeeded);
     }
   }
@@ -234,8 +234,9 @@ class [[nodiscard]] tree_verifier final {
   void preinsert_key_range_to_verifier_only(unodb::key start_key,
                                             std::size_t count) {
     for (auto key = start_key; key < start_key + count; ++key) {
-      const auto UNODB_DETAIL_UNUSED[pos, insert_succeeded] =
+      const auto [pos, insert_succeeded] =
           values.try_emplace(key, test_values[key % test_values.size()]);
+      (void)pos;
       UNODB_ASSERT_TRUE(insert_succeeded);
     }
   }

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -74,7 +74,7 @@ class QSBR : public ::testing::Test {
 #ifndef NDEBUG
   static void check_ptr_on_qsbr_dealloc(const void *ptr) noexcept {
     // The pointer must be readable
-    static volatile char UNODB_DETAIL_UNUSED sink =
+    static volatile char sink UNODB_DETAIL_UNUSED =
         *static_cast<const char *>(ptr);
   }
 #endif


### PR DESCRIPTION
- Don't try to use it for structured bindins. Do the old-school void cast
  instead.
- Now that it's no longer used for structured bindings, define
  UNODB_DETAIL_UNUSED to be [[gnu::unused]] for GCC and clang.
- Place UNODB_DETAIL_UNUSED in the correct location for one local var.