### PR TITLE
Tweak OOM tests

### DIFF
--- a/heap.cpp
+++ b/heap.cpp
@@ -16,7 +16,8 @@ namespace unodb::test {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<std::uint64_t> allocation_failure_injector::allocation_counter{0};
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::uint64_t allocation_failure_injector::fail_on_nth_allocation_{0};
+std::atomic<std::uint64_t> allocation_failure_injector::fail_on_nth_allocation_{
+    0};
 
 #endif  // #ifndef NDEBUG
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -239,6 +239,7 @@ class [[nodiscard]] tree_verifier final {
                       node_counts_before[as_i<unodb::node_type::LEAF>] + 1);
 
     if (!bypass_verifier) {
+      allocation_failure_injector::reset();
       const auto [pos, insert_succeeded] = values.try_emplace(k, v);
       (void)pos;
       UNODB_ASSERT_TRUE(insert_succeeded);
@@ -366,7 +367,6 @@ class [[nodiscard]] tree_verifier final {
 
   void clear() {
     test_db.clear();
-    // TODO(laurynas): refactor
     allocation_failure_injector::reset();
     assert_empty();
 

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -51,7 +51,7 @@ void oom_insert_test(unsigned fail_limit, Init init, unodb::key k,
   oom_test<TypeParam>(
       fail_limit, init,
       [k, v](unodb::test::tree_verifier<TypeParam>& verifier) {
-        verifier.insert(k, v, true);
+        verifier.insert(k, v);
       },
       [k](unodb::test::tree_verifier<TypeParam>& verifier) {
         verifier.check_absent_keys({k});


### PR DESCRIPTION
- Reset OOM failure injector in the test inserter, before inserting to the
  verifier
- No longer bypass verifier in the OOM insert tests
- Remove a TODO comment