### PR TITLE
MSVC: disable C5264 "'const' variable is not used" warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,11 @@ endif()
 # - "C5246: '...': the initialization of a subobject should be wrapped in
 #   braces": billions of std::array false positives with 17.2.2.
 # - The other disabled warnings only activate on /Wall
-set(MSVC_CXX_WARNING_FLAGS "/Wall" "/wd4324" "/wd5030" "/wd5072" 
+# - "C5264": "'const' variable is not used": billions of false positives with
+#   17.5.
+set(MSVC_CXX_WARNING_FLAGS "/Wall" "/wd4324" "/wd5030" "/wd5072"
   "/wd4623" "/wd4625" "/wd4626" "/wd4582" "/wd4820" "/wd4710" "/wd4711"
-  "/wd4868" "/wd5026" "/wd5027" "/wd5045" "/wd5246")
+  "/wd4868" "/wd5026" "/wd5027" "/wd5045" "/wd5246" "/wd5264")
 
 # Flags for both MSVC cl and clang-cl compilers
 set(ANY_MSVC_CXX_FLAGS "/arch:AVX" "/permissive-")


### PR DESCRIPTION
Too many false positives with 15.5.