### PR TITLE
Cleanup heap

### DIFF
--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -11,6 +11,7 @@
 #include "gtest_utils.hpp"
 #include "heap.hpp"
 #include "qsbr.hpp"
+#include "test_utils.hpp"
 
 namespace unodb::test {
 

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -14,9 +14,9 @@
 #include "art_common.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
-#include "heap.hpp"
 #include "mutex_art.hpp"  // IWYU pragma: keep
 #include "olc_art.hpp"    // IWYU pragma: keep
+#include "test_utils.hpp"
 #include "thread_sync.hpp"
 
 namespace {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -1,0 +1,21 @@
+// Copyright 2022 Laurynas Biveinis
+#ifndef UNODB_DETAIL_TEST_UTILS_HPP
+#define UNODB_DETAIL_TEST_UTILS_HPP
+
+#include "global.hpp"  // IWYU pragma: keep
+
+#include "heap.hpp"
+
+namespace unodb::test {
+
+template <typename TestAction>
+void must_not_allocate(TestAction test_action) noexcept(
+    noexcept(test_action())) {
+  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
+  test_action();
+  unodb::test::allocation_failure_injector::reset();
+}
+
+}  // namespace unodb::test
+
+#endif  // UNODB_DETAIL_TEST_UTILS_HPP


### PR DESCRIPTION
- Move unodb::test::must_not_allocate to a new file test/test_utils.hpp
- Inline allocate_aligned_nothrow into allocate_aligned