### PR TITLE
Fix Sonatype Lift integration

### DIFF
--- a/.muse.toml
+++ b/.muse.toml
@@ -1,3 +1,3 @@
 setup = ".muse/dependencies.sh"
-build = "CC=clang-11 CXX=clang++-11 cmake"
+build = "CC=gcc-10 CXX=g++-10 cmake"
 ignoreFiles = "3rd_party/**"

--- a/.muse/dependencies.sh
+++ b/.muse/dependencies.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-add-apt-repository -y 'ppa:mhier/libboost-latest'
-apt-get update
-apt-get install -y boost1.74 clang-11 libc6-dev-i386
+sudo apt-get install -y libboost-dev libc6-dev-i386 g++-10
 git submodule update --init


### PR DESCRIPTION
- Use GCC 10 instead of clang 11 to produce the compilation database
- Use default instead of 3rd party Boost libraries