### PR TITLE
Remove mistaken aligned allocation support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,24 +153,6 @@ else()
   message(STATUS "Code coverage reporting not enabled")
 endif()
 
-find_path(VALGRIND_H_PATH valgrind.h PATH_SUFFIXES valgrind)
-if(VALGRIND_H_PATH)
-  find_path(MEMCHECK_H_PATH memcheck.h PATH_SUFFIXES valgrind)
-  if(MEMCHECK_H_PATH)
-    message(STATUS
-      "valgrind.h & memcheck.h found, enabling Valgrind client requests in debug config")
-    set(VALGRIND_CLIENT ON)
-  else()
-    message(STATUS
-      "valgrind.h found but memcheck.h not found, disabling Valgrind client requests in debug config")
-    set(VALGRIND_CLIENT OFF)
-  endif()
-else()
-  message(STATUS
-    "valgrind.h not found, disabling Valgrind client requests in debug config")
-  set(VALGRIND_CLIENT OFF)
-endif()
-
 if(NOT (MSVC AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang"))
   include(CheckIPOSupported)
   check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_SUPPORT_ERROR LANGUAGES CXX)
@@ -413,7 +395,6 @@ set(is_clang_ge_13_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_13}>")
 set(is_clang_ge_14_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_14}>")
 set(is_gxx_ge_11 "$<AND:${is_gxx},${cxx_ge_11}>")
 set(is_gxx_ge_12 "$<AND:${is_gxx},${cxx_ge_12}>")
-set(has_valgrind_client "$<BOOL:${VALGRIND_CLIENT}>")
 set(has_avx2 "$<BOOL:${AVX2}>")
 set(fatal_warnings_on "$<BOOL:${FATAL_WARNINGS}>")
 set(coverage_on "$<BOOL:${COVERAGE}>")
@@ -515,8 +496,6 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   set_target_properties(${TARGET} PROPERTIES CXX_EXTENSIONS OFF)
   target_compile_definitions(${TARGET} PRIVATE
     "$<${is_standalone}:UNODB_DETAIL_STANDALONE>")
-  target_compile_definitions(${TARGET} PRIVATE
-    "$<${has_valgrind_client}:UNODB_DETAIL_VALGRIND_CLIENT_REQUESTS>")
   target_compile_options(${TARGET} PRIVATE
     "${CXX_FLAGS}" "${SANITIZER_CXX_FLAGS}"
     "$<${is_msvc}:${MSVC_CXX_FLAGS}>"

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -167,10 +167,8 @@ void allocate_pointer(std::size_t thread_i) {
   }
 
   LOG(TRACE) << "Allocating pointer";
-  auto *const new_ptr{static_cast<std::uint64_t *>(
-      unodb::detail::allocate_aligned(sizeof(object_mem)))};
-  *new_ptr = object_mem;
-  allocated_pointers.insert(new_ptr);
+  auto new_ptr = std::make_unique<std::uint64_t>(object_mem);
+  allocated_pointers.insert(new_ptr.release());
 }
 
 #ifndef NDEBUG

--- a/heap.cpp
+++ b/heap.cpp
@@ -5,18 +5,17 @@
 #include "heap.hpp"
 
 #ifndef NDEBUG
+
 #include <atomic>
 #include <cstdint>
+
 #if !defined(_MSC_VER) && !defined(UNODB_DETAIL_ADDRESS_SANITIZER) && \
     !defined(UNODB_DETAIL_THREAD_SANITIZER)
 #include <cstdlib>
 #include <new>
 #endif
-#endif
 
 namespace unodb::test {
-
-#ifndef NDEBUG
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<std::uint64_t> allocation_failure_injector::allocation_counter{0};
@@ -24,16 +23,13 @@ std::atomic<std::uint64_t> allocation_failure_injector::allocation_counter{0};
 std::atomic<std::uint64_t> allocation_failure_injector::fail_on_nth_allocation_{
     0};
 
-#endif  // #ifndef NDEBUG
-
 }  // namespace unodb::test
 
 // - ASan/TSan do not work with replaced global new/delete:
 //   https://github.com/llvm/llvm-project/issues/20034
 // - Google Test with MSVC standard library tries to allocate memory in the
 //   exception-thrown-as-expected path
-#if !defined(NDEBUG) && !defined(_MSC_VER) &&   \
-    !defined(UNODB_DETAIL_ADDRESS_SANITIZER) && \
+#if !defined(_MSC_VER) && !defined(UNODB_DETAIL_ADDRESS_SANITIZER) && \
     !defined(UNODB_DETAIL_THREAD_SANITIZER)
 
 namespace {
@@ -57,11 +53,6 @@ void* do_new(Alloc alloc, std::size_t count, Args... args) {
 
 void* operator new(std::size_t count) { return do_new(&malloc, count); }
 
-void* operator new(std::size_t count, std::align_val_t al) {
-  return do_new(&unodb::detail::allocate_aligned_nothrow, count,
-                static_cast<std::size_t>(al));
-}
-
 void operator delete(void* ptr) noexcept {
   // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory,hicpp-no-malloc)
   free(ptr);
@@ -74,10 +65,7 @@ void operator delete(void* ptr, std::size_t) noexcept {
 }
 UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
-void operator delete(void* ptr, std::align_val_t) noexcept {
-  unodb::detail::free_aligned(ptr);
-}
-
-#endif  // !defined(NDEBUG) && !defined(_MSC_VER) &&
-        // !defined(UNODB_DETAIL_ADDRESS_SANITIZER) &&
+#endif  // !defined(_MSC_VER) && !defined(UNODB_DETAIL_ADDRESS_SANITIZER) &&
         // !defined(UNODB_DETAIL_THREAD_SANITIZER)
+
+#endif  // !defined(NDEBUG)

--- a/heap.hpp
+++ b/heap.hpp
@@ -4,49 +4,11 @@
 
 #include "global.hpp"
 
-#include <algorithm>  // IWYU pragma: keep
 #ifndef NDEBUG
 #include <atomic>
-#include <cerrno>
 #endif
 #include <cstdint>
-#include <cstdlib>
 #include <new>
-
-#ifdef _MSC_VER
-#include <malloc.h>
-#endif
-
-// Do not try to use ASan interface under MSVC until the headers are added to
-// the default search paths:
-// https://developercommunity.visualstudio.com/t/ASan-API-headers-not-in-include-path-whe/1517192
-#ifndef UNODB_DETAIL_MSVC
-#if defined(__SANITIZE_ADDRESS__)
-#include <sanitizer/asan_interface.h>
-#elif defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#include <sanitizer/asan_interface.h>
-#endif
-#endif
-#endif
-
-#ifndef ASAN_POISON_MEMORY_REGION
-
-#define ASAN_POISON_MEMORY_REGION(a, s)
-#define ASAN_UNPOISON_MEMORY_REGION(a, s)
-
-#endif
-
-#if !defined(NDEBUG) && defined(UNODB_DETAIL_VALGRIND_CLIENT_REQUESTS)
-#include <valgrind/memcheck.h>
-#include <valgrind/valgrind.h>
-#else
-#define VALGRIND_MALLOCLIKE_BLOCK(addr, sizeB, rzB, is_zeroed)
-#define VALGRIND_FREELIKE_BLOCK(addr, rzB)
-#define VALGRIND_MAKE_MEM_UNDEFINED(_qzz_addr, _qzz_len)
-#endif
-
-#include "assert.hpp"
 
 namespace unodb::test {
 
@@ -100,62 +62,5 @@ void must_not_allocate(TestAction test_action) noexcept(
 }
 
 }  // namespace unodb::test
-
-namespace unodb::detail {
-
-template <typename T>
-[[nodiscard]] constexpr auto alignment_for_new() noexcept {
-  return std::max(alignof(T),
-                  static_cast<std::size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__));
-}
-
-[[nodiscard]] inline void* allocate_aligned_nothrow(
-    std::size_t size,
-    std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__) noexcept {
-  void* result;
-
-#ifndef _MSC_VER
-  const auto err = posix_memalign(&result, alignment, size);
-  if (UNODB_DETAIL_UNLIKELY(err != 0)) result = nullptr;
-#else
-  result = _aligned_malloc(size, alignment);
-#ifndef NDEBUG
-  const auto err = UNODB_DETAIL_LIKELY(result != nullptr) ? 0 : errno;
-#endif
-#endif
-
-  UNODB_DETAIL_ASSERT(err != EINVAL);
-  // NOLINTNEXTLINE(readability-simplify-boolean-expr)
-  UNODB_DETAIL_ASSERT(result != nullptr || err == ENOMEM);
-
-  return result;
-}
-
-[[nodiscard]] inline void* allocate_aligned(
-    std::size_t size,
-    std::size_t alignment = __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
-#ifndef NDEBUG
-  unodb::test::allocation_failure_injector::maybe_fail();
-#endif
-
-  void* result = allocate_aligned_nothrow(size, alignment);
-
-  if (UNODB_DETAIL_UNLIKELY(result == nullptr)) {
-    throw std::bad_alloc{};
-  }
-
-  return result;
-}
-
-inline void free_aligned(void* ptr) noexcept {
-#ifndef _MSC_VER
-  // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory,hicpp-no-malloc)
-  free(ptr);
-#else
-  _aligned_free(ptr);
-#endif
-}
-
-}  // namespace unodb::detail
 
 #endif  // UNODB_DETAIL_HEAP_HPP

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -150,7 +150,7 @@ class QSBRTestBase : public ::testing::Test {
   // Allocation and deallocation
 
   [[nodiscard]] static void *allocate() {
-    return unodb::detail::allocate_aligned(1);
+    return ::operator new(1);
   }
 
 #ifndef NDEBUG


### PR DESCRIPTION
It would be only needed for overaligned allocation support, which is not used, so ends up explicitly requesting the same alignment that we'd be getting without any special work.

- Remove allocate_aligned, alignment_for_new, & free_aligned methods, calling global operator new & delete instead.
- Remove basic_inode::operator new and basic_inode::operator delete, no longer needed.
- Simplify heap.cpp, no longer include heap.hpp in several files
- Remove Valgrind and AddressSanitizer client requests