### PR TITLE
GitHub Actions: remove clang-tidy-10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,7 @@ jobs:
         run: |
           sudo add-apt-repository -y 'ppa:mhier/libboost-latest'
           sudo apt-get install -y boost1.74 libc6-dev-i386
+          sudo apt-get remove clang-tidy-11
         if: runner.os == 'Linux'
 
       - name: Setup dependencies for cpplint


### PR DESCRIPTION
So that it's not picked up. The jobs that need it install clang-tidy-13 instead.