### PR TITLE
Fix MSVC 17.2.2 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,11 +87,13 @@ endif()
 # - "C4324: '...': structure was padded due to alignment specifier"
 # - "C5030: attribute '...' is not recognized"
 # - "C5072, ASAN enabled without debug information emission" - triggered by
-# msvc-release-asan preset
+#   msvc-release-asan preset
+# - "C5246: '...': the initialization of a subobject should be wrapped in
+#   braces": billions of std::array false positives with 17.2.2.
 # - The other disabled warnings only activate on /Wall
 set(MSVC_CXX_WARNING_FLAGS "/Wall" "/wd4324" "/wd5030" "/wd5072" 
   "/wd4623" "/wd4625" "/wd4626" "/wd4582" "/wd4820" "/wd4710" "/wd4711"
-  "/wd4868" "/wd5026" "/wd5027" "/wd5045")
+  "/wd4868" "/wd5026" "/wd5027" "/wd5045" "/wd5246")
 
 set(MSVC_CLANG_CXX_FLAGS "/arch:AVX" "/permissive-")
 
@@ -273,31 +275,41 @@ find_package(Threads REQUIRED)
 
 find_package(Boost REQUIRED)
 
-set(ORIG_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-set(ORIG_CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
-set(ORIG_CMAKE_MODULE_LINKER_FLAGS ${CMAKE_MODULE_LINKER_FLAGS})
-set(ORIG_CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
-
 string(REPLACE ";" " " CXX_FLAGS_FOR_SUBDIR_STR "${SANITIZER_CXX_FLAGS}")
-string(APPEND CMAKE_CXX_FLAGS ${CXX_FLAGS_FOR_SUBDIR_STR})
 if(MSVC)
-  string(REPLACE ";" " " WARNING_FLAGS_FOR_SUBDIR_STR "${MSVC_CXX_WARNING_FLAGS}")
-  string(REPLACE "/Wall" "" WARNING_FLAGS_FOR_SUBDIR_STR2 
-      "${WARNING_FLAGS_FOR_SUBDIR_STR}")
-  string(APPEND CMAKE_CXX_FLAGS " " ${WARNING_FLAGS_FOR_SUBDIR_STR2})
+  string(REPLACE ";" " " MSVC_WARNING_FLAGS_FOR_SUBDIR_STR_TMP "${MSVC_CXX_WARNING_FLAGS}")
+  string(REPLACE "/Wall" "" MSVC_WARNING_FLAGS_FOR_SUBDIR_STR
+    "${MSVC_WARNING_FLAGS_FOR_SUBDIR_STR_TMP}")
 endif()
 string(REPLACE ";" " " LD_FLAGS_FOR_SUBDIR_STR "${SANITIZER_LD_FLAGS}")
-string(APPEND CMAKE_EXE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
-string(APPEND CMAKE_MODULE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
-string(APPEND CMAKE_SHARED_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
+
+macro(ADD_CXX_FLAGS_FOR_SUBDIR)
+  set(ORIG_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  set(ORIG_CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})
+  set(ORIG_CMAKE_MODULE_LINKER_FLAGS ${CMAKE_MODULE_LINKER_FLAGS})
+  set(ORIG_CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
+  string(APPEND CMAKE_CXX_FLAGS " " "${CXX_FLAGS_FOR_SUBDIR_STR}")
+  if(MSVC)
+    string(APPEND CMAKE_CXX_FLAGS " " "${MSVC_WARNING_FLAGS_FOR_SUBDIR_STR}")
+  endif()
+  string(APPEND CMAKE_EXE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
+  string(APPEND CMAKE_MODULE_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS "${LD_FLAGS_FOR_SUBDIR_STR}")
+endmacro()
+
+macro(RESTORE_CXX_FLAGS_FOR_SUBDIR)
+  set(CMAKE_CXX_FLAGS ${ORIG_CMAKE_CXX_FLAGS})
+  set(CMAKE_EXE_LINKER_FLAGS ${ORIG_CMAKE_EXE_LINKER_FLAGS})
+  set(CMAKE_MODULE_LINKER_FLAGS ${ORIG_CMAKE_MODULE_LINKER_FLAGS})
+  set(CMAKE_SHARED_LINKER_FLAGS ${ORIG_CMAKE_SHARED_LINKER_FLAGS})
+endmacro()
+
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-add_subdirectory(3rd_party/googletest)
 
-set(CMAKE_CXX_FLAGS ${ORIG_CMAKE_CXX_FLAGS})
-set(CMAKE_EXE_LINKER_FLAGS ${ORIG_CMAKE_EXE_LINKER_FLAGS})
-set(CMAKE_MODULE_LINKER_FLAGS ${ORIG_CMAKE_MODULE_LINKER_FLAGS})
-set(CMAKE_SHARED_LINKER_FLAGS ${ORIG_CMAKE_SHARED_LINKER_FLAGS})
+ADD_CXX_FLAGS_FOR_SUBDIR()
+add_subdirectory(3rd_party/googletest)
+RESTORE_CXX_FLAGS_FOR_SUBDIR()
 
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Suppressing Google Benchmark tests"
   FORCE)
@@ -319,7 +331,9 @@ if(IPO_SUPPORTED)
   endif()
 endif()
 
+ADD_CXX_FLAGS_FOR_SUBDIR()
 add_subdirectory(3rd_party/benchmark)
+RESTORE_CXX_FLAGS_FOR_SUBDIR()
 
 # Do not build DeepState:
 # - under Windows as it's not supported

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -175,19 +175,19 @@ template <unsigned B>
 }
 
 template <unsigned NodeSize>
-[[nodiscard, gnu::const]] constexpr auto number_to_full_node_size_tree_key(
-    std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr std::uint64_t
+number_to_full_node_size_tree_key(std::uint64_t i) noexcept {
   return to_base_n_value<NodeSize>(i);
 }
 
 template <unsigned NodeSize>
-[[nodiscard, gnu::const]] constexpr auto number_to_minimal_node_size_tree_key(
-    std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr std::uint64_t
+number_to_minimal_node_size_tree_key(std::uint64_t i) noexcept {
   return to_base_n_value<node_capacity_to_minimum_size<NodeSize>()>(i);
 }
 
 template <unsigned NodeSize>
-[[nodiscard, gnu::const]] constexpr auto
+[[nodiscard, gnu::const]] constexpr std::uint64_t
 number_to_full_leaf_over_minimal_tree_key(std::uint64_t i) noexcept {
   constexpr auto min = node_capacity_to_minimum_size<NodeSize>();
   constexpr auto delta = node_capacity_over_minimum<NodeSize>();
@@ -199,7 +199,7 @@ number_to_full_leaf_over_minimal_tree_key(std::uint64_t i) noexcept {
 }
 
 template <unsigned NodeSize>
-[[nodiscard, gnu::const]] constexpr auto
+[[nodiscard, gnu::const]] constexpr std::uint64_t
 number_to_minimal_leaf_over_smaller_node_tree(std::uint64_t i) noexcept {
   constexpr auto N = static_cast<std::uint64_t>(NodeSize);
   UNODB_DETAIL_ASSERT(i / (N * N * N * N * N * N) < N);
@@ -207,8 +207,8 @@ number_to_minimal_leaf_over_smaller_node_tree(std::uint64_t i) noexcept {
 }
 
 template <unsigned NodeSize>
-[[nodiscard, gnu::const]] constexpr auto number_to_full_node_tree_with_gaps_key(
-    std::uint64_t i) noexcept {
+[[nodiscard, gnu::const]] constexpr std::uint64_t
+number_to_full_node_tree_with_gaps_key(std::uint64_t i) noexcept {
   static_assert(NodeSize == 4 || NodeSize == 16 || NodeSize == 48);
   // Full Node4 tree keys with 1, 3, 5, & 7 as the different key byte values
   // so that a new byte could be inserted later at any position:


### PR DESCRIPTION
- Expand some auto return types as the compiler complains about such functions being passed as template args
- Disable C5246 warning ("the initialization of a subobject should be wrapped in braces") due to std::array false positives