### PR TITLE
Mark all the implicitly-noexcept destructors explicitly noexcept

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -274,7 +274,7 @@ struct basic_art_policy final {
                                                         Db &db_) noexcept
         : node_ptr{node_ptr_}, db{db_} {}
 
-    ~delete_db_node_ptr_at_scope_exit() {
+    ~delete_db_node_ptr_at_scope_exit() noexcept {
       switch (node_ptr.type()) {
         case node_type::LEAF: {
           const auto r{

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -60,7 +60,7 @@ class [[nodiscard]] concurrent_benchmark {
 
  public:
   concurrent_benchmark() noexcept = default;
-  virtual ~concurrent_benchmark() = default;
+  virtual ~concurrent_benchmark() noexcept = default;
 
   void parallel_get(::benchmark::State &state) {
     const auto num_of_threads = static_cast<std::size_t>(state.range(0));

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -58,7 +58,7 @@ struct [[nodiscard]] thread_info final {
 
   thread_info(const thread_info &) = delete;
 
-  ~thread_info() = default;
+  ~thread_info() noexcept = default;
 
   thread_info &operator=(thread_info &&other) noexcept = default;
 

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -116,7 +116,7 @@ class [[nodiscard]] optimistic_lock final {
 
     // If the destructor ever starts doing something in the release build, reset
     // moved-from lock fields in the move and write_guard constructors.
-    ~read_critical_section() {
+    ~read_critical_section() noexcept {
 #ifndef NDEBUG
       if (lock != nullptr) std::ignore = lock->try_read_unlock(version);
 #endif
@@ -145,7 +145,7 @@ class [[nodiscard]] optimistic_lock final {
       if (UNODB_DETAIL_UNLIKELY(!result)) lock = nullptr;  // LCOV_EXCL_LINE
     }
 
-    ~write_guard() {
+    ~write_guard() noexcept {
       if (lock == nullptr) return;
       lock->write_unlock();
     }
@@ -188,7 +188,7 @@ class [[nodiscard]] optimistic_lock final {
   optimistic_lock &operator=(const optimistic_lock &) = delete;
   optimistic_lock &operator=(optimistic_lock &&) = delete;
 
-  ~optimistic_lock() = default;
+  ~optimistic_lock() noexcept = default;
 
   [[nodiscard]] read_critical_section try_read_lock() noexcept {
     while (true) {

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -414,7 +414,7 @@ class [[nodiscard]] deferred_requests final {
   deferred_requests &operator=(const deferred_requests &) noexcept = delete;
   deferred_requests &operator=(deferred_requests &&) noexcept = delete;
 
-  ~deferred_requests() {
+  ~deferred_requests() noexcept {
     for (const auto &dealloc_request : requests) {
       dealloc_request.deallocate(
 #ifndef NDEBUG

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -166,7 +166,7 @@ class qsbr_ptr_span {
   UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span(
       const qsbr_ptr_span<T> &) noexcept = default;
   constexpr qsbr_ptr_span(qsbr_ptr_span<T> &&) noexcept = default;
-  ~qsbr_ptr_span() = default;
+  ~qsbr_ptr_span() noexcept = default;
 
   UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span<T> &operator=(
       const qsbr_ptr_span<T> &) noexcept = default;

--- a/test/qsbr_gtest_utils.cpp
+++ b/test/qsbr_gtest_utils.cpp
@@ -15,7 +15,7 @@ QSBRTestBase::QSBRTestBase() {
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
-QSBRTestBase::~QSBRTestBase() {
+QSBRTestBase::~QSBRTestBase() noexcept {
   if (is_qsbr_paused()) unodb::this_thread().qsbr_resume();
   unodb::this_thread().quiescent();
   unodb::test::expect_idle_qsbr();

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -14,7 +14,7 @@ namespace unodb::test {
 
 class QSBRTestBase : public ::testing::Test {
  public:
-  ~QSBRTestBase() override;
+  ~QSBRTestBase() noexcept override;
 
  protected:
   QSBRTestBase();

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -23,7 +23,7 @@ template <class Db>
 class ARTConcurrencyTest : public ::testing::Test {
  public:
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
-  ~ARTConcurrencyTest() override {
+  ~ARTConcurrencyTest() noexcept override {
     if constexpr (std::is_same_v<Db, unodb::olc_db>) {
       unodb::this_thread().quiescent();
       unodb::test::expect_idle_qsbr();


### PR DESCRIPTION
So that I have to think less.