### PR TITLE
Clean up cppcheck 2.10 diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -452,6 +452,8 @@ set(CPPCHECK_ARGS
   # False positive on Google Test TEST macro and compilers are much better
   # for syntax checking anyway
   "--suppress=syntaxError"
+  # Likewise
+  "--suppress=internalAstError"
   # False positives on structured bindings with 2.5
   "--suppress=unassignedVariable"
   "--suppress=unusedVariable")

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -16,6 +16,7 @@ template <typename T>
 class [[nodiscard]] in_fake_critical_section final {
  public:
   constexpr in_fake_critical_section() noexcept = default;
+  // cppcheck-suppress noExplicitConstructor
   // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
   constexpr in_fake_critical_section(T value_) noexcept : value{value_} {}
   constexpr in_fake_critical_section(const in_fake_critical_section<T> &) =

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -349,6 +349,7 @@ class [[nodiscard]] in_critical_section final {
  public:
   constexpr in_critical_section() noexcept = default;
 
+  // cppcheck-suppress noExplicitConstructor
   // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
   constexpr in_critical_section(T value_) noexcept : value{value_} {}
 

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -26,6 +26,12 @@ namespace unodb::detail {
 template <typename T>
 [[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC std::uint8_t ctz(
     T x) noexcept {
+  static_assert(std::is_same_v<unsigned, T> ||
+                // NOLINTNEXTLINE(google-runtime-int)
+                std::is_same_v<unsigned long, T> ||  // NOLINT(runtime/int)
+                // NOLINTNEXTLINE(google-runtime-int)
+                std::is_same_v<unsigned long long, T>);  // NOLINT(runtime/int)
+
   if constexpr (std::is_same_v<unsigned, T>) {
 #ifndef UNODB_DETAIL_MSVC
     return gsl::narrow_cast<std::uint8_t>(__builtin_ctz(x));
@@ -54,7 +60,7 @@ template <typename T>
     _BitScanForward64(&result, x);
     return gsl::narrow_cast<std::uint8_t>(result);
 #endif
-  }
+  }  // cppcheck-suppress missingReturn
 }
 
 [[nodiscard, gnu::pure]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned popcount(

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -177,7 +177,9 @@ void qsbr_per_thread::orphan_deferred_requests() noexcept {
   previous_interval_dealloc_requests.clear();
   current_interval_dealloc_requests.clear();
 
+  // cppcheck-suppress accessMoved
   UNODB_DETAIL_ASSERT(previous_interval_orphan_list_node == nullptr);
+  // cppcheck-suppress accessMoved
   UNODB_DETAIL_ASSERT(current_interval_orphan_list_node == nullptr);
 }
 


### PR DESCRIPTION
- Disable internalAstError check, as it catches the same error class as
- compilers and has false positives.
- Suppress noExplicitConstructor where corresponding diagnostics have been
- already suppressed for clang-tidy.
- Suppress accessMoved where the used after moved object is std::unique_ptr, guarenteed to be nullptr.
- For unodb::detail::ctz, suppress the missing return diagnostics, but at the same time add a static_assert that all the cases are being handled.