### PR TITLE
Fix including UnoDB into other projects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,10 @@ jobs:
               EXTRA_CMAKE_ARGS=("${EXTRA_CMAKE_ARGS[@]}" \
                   "-DCLANG_TIDY_EXE=/usr/bin/clang-tidy-15")
             fi
-            cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFATAL_WARNINGS=ON \
-              -DSANITIZE_ADDRESS=$ASAN -DSANITIZE_THREAD=$TSAN \
-              -DSANITIZE_UB=$UBSAN "${EXTRA_CMAKE_ARGS[@]}"
+            cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSTANDALONE=ON \
+              -DFATAL_WARNINGS=ON -DSANITIZE_ADDRESS=$ASAN \
+              -DSANITIZE_THREAD=$TSAN -DSANITIZE_UB=$UBSAN \
+              "${EXTRA_CMAKE_ARGS[@]}"
       - run:
           name: Build
           working_directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,7 +333,7 @@ jobs:
             export CC=clang
             export CXX=clang++
           fi
-          cmake "$GITHUB_WORKSPACE" -DFATAL_WARNINGS=ON \
+          cmake "$GITHUB_WORKSPACE" -DSTANDALONE=ON -DFATAL_WARNINGS=ON \
               "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
               "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
               "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \

--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: XCode Release include-what-you-use & aggressive cppcheck
+          - name: XCode Release iwyu, aggressive cppcheck, not standalone
             BUILD_TYPE: Release
 
-          - name: XCode Debug include-what-you-use & aggressive cppcheck
+          - name: XCode Debug iwyu, aggressive cppcheck, not standalone
             BUILD_TYPE: Debug
 
     steps:

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -412,7 +412,7 @@ jobs:
                   "-DLLVMRANLIB_EXECUTABLE=/usr/bin/llvm-ranlib-${VERSION}")
             fi
           fi
-          cmake "$GITHUB_WORKSPACE" -DFATAL_WARNINGS=ON \
+          cmake "$GITHUB_WORKSPACE" -DSTANDALONE=ON -DFATAL_WARNINGS=ON \
               "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
               "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
               "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(unodb VERSION 0.1
   DESCRIPTION "unodb key-value store library"
   HOMEPAGE_URL "https://github.com/laurynas-biveinis/unodb" LANGUAGES CXX)
 
+option(STANDALONE
+  "Build UnoDB not for linking with outside code. Enables extra global checks")
+
 option(FATAL_WARNINGS "Make warning diagnostics fatal")
 if(FATAL_WARNINGS)
   message(STATUS "Warning diagnostics are fatal")
@@ -423,9 +426,11 @@ set(has_valgrind_client "$<BOOL:${VALGRIND_CLIENT}>")
 set(has_avx2 "$<BOOL:${AVX2}>")
 set(fatal_warnings_on "$<BOOL:${FATAL_WARNINGS}>")
 set(coverage_on "$<BOOL:${COVERAGE}>")
+set(is_standalone "$<BOOL:${STANDALONE}>")
+set(is_gxx_debug_standalone $<AND:${is_gxx},${is_debug},${is_standalone}>)
 
 target_compile_definitions(benchmark PUBLIC
-  "$<$<AND:${is_gxx},${is_debug}>:_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC>")
+  "$<${is_gxx_debug_standalone}:_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC>")
 
 # Add benchmark_include_dirs by target_include_directories(... SYSTEM ...)
 # before target_link_libraries so that benchmark headers are included through
@@ -517,6 +522,8 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   cmake_parse_arguments(PARSE_ARGV 1 CTP "SKIP_CHECKS" "" "")
   target_compile_features(${TARGET} PUBLIC cxx_std_17)
   set_target_properties(${TARGET} PROPERTIES CXX_EXTENSIONS OFF)
+  target_compile_definitions(${TARGET} PRIVATE
+    "$<${is_standalone}:UNODB_DETAIL_STANDALONE>")
   target_compile_definitions(${TARGET} PRIVATE
     "$<${has_valgrind_client}:UNODB_DETAIL_VALGRIND_CLIENT_REQUESTS>")
   target_compile_options(${TARGET} PRIVATE
@@ -654,6 +661,7 @@ if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
 endif()
 
 message(STATUS "User-set CMake options:")
+message(STATUS "STANDALONE: ${STANDALONE}")
 message(STATUS "FATAL_WARNINGS: ${FATAL_WARNINGS}")
 message(STATUS "AVX2: ${AVX2}")
 message(STATUS "COVERAGE: ${COVERAGE}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,6 +11,7 @@
             "hidden": true,
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
+                "STANDALONE": "ON",
                 "FATAL_WARNINGS": "ON"
             }
         },

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The are three ART classes available:
   (QSBR) was chosen.
 
 Any macros starting with `UNODB_DETAIL_` are internal and should not be used.
+Likewise for any declarations in `unodb::detail` and ``unodb::test`` namespaces.
 
 ## Dependencies
 
@@ -106,6 +107,11 @@ Source code is formatted with [Google C++ style][gc++style]. Automatic code
 formatting is configured through git  clean/fuzz filters. To enable it, do `git
 config --local include.path ../.gitconfig`. If for any reason you need to
 disable it temporarily, do `git config  --local --unset include.path`
+
+When building this project alone and not as a part of another project, add
+`-DSTANDALONE=ON` CMake option. It will enable extra global debug checks that
+require whole programs to be compiled with them. Currently this consists of
+libstdc+++ debug mode.
 
 To make compiler warnings fatal, add `-DFATAL_WARNINGS=ON` CMake option.
 

--- a/global.hpp
+++ b/global.hpp
@@ -4,8 +4,9 @@
 
 // Defines that must precede includes
 
-#ifndef NDEBUG
-#ifndef __clang__
+#ifdef UNODB_DETAIL_STANDALONE
+
+#if !defined(NDEBUG) && !defined(__clang__)
 
 #ifndef _GLIBCXX_DEBUG
 #define _GLIBCXX_DEBUG
@@ -15,8 +16,7 @@
 #define _GLIBCXX_DEBUG_PEDANTIC
 #endif
 
-#endif  // #ifndef __clang__
-#endif  // #ifndef NDEBUG
+#endif  // !defined(NDEBUG) && !defined(__clang__)
 
 #if defined(__has_feature) && !defined(__clang__)
 #if __has_feature(address_sanitizer)
@@ -25,6 +25,8 @@
 #elif defined(__SANITIZE_ADDRESS__)
 #define _GLIBCXX_SANITIZE_VECTOR 1
 #endif
+
+#endif  // UNODB_DETAIL_STANDALONE
 
 #ifdef _MSC_VER
 #define NOMINMAX


### PR DESCRIPTION
Do not define global debugging checks _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC unconditionally, because they require the whole program to be built either with, either without the define.

Add a new CMake option STANDALONE which indicates that UnoDB is being built separately, and it is OK to enable such checks.