### PR TITLE
Avoid passing uninitialized QSBR epoch numbers around in the debug build

### DIFF
--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -244,7 +244,7 @@ class QSBRTestBase : public ::testing::Test {
   QSBRTestBase &operator=(QSBRTestBase &&) = delete;
 
  private:
-  unodb::qsbr_epoch last_epoch{};
+  unodb::qsbr_epoch last_epoch{0};
 };
 
 }  // namespace unodb::test


### PR DESCRIPTION
Wrap debug fields in deallocation_request with std::optional, and extend the
assert in deallocate method to assert presence or absence of the values. Delete
the default constructor of qsbr_epoch.

Done because of a cppcheck 2.8 suggestion.