### PR TITLE
Add LLVM 16 and recent cppcheck support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,3 +21,5 @@ WarningsAsErrors: '*'
 CheckOptions:
   - key: performance-unnecessary-value-param.AllowedTypes
     value: 'version_type'
+  - key: cppcoreguidelines-avoid-do-while.IgnoreMacros
+    value: true

--- a/art.cpp
+++ b/art.cpp
@@ -246,9 +246,11 @@ std::optional<detail::node_ptr *> impl_helpers::remove_or_choose_subtree(
 
 namespace unodb {
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 db::~db() noexcept { delete_root_subtree(); }
 
 template <class INode>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::increment_inode_count() noexcept {
   static_assert(inode_defs::is_inode<INode>());
 
@@ -257,6 +259,7 @@ constexpr void db::increment_inode_count() noexcept {
 }
 
 template <class INode>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::decrement_inode_count() noexcept {
   static_assert(inode_defs::is_inode<INode>());
   UNODB_DETAIL_ASSERT(node_counts[as_i<INode::type>] > 0);
@@ -266,6 +269,7 @@ constexpr void db::decrement_inode_count() noexcept {
 }
 
 template <node_type NodeType>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::account_growing_inode() noexcept {
   static_assert(NodeType != node_type::LEAF);
 
@@ -275,6 +279,7 @@ constexpr void db::account_growing_inode() noexcept {
 }
 
 template <node_type NodeType>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::account_shrinking_inode() noexcept {
   static_assert(NodeType != node_type::LEAF);
 
@@ -283,6 +288,7 @@ constexpr void db::account_shrinking_inode() noexcept {
                       growing_inode_counts[internal_as_i<NodeType>]);
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 db::get_result db::get(key search_key) const noexcept {
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) return {};
 
@@ -426,6 +432,7 @@ bool db::remove(key remove_key) {
   }
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void db::delete_root_subtree() noexcept {
   if (root != nullptr) art_policy::delete_subtree(root, *this);
 
@@ -434,6 +441,7 @@ void db::delete_root_subtree() noexcept {
   UNODB_DETAIL_ASSERT(node_counts[as_i<node_type::LEAF>] == 0);
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void db::clear() noexcept {
   delete_root_subtree();
 

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -30,6 +30,7 @@ struct [[nodiscard]] olc_node_header {
   }
 
 #ifndef NDEBUG
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   static void check_on_dealloc(const void *ptr) noexcept {
     static_cast<const olc_node_header *>(ptr)->m_lock.check_on_dealloc();
   }
@@ -64,7 +65,16 @@ class db_leaf_qsbr_deleter {
     db_instance.decrement_leaf_count(leaf_size);
   }
 
+  ~db_leaf_qsbr_deleter() = default;
+  db_leaf_qsbr_deleter(const db_leaf_qsbr_deleter<Header, Db> &) = default;
+  db_leaf_qsbr_deleter<Header, Db> &operator=(
+      const db_leaf_qsbr_deleter<Header, Db> &) = delete;
+  db_leaf_qsbr_deleter(db_leaf_qsbr_deleter<Header, Db> &&) = delete;
+  db_leaf_qsbr_deleter<Header, Db> &operator=(
+      db_leaf_qsbr_deleter<Header, Db> &&) = delete;
+
  private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   Db &db_instance;
 };
 
@@ -151,6 +161,7 @@ template <class INode>
 }
 
 template <class T>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] T &obsolete(T &t UNODB_DETAIL_LIFETIMEBOUND,
                           unodb::optimistic_lock::write_guard &guard) noexcept {
   UNODB_DETAIL_ASSERT(guard.guards(lock(t)));
@@ -163,6 +174,7 @@ template <class T>
   return t;
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] inline auto obsolete_child_by_index(
     std::uint8_t child UNODB_DETAIL_LIFETIMEBOUND,
     unodb::optimistic_lock::write_guard &guard) noexcept {
@@ -176,6 +188,7 @@ template <class T>
 namespace unodb {
 
 template <class INode>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void olc_db::increment_inode_count() noexcept {
   static_assert(olc_inode_defs::is_inode<INode>());
 
@@ -238,6 +251,7 @@ class [[nodiscard]] olc_inode_4 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(unodb::detail::art_key k1, unodb::detail::art_key shifted_k2,
             unodb::detail::tree_depth depth, leaf *child1,
             olc_db_leaf_unique_ptr &&child2) noexcept {
@@ -269,12 +283,14 @@ class [[nodiscard]] olc_inode_4 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
     basic_inode_4::remove(child_index, db_instance);
   }
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] auto leave_last_child(std::uint8_t child_to_delete,
                                       unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_obsoleted_by_this_thread());
@@ -317,6 +333,7 @@ class [[nodiscard]] olc_inode_16 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_4 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             olc_db_leaf_unique_ptr &&child,
@@ -327,6 +344,7 @@ class [[nodiscard]] olc_inode_16 final
     UNODB_DETAIL_ASSERT_INACTIVE(source_node_guard);
   }
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_48 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             std::uint8_t child_to_delete,
@@ -348,6 +366,7 @@ class [[nodiscard]] olc_inode_16 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
@@ -409,6 +428,7 @@ class [[nodiscard]] olc_inode_48 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_16 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             olc_db_leaf_unique_ptr &&child,
@@ -419,6 +439,7 @@ class [[nodiscard]] olc_inode_48 final
     UNODB_DETAIL_ASSERT_INACTIVE(source_node_guard);
   }
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_256 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             std::uint8_t child_to_delete,
@@ -440,6 +461,7 @@ class [[nodiscard]] olc_inode_48 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
@@ -469,6 +491,7 @@ static_assert(sizeof(olc_inode_48) == 656 + 32);
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_inode_16::init(
     db &db_instance, olc_inode_48 &source_node,
     unodb::optimistic_lock::write_guard &source_node_guard,
@@ -495,6 +518,7 @@ class [[nodiscard]] olc_inode_256 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_48 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             olc_db_leaf_unique_ptr &&child,
@@ -521,6 +545,7 @@ class [[nodiscard]] olc_inode_256 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
@@ -545,6 +570,7 @@ static_assert(sizeof(olc_inode_256) == 2064 + 24);
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_inode_48::init(
     db &db_instance, olc_inode_256 &source_node,
     unodb::optimistic_lock::write_guard &source_node_guard,
@@ -767,6 +793,7 @@ namespace unodb {
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(4189)
 template <class INode>
+// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void olc_db::decrement_inode_count() noexcept {
   static_assert(olc_inode_defs::is_inode<INode>());
 
@@ -794,6 +821,7 @@ constexpr void olc_db::account_shrinking_inode() noexcept {
       1, std::memory_order_relaxed);
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 olc_db::~olc_db() noexcept {
   UNODB_DETAIL_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
@@ -804,15 +832,18 @@ olc_db::~olc_db() noexcept {
 olc_db::get_result olc_db::get(key search_key) const noexcept {
   try_get_result_type result;
   const detail::art_key bin_comparable_key{search_key};
-  do {
+
+  while (true) {
     result = try_get(bin_comparable_key);
+    if (result) break;
     // TODO(laurynas): upgrade to write locks to prevent starving after a
     // certain number of failures?
-  } while (!result);
+  }
 
   return *result;
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
   auto parent_critical_section = root_pointer_lock.try_read_lock();
   if (UNODB_DETAIL_UNLIKELY(parent_critical_section.must_restart())) {
@@ -907,9 +938,11 @@ bool olc_db::insert(key insert_key, value_view v) {
   olc_db_leaf_unique_ptr cached_leaf{
       nullptr,
       detail::basic_db_leaf_deleter<detail::olc_node_header, olc_db>{*this}};
-  do {
+
+  while (true) {
     result = try_insert(bin_comparable_key, v, cached_leaf);
-  } while (!result);
+    if (result) break;
+  }
 
   return *result;
 }
@@ -1062,9 +1095,10 @@ bool olc_db::remove(key remove_key) {
   const auto bin_comparable_key = detail::art_key{remove_key};
 
   try_update_result_type result;
-  do {
+  while (true) {
     result = try_remove(bin_comparable_key);
-  } while (!result);
+    if (result) break;
+  }
 
   return *result;
 }
@@ -1180,6 +1214,7 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
   }
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::delete_root_subtree() noexcept {
   UNODB_DETAIL_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
@@ -1191,6 +1226,7 @@ void olc_db::delete_root_subtree() noexcept {
       node_counts[as_i<node_type::LEAF>].load(std::memory_order_relaxed) == 0);
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::clear() noexcept {
   UNODB_DETAIL_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
@@ -1208,6 +1244,7 @@ void olc_db::clear() noexcept {
 
 UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=cold")
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::increase_memory_use(std::size_t delta) noexcept {
   UNODB_DETAIL_ASSERT(delta > 0);
 
@@ -1216,6 +1253,7 @@ void olc_db::increase_memory_use(std::size_t delta) noexcept {
 
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::decrease_memory_use(std::size_t delta) noexcept {
   UNODB_DETAIL_ASSERT(delta > 0);
   UNODB_DETAIL_ASSERT(delta <=

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -20,6 +20,7 @@ namespace unodb::detail {
 
 struct set_qsbr_per_thread_in_main_thread {
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   set_qsbr_per_thread_in_main_thread() noexcept {
     try {
       auto main_thread_qsbr_reclamator_instance =
@@ -68,6 +69,7 @@ thread_local std::unique_ptr<qsbr_per_thread>
 }
 // LCOV_EXCL_STOP
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] auto qsbr_state::atomic_fetch_dec_threads_in_previous_epoch(
     std::atomic<qsbr_state::type> &word) noexcept {
   const auto old_word = word.fetch_sub(1, std::memory_order_acq_rel);
@@ -167,6 +169,7 @@ void free_orphan_list(detail::dealloc_vector_list_node *list) noexcept {
 
 }  // namespace
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void qsbr_per_thread::orphan_deferred_requests() noexcept {
   add_to_orphan_list(
       qsbr::instance().orphaned_previous_interval_dealloc_requests,
@@ -186,6 +189,7 @@ void qsbr_per_thread::orphan_deferred_requests() noexcept {
   UNODB_DETAIL_ASSERT(current_interval_orphan_list_node == nullptr);
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 qsbr_epoch qsbr::register_thread() noexcept {
   auto old_state = get_state();
 
@@ -359,6 +363,7 @@ void qsbr::thread_epoch_change_barrier() noexcept {
 #endif
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 qsbr_epoch qsbr::remove_thread_from_previous_epoch(
     qsbr_epoch current_global_epoch
 #ifndef NDEBUG
@@ -435,6 +440,7 @@ void qsbr::epoch_change_barrier_and_handle_orphans(
   }
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape)
 qsbr_epoch qsbr::change_epoch(qsbr_epoch current_global_epoch,
                               bool single_thread_mode) noexcept {
   epoch_change_barrier_and_handle_orphans(single_thread_mode);

--- a/test/qsbr_gtest_utils.cpp
+++ b/test/qsbr_gtest_utils.cpp
@@ -16,6 +16,7 @@ QSBRTestBase::QSBRTestBase() {
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
+// NOLINTNEXTLINE(bugprone-exception-escape)
 QSBRTestBase::~QSBRTestBase() noexcept {
   if (is_qsbr_paused()) unodb::this_thread().qsbr_resume();
   unodb::this_thread().quiescent();

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -12,6 +12,7 @@
 namespace unodb::test {
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
+// NOLINTNEXTLINE(bugprone-exception-escape)
 void expect_idle_qsbr() noexcept {
   const auto state = unodb::qsbr::instance().get_state();
   UNODB_EXPECT_EQ(

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -28,6 +28,7 @@ template <class Db>
 class ARTConcurrencyTest : public ::testing::Test {
  public:
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
+  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~ARTConcurrencyTest() noexcept override {
     if constexpr (std::is_same_v<Db, unodb::olc_db>) {
       unodb::this_thread().quiescent();


### PR DESCRIPTION
- Rewrite several do ... while loops to while (true) loops with break inside
- Add special members for db_leaf_qsbr_deleter to show that it is copy-constructable (and disable moving it) to support std::unique_ptr deleter requirements.
- Suppress cppcoreguidelines-avoid-const-or-ref-data-members for the same class because it has a reference data member. I don't want to make it a pointer because it cannot be nullptr.
- Suppress many spurious "bugprone-exception-escape" clang-tidy diagnostics
- For cppcheck, disable internalAstError check, as it catches the same error class as compilers and has false positives.
- Suppress inline cppcheck noExplicitConstructor where corresponding diagnostics have been already suppressed for clang-tidy.
- Tune clang-tidy cppcoreguidelines-avoid-do-while check to ignore macros