### PR TITLE
Add UNODB_DETAIL_ prefix to VALGRIND_CLIENT_REQUESTS macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,7 +519,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   set_target_properties(${TARGET} PROPERTIES CXX_EXTENSIONS OFF)
   target_compile_definitions(${TARGET} PRIVATE
-    "$<$<AND:${is_debug},${has_valgrind_client}>:VALGRIND_CLIENT_REQUESTS>")
+    "$<${has_valgrind_client}:UNODB_DETAIL_VALGRIND_CLIENT_REQUESTS>")
   target_compile_options(${TARGET} PRIVATE
     "${CXX_FLAGS}" "${SANITIZER_CXX_FLAGS}"
     "$<${is_msvc}:${MSVC_CXX_FLAGS}>"

--- a/heap.hpp
+++ b/heap.hpp
@@ -37,7 +37,7 @@
 
 #endif
 
-#if !defined(NDEBUG) && defined(VALGRIND_CLIENT_REQUESTS)
+#if !defined(NDEBUG) && defined(UNODB_DETAIL_VALGRIND_CLIENT_REQUESTS)
 #include <valgrind/memcheck.h>
 #include <valgrind/valgrind.h>
 #else


### PR DESCRIPTION
Try to reduce name pollution.