### PR TITLE
Cleanup QSBR OOM tests

### DIFF
--- a/test/test_qsbr_oom.cpp
+++ b/test/test_qsbr_oom.cpp
@@ -24,23 +24,18 @@ constexpr auto std_thread_thread_alloc_count = 3;
 #error Needs porting
 #endif
 
-template <typename Init, typename TestOOM, typename AfterOOM,
-          typename TestSuccess, typename AfterSuccess>
-void oom_test(unsigned fail_limit, Init init, TestOOM test_oom,
-              AfterOOM after_oom, TestSuccess test_success,
-              AfterSuccess after_success) {
-  init();
+template <typename Test, typename AfterOOM>
+void oom_test(unsigned fail_limit, Test test, AfterOOM after_oom) {
   unsigned fail_n;
   for (fail_n = 1; fail_n < fail_limit; ++fail_n) {
     unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-    UNODB_ASSERT_THROW(test_oom(), std::bad_alloc);
+    UNODB_ASSERT_THROW(test(), std::bad_alloc);
     unodb::test::allocation_failure_injector::reset();
     after_oom();
   }
   unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-  test_success();
+  test();
   unodb::test::allocation_failure_injector::reset();
-  after_success();
 }
 
 using QSBROOMTest = unodb::test::QSBRTestBase;
@@ -48,53 +43,41 @@ using QSBROOMTest = unodb::test::QSBRTestBase;
 UNODB_START_TESTS()
 
 TEST_F(QSBROOMTest, Resume) {
+  qsbr_pause();
+  UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
   oom_test(
-      3,
-      []() noexcept {
-        qsbr_pause();
-        UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
-      },
-      [] { unodb::this_thread().qsbr_resume(); },
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0); },
-      [] { unodb::this_thread().qsbr_resume(); },
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); });
+      3, [] { unodb::this_thread().qsbr_resume(); },
+      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0); });
+  UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
 }
 
 TEST_F(QSBROOMTest, StartThread) {
   unodb::qsbr_thread second_thread;
+  UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
   oom_test(
       4 + std_thread_thread_alloc_count,
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); },
-      [] { unodb::qsbr_thread oom_thread{[]() noexcept {}}; },
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); },
       [&second_thread] {
         second_thread = unodb::qsbr_thread{
             []() noexcept { UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2); }};
       },
-      [&second_thread] { join(second_thread); });
+      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); });
+  join(second_thread);
 }
 
 TEST_F(QSBROOMTest, DeferredDeallocation) {
   auto *ptr = static_cast<char *>(allocate());
-  unodb::qsbr_thread second_thread;
+  unodb::qsbr_thread second_thread{[] {
+    unodb::detail::thread_syncs[0].notify();
+    unodb::detail::thread_syncs[1].wait();
+
+    quiescent();
+  }};
+  unodb::detail::thread_syncs[0].wait();
   oom_test(
-      2,
-      [&second_thread]() noexcept {
-        second_thread = unodb::qsbr_thread{[] {
-          unodb::detail::thread_syncs[0].notify();
-          unodb::detail::thread_syncs[1].wait();
-
-          quiescent();
-        }};
-
-        unodb::detail::thread_syncs[0].wait();
-      },
-      [ptr] { qsbr_deallocate(ptr); }, [ptr]() noexcept { touch_memory(ptr); },
-      [ptr] { qsbr_deallocate(ptr); },
-      [&second_thread] {
-        unodb::detail::thread_syncs[1].notify();
-        join(second_thread);
-      });
+      2, [ptr] { qsbr_deallocate(ptr); },
+      [ptr]() noexcept { touch_memory(ptr); });
+  unodb::detail::thread_syncs[1].notify();
+  join(second_thread);
 }
 
 UNODB_END_TESTS()


### PR DESCRIPTION
- Move out test init and after success actions out of oom_test
- Merge test-for-OOM and test-for-success actions