### PR TITLE
Do not use C++ standard library hardware interference sizes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,7 +539,7 @@ function(ADD_UNODB_LIBRARY LIB)
 endfunction()
 
 add_unodb_library(unodb_util global.hpp assert.hpp portability_builtins.hpp
-  thread_sync.hpp heap.hpp heap.cpp portability_stdlib.hpp)
+  thread_sync.hpp heap.hpp heap.cpp portability_arch.hpp)
 target_include_directories(unodb_util INTERFACE ".")
 target_include_directories(unodb_util SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
 target_link_libraries(unodb_util PRIVATE "${Boost_LIBRARIES}")

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -16,7 +16,7 @@
 #include "assert.hpp"
 #include "node_type.hpp"
 #include "optimistic_lock.hpp"
-#include "portability_stdlib.hpp"
+#include "portability_arch.hpp"
 #include "qsbr_ptr.hpp"
 
 namespace unodb {

--- a/portability_arch.hpp
+++ b/portability_arch.hpp
@@ -1,16 +1,17 @@
 // Copyright 2022 Laurynas Biveinis
-#ifndef UNODB_DETAIL_PORTABILITY_STDLIB_HPP
-#define UNODB_DETAIL_PORTABILITY_STDLIB_HPP
+#ifndef UNODB_DETAIL_PORTABILITY_ARCH_HPP
+#define UNODB_DETAIL_PORTABILITY_ARCH_HPP
 
 #include "global.hpp"
 
 #include <cstddef>
-#include <new>
 
 namespace unodb::detail {
 
-#if !defined(__cpp_lib_hardware_interference_size) || \
-    __cpp_lib_hardware_interference_size < 201703
+// Do not use std::hardware_constructive_interference_size and
+// std::hardware_destructive_interference_size even when they are available,
+// because they are used in public headers, and their values are unstable (i.e.
+// can be affected by GCC 12 --param or -mtune flags).
 
 #ifdef UNODB_DETAIL_X86_64
 inline constexpr std::size_t hardware_constructive_interference_size = 64;
@@ -19,7 +20,8 @@ inline constexpr std::size_t hardware_constructive_interference_size = 64;
 inline constexpr std::size_t hardware_destructive_interference_size = 128;
 #elif defined(__aarch64__)
 inline constexpr std::size_t hardware_constructive_interference_size = 64;
-inline constexpr std::size_t hardware_destructive_interference_size = 64;
+// Value stolen from GCC 12 implementation
+inline constexpr std::size_t hardware_destructive_interference_size = 256;
 #else
 #error Needs porting
 #endif
@@ -28,13 +30,6 @@ static_assert(hardware_constructive_interference_size >=
               alignof(std::max_align_t));
 static_assert(hardware_destructive_interference_size >=
               alignof(std::max_align_t));
-
-#else
-
-using std::hardware_constructive_interference_size;
-using std::hardware_destructive_interference_size;
-
-#endif
 
 }  // namespace unodb::detail
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -33,7 +33,7 @@
 
 #include "assert.hpp"
 #include "heap.hpp"
-#include "portability_stdlib.hpp"
+#include "portability_arch.hpp"
 
 namespace unodb {
 


### PR DESCRIPTION
Even if they are available, because they are used in public headers, and their
values are unstable (i.e. can be affected by GCC 12 --param or -mtune flags).