### PR TITLE
Merge OOM do-not-allocate tests with the main functional tests

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,5 +1,5 @@
 {
-    "threshold": 15,
+    "threshold": 17,
     "reporters": [
         "consoleFull"
     ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,21 +518,9 @@ function(SET_CLANG_TIDY_OPTIONS TARGET COMMAND)
   endif()
 endfunction()
 
-add_library(unodb_util INTERFACE)
-# Move to add_library itself once CMake minimum version is 3.13
-target_sources(unodb_util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/global.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/assert.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/portability_builtins.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/thread_sync.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/heap.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/portability_stdlib.hpp)
-target_include_directories(unodb_util INTERFACE ".")
-target_include_directories(unodb_util INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
-
 function(ADD_UNODB_LIBRARY LIB)
   add_library(${LIB} ${ARGN})
   common_target_properties(${LIB})
-  target_link_libraries(${LIB} PUBLIC unodb_util)
   target_include_directories(${LIB} SYSTEM PUBLIC "${GSL_INCLUDES}")
   set_clang_tidy_options(${LIB} "${DO_CLANG_TIDY}")
 
@@ -540,28 +528,38 @@ function(ADD_UNODB_LIBRARY LIB)
     set(LIB_LF "${LIB}_lf")
     add_library(${LIB_LF} ${ARGN})
     common_target_properties(${LIB_LF} SKIP_CHECKS)
-    target_link_libraries(${LIB_LF} PUBLIC unodb_util)
     target_include_directories(${LIB_LF} SYSTEM PUBLIC "${GSL_INCLUDES}")
     target_compile_options(${LIB_LF} PRIVATE "-fsanitize=fuzzer-no-link")
   endif()
 endfunction()
 
+add_unodb_library(unodb_util global.hpp assert.hpp portability_builtins.hpp
+  thread_sync.hpp heap.hpp heap.cpp portability_stdlib.hpp)
+target_include_directories(unodb_util INTERFACE ".")
+target_include_directories(unodb_util SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+target_link_libraries(unodb_util PRIVATE "${Boost_LIBRARIES}")
+if(LIBFUZZER_AVAILABLE)
+  target_include_directories(unodb_util_lf INTERFACE ".")
+  target_include_directories(unodb_util_lf SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+  target_link_libraries(unodb_util_lf PRIVATE "${Boost_LIBRARIES}")
+endif()
+
 add_unodb_library(unodb_qsbr qsbr.cpp qsbr.hpp qsbr_ptr.cpp qsbr_ptr.hpp)
 target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
 target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
-target_link_libraries(unodb_qsbr PUBLIC Threads::Threads)
+target_link_libraries(unodb_qsbr PUBLIC unodb_util Threads::Threads)
 if(LIBFUZZER_AVAILABLE)
   target_include_directories(unodb_qsbr_lf SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
   target_link_libraries(unodb_qsbr_lf PRIVATE "${Boost_LIBRARIES}")
-  target_link_libraries(unodb_qsbr_lf PUBLIC Threads::Threads)
+  target_link_libraries(unodb_qsbr_lf PUBLIC unodb_util_lf Threads::Threads)
 endif()
 
 add_unodb_library(unodb art.cpp art.hpp art_common.cpp art_common.hpp
   mutex_art.hpp optimistic_lock.hpp art_internal_impl.hpp olc_art.hpp
   olc_art.cpp art_internal.cpp art_internal.hpp node_type.hpp)
-target_link_libraries(unodb PUBLIC unodb_qsbr)
+target_link_libraries(unodb PUBLIC unodb_util unodb_qsbr)
 if(LIBFUZZER_AVAILABLE)
-  target_link_libraries(unodb_lf PUBLIC unodb_qsbr_lf)
+  target_link_libraries(unodb_lf PUBLIC unodb_util_lf unodb_qsbr_lf)
 endif()
 
 set(VALGRIND_COMMAND "valgrind" "--error-exitcode=1" "--leak-check=full"

--- a/global.hpp
+++ b/global.hpp
@@ -101,11 +101,19 @@
 // Sanitizers
 
 #if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define UNODB_DETAIL_ADDRESS_SANITIZER 1
+#endif
 #if __has_feature(thread_sanitizer)
 #define UNODB_DETAIL_THREAD_SANITIZER 1
 #endif
-#elif defined(__SANITIZE_THREAD__)
+#else
+#ifdef __SANITIZE_ADDRESS__
+#define UNODB_DETAIL_ADDRESS_SANITIZER 1
+#endif
+#ifdef __SANITIZE_THREAD__
 #define UNODB_DETAIL_THREAD_SANITIZER 1
+#endif
 #endif
 
 // Warnings

--- a/heap.cpp
+++ b/heap.cpp
@@ -1,0 +1,77 @@
+// Copyright 2022 Laurynas Biveinis
+
+#include "global.hpp"
+
+#include "heap.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+namespace unodb::test {
+
+#ifndef NDEBUG
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::atomic<std::uint64_t> allocation_failure_injector::allocation_counter{0};
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+std::uint64_t allocation_failure_injector::fail_on_nth_allocation_{0};
+
+#endif  // #ifndef NDEBUG
+
+}  // namespace unodb::test
+
+// - LLVM ASan/TSan do not work with replaced global new/delete:
+//   https://github.com/llvm/llvm-project/issues/20034
+// - Google Test with MSVC standard library tries to allocate memory in the
+//   exception-thrown-as-expected path
+#if !defined(NDEBUG) && !defined(_MSC_VER) &&                           \
+    !(defined(__clang__) && (defined(UNODB_DETAIL_ADDRESS_SANITIZER) || \
+                             defined(UNODB_DETAIL_THREAD_SANITIZER)))
+
+namespace {
+
+template <typename Alloc, typename... Args>
+void* do_new(Alloc alloc, std::size_t count, Args... args) {
+  unodb::test::allocation_failure_injector::maybe_fail();
+  while (true) {
+    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,hicpp-no-malloc)
+    void* const result = alloc(count, args...);
+    if (UNODB_DETAIL_LIKELY(result != nullptr)) return result;
+    // LCOV_EXCL_START
+    auto* new_handler = std::get_new_handler();
+    if (new_handler == nullptr) throw std::bad_alloc{};
+    (*new_handler)();
+    // LCOV_EXCL_STOP
+  }
+}
+
+}  // namespace
+
+void* operator new(std::size_t count) { return do_new(&malloc, count); }
+
+void* operator new(std::size_t count, std::align_val_t al) {
+  return do_new(&unodb::detail::allocate_aligned_nothrow, count,
+                static_cast<std::size_t>(al));
+}
+
+void operator delete(void* ptr) noexcept {
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory,hicpp-no-malloc)
+  free(ptr);
+}
+
+UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wmissing-prototypes")
+void operator delete(void* ptr, std::size_t) noexcept {
+  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory,hicpp-no-malloc)
+  free(ptr);
+}
+UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
+
+void operator delete(void* ptr, std::align_val_t) noexcept {
+  unodb::detail::free_aligned(ptr);
+}
+
+#endif  // #if !defined(NDEBUG) && !defined(_MSC_VER) &&
+        // !(defined(__clang__) && (defined(UNODB_DETAIL_ADDRESS_SANITIZER) ||
+        // defined(UNODB_DETAIL_THREAD_SANITIZER)))

--- a/heap.hpp
+++ b/heap.hpp
@@ -56,11 +56,14 @@ class allocation_failure_injector final {
 #endif
   }
 
+  static void fail_on_nth_allocation(
+      std::uint64_t n UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
-
-  static void fail_on_nth_allocation(std::uint64_t n) noexcept {
     fail_on_nth_allocation_ = n;
+#endif
   }
+
+#ifndef NDEBUG
 
   UNODB_DETAIL_DISABLE_GCC_WARNING("-Wanalyzer-malloc-leak")
 
@@ -75,8 +78,8 @@ class allocation_failure_injector final {
   UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
  private:
-  static inline std::atomic<std::uint64_t> allocation_counter{0};
-  static inline std::uint64_t fail_on_nth_allocation_{0};
+  static std::atomic<std::uint64_t> allocation_counter;
+  static std::uint64_t fail_on_nth_allocation_;
 
 #endif  // #ifndef NDEBUG
 };

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -4,9 +4,6 @@
 
 #include "global.hpp"
 
-#include <cstdlib>
-#include <new>
-
 #include <gtest/gtest.h>
 
 #include "art.hpp"
@@ -15,48 +12,6 @@
 #include "heap.hpp"
 #include "mutex_art.hpp"
 #include "olc_art.hpp"
-
-namespace {
-
-template <typename Alloc, typename... Args>
-void* do_new(Alloc alloc, std::size_t count, Args... args) {
-  unodb::test::allocation_failure_injector::maybe_fail();
-  while (true) {
-    // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,hicpp-no-malloc)
-    void* const result = alloc(count, args...);
-    if (UNODB_DETAIL_LIKELY(result != nullptr)) return result;
-    // LCOV_EXCL_START
-    auto* new_handler = std::get_new_handler();
-    if (new_handler == nullptr) throw std::bad_alloc{};
-    (*new_handler)();
-    // LCOV_EXCL_STOP
-  }
-}
-
-}  // namespace
-
-void* operator new(std::size_t count) { return do_new(&malloc, count); }
-
-void* operator new(std::size_t count, std::align_val_t al) {
-  return do_new(&unodb::detail::allocate_aligned_nothrow, count,
-                static_cast<std::size_t>(al));
-}
-
-void operator delete(void* ptr) noexcept {
-  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,hicpp-no-malloc)
-  free(ptr);
-}
-
-UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wmissing-prototypes")
-void operator delete(void* ptr, std::size_t) noexcept {
-  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,hicpp-no-malloc)
-  free(ptr);
-}
-UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
-
-void operator delete(void* ptr, std::align_val_t) noexcept {
-  unodb::detail::free_aligned(ptr);
-}
 
 namespace {
 
@@ -161,20 +116,6 @@ TYPED_TEST(ARTOOMTest, ExpandLeafToNode4) {
         verifier.assert_node_counts({2, 1, 0, 0, 0});
         verifier.assert_growing_inodes({1, 0, 0, 0});
       });
-}
-
-TYPED_TEST(ARTOOMTest, NoAllocationOnDuplicateKey) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert(0, unodb::test::test_values[0]);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  UNODB_ASSERT_FALSE(verifier.get_db().insert(0, unodb::test::test_values[3]));
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-  verifier.assert_growing_inodes({0, 0, 0, 0});
-  verifier.check_present_values();
 }
 
 TYPED_TEST(ARTOOMTest, TwoNode4) {
@@ -360,146 +301,6 @@ TYPED_TEST(ARTOOMTest, Node256KeyPrefixSplit) {
       });
 }
 
-TYPED_TEST(ARTOOMTest, DeleteFromEmptyDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.attempt_remove_missing_keys({1});
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_empty();
-  verifier.check_absent_keys({1});
-}
-
-TYPED_TEST(ARTOOMTest, SingleNodeTreeDeleteDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert(1, unodb::test::test_values[0]);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.remove(1);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_empty();
-  verifier.check_absent_keys({1});
-  verifier.attempt_remove_missing_keys({1});
-  verifier.check_absent_keys({1});
-}
-
-TYPED_TEST(ARTOOMTest, SingleNodeTreeAttemptDeleteAbsentDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert(2, unodb::test::test_values[1]);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.attempt_remove_missing_keys({1, 3, 0xFF02});
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.check_present_values();
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-  verifier.check_absent_keys({1, 3, 0xFF02});
-}
-
-TYPED_TEST(ARTOOMTest, Node4AttemptDeleteAbsentDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(1, 4);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.attempt_remove_missing_keys({0, 6, 0xFF000001});
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_node_counts({4, 1, 0, 0, 0});
-  verifier.check_absent_keys({0, 6, 0xFF00000});
-}
-
-TYPED_TEST(ARTOOMTest, Node4DeleteDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(1, 4);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.remove(2);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({0, 2, 5});
-  verifier.assert_node_counts({3, 1, 0, 0, 0});
-}
-
-TYPED_TEST(ARTOOMTest, Node4ShrinkToSingleLeafDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(1, 2);
-  verifier.assert_shrinking_inodes({0, 0, 0, 0});
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.remove(1);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_shrinking_inodes({1, 0, 0, 0});
-  verifier.check_present_values();
-  verifier.check_absent_keys({1});
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-}
-
-TYPED_TEST(ARTOOMTest, Node4DeleteLowerNodeDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(0, 2);
-  // Insert a value that does not share full prefix with the current Node4
-  verifier.insert(0xFF00, unodb::test::test_values[3]);
-  verifier.assert_shrinking_inodes({0, 0, 0, 0});
-  verifier.assert_key_prefix_splits(1);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  // Make the lower Node4 shrink to a single value leaf
-  verifier.remove(0);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_shrinking_inodes({1, 0, 0, 0});
-  verifier.assert_key_prefix_splits(1);
-  verifier.check_present_values();
-  verifier.check_absent_keys({0, 2, 0xFF01});
-  verifier.assert_node_counts({2, 1, 0, 0, 0});
-}
-
-TYPED_TEST(ARTOOMTest, Node4DeleteKeyPrefixMergeDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(0x8001, 2);
-  // Insert a value that does not share full prefix with the current Node4
-  verifier.insert(0x90AA, unodb::test::test_values[3]);
-  verifier.assert_key_prefix_splits(1);
-  verifier.assert_node_counts({3, 2, 0, 0, 0});
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  // And delete it
-  verifier.remove(0x90AA);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_key_prefix_splits(1);
-  verifier.assert_node_counts({2, 1, 0, 0, 0});
-  verifier.assert_shrinking_inodes({1, 0, 0, 0});
-  verifier.check_present_values();
-  verifier.check_absent_keys({0x90AA, 0x8003});
-  verifier.assert_node_counts({2, 1, 0, 0, 0});
-}
-
-TYPED_TEST(ARTOOMTest, Node16DeleteDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(1, 16);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.remove(5);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({5});
-  verifier.assert_node_counts({15, 0, 1, 0, 0});
-}
-
 TYPED_TEST(ARTOOMTest, Node16ShrinkToNode4) {
   oom_test<TypeParam>(
       2,
@@ -518,41 +319,6 @@ TYPED_TEST(ARTOOMTest, Node16ShrinkToNode4) {
         verifier.assert_node_counts({4, 1, 0, 0, 0});
         verifier.check_absent_keys({2});
       });
-}
-
-TYPED_TEST(ARTOOMTest, Node16KeyPrefixMergeDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(10, 5);
-  // Insert a value that does not share full prefix with the current Node16
-  verifier.insert(0x1020, unodb::test::test_values[0]);
-  verifier.assert_node_counts({6, 1, 1, 0, 0});
-  verifier.assert_key_prefix_splits(1);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  // And delete it, so that upper level Node4 key prefix gets merged with
-  // Node16 one
-  verifier.remove(0x1020);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.assert_shrinking_inodes({1, 0, 0, 0});
-  verifier.assert_node_counts({5, 0, 1, 0, 0});
-  verifier.check_present_values();
-  verifier.check_absent_keys({9, 16, 0x1020});
-}
-
-TYPED_TEST(ARTOOMTest, Node48DeleteDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(1, 48);
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.remove(30);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({30});
-  verifier.assert_node_counts({47, 0, 0, 1, 0});
 }
 
 TYPED_TEST(ARTOOMTest, Node48ShrinkToNode16) {
@@ -575,21 +341,6 @@ TYPED_TEST(ARTOOMTest, Node48ShrinkToNode16) {
       });
 }
 
-TYPED_TEST(ARTOOMTest, Node256DeleteDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert_key_range(1, 255);
-  verifier.assert_node_counts({255, 0, 0, 0, 1});
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.remove(180);
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.check_present_values();
-  verifier.check_absent_keys({180});
-  verifier.assert_node_counts({254, 0, 0, 0, 1});
-}
-
 TYPED_TEST(ARTOOMTest, Node256ShrinkToNode48) {
   oom_test<TypeParam>(
       2,
@@ -608,20 +359,6 @@ TYPED_TEST(ARTOOMTest, Node256ShrinkToNode48) {
         verifier.assert_node_counts({48, 0, 0, 1, 0});
         verifier.check_absent_keys({25});
       });
-}
-
-TYPED_TEST(ARTOOMTest, ClearDoesNotAllocate) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  verifier.clear();
-  unodb::test::allocation_failure_injector::reset();
-
-  verifier.check_absent_keys({1});
-  verifier.assert_node_counts({0, 0, 0, 0, 0});
 }
 
 }  // namespace


### PR DESCRIPTION
This avoids duplicating test logic. For that,
- introduce heap.cpp source file with global new & delete operators
- Because of heap.cpp, unodb_util cannot remain an interface-only library.
  Rework CMake to make it a regular library.