### PR TITLE
Introduce maintainer mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
                     | sudo tee -a /etc/apt/sources.list
                   sudo apt-get update
                   sudo NEEDRESTART_MODE=a apt-get install -y clang-15 \
-                    clang-tidy-15
+                    clang-tidy-15 iwyu
       - when:
           condition:
             and:
@@ -95,7 +95,7 @@ jobs:
                   "-DCLANG_TIDY_EXE=/usr/bin/clang-tidy-15")
             fi
             cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSTANDALONE=ON \
-              -DFATAL_WARNINGS=ON -DSANITIZE_ADDRESS=$ASAN \
+              -DMAINTAINER_MODE=ON -DSANITIZE_ADDRESS=$ASAN \
               -DSANITIZE_THREAD=$TSAN -DSANITIZE_UB=$UBSAN \
               "${EXTRA_CMAKE_ARGS[@]}"
       - run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,7 +249,7 @@ jobs:
           echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main' \
             | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          sudo apt-get install -y clang-15
+          sudo apt-get install -y clang-15 iwyu
         if: runner.os == 'Linux' && env.COMPILER == 'clang'
 
       - name: Setup dependencies for Linux LLVM (Release)
@@ -272,7 +272,7 @@ jobs:
 
       - name: Set up dependencies for macOS (common)
         run: |
-          brew install boost
+          brew install boost include-what-you-use
         if: runner.os == 'macOS'
 
       - name: Set up dependencies for macOS (coverage)
@@ -343,7 +343,7 @@ jobs:
             export CC=clang
             export CXX=clang++
           fi
-          cmake "$GITHUB_WORKSPACE" "$CBT" -DSTANDALONE=ON -DFATAL_WARNINGS=ON \
+          cmake "$GITHUB_WORKSPACE" "$CBT" -DSTANDALONE=ON -DMAINTAINER_MODE=ON \
               "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
               "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \
               "-DSANITIZE_UB=${SANITIZE_UB}" \

--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: XCode Release iwyu, aggressive cppcheck, not standalone
+          - name: XCode Release aggressive cppcheck, not standalone
             BUILD_TYPE: Release
 
-          - name: XCode Debug iwyu, aggressive cppcheck, not standalone
+          - name: XCode Debug aggressive cppcheck, not standalone
             BUILD_TYPE: Debug
 
     steps:
@@ -33,7 +33,7 @@ jobs:
           rm '/usr/local/bin/python3.11'
           rm '/usr/local/bin/python3.11-config'
           brew update
-          brew install boost cppcheck iwyu
+          brew install boost cppcheck
 
       - name: Create build environment
         run: mkdir ${{github.workspace}}/build
@@ -44,7 +44,7 @@ jobs:
         run: |
           export CC=clang
           export CXX=clang++
-          cmake "$GITHUB_WORKSPACE" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" -DIWYU=ON \
+          cmake "$GITHUB_WORKSPACE" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
             -DCPPCHECK_AGGRESSIVE=ON -Wdev --warn-uninitialized
 
       - name: Build

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -382,6 +382,10 @@ jobs:
                 "clang-${VERSION}" "clang-tidy-${VERSION}"
         if: runner.os == 'Linux' && env.COMPILER == 'clang' && env.VERSION == 13
 
+      - name: Setup dependencies for Linux LLVM 13+
+        run: sudo apt-get install -y iwyu
+        if: runner.os == 'Linux' && env.COMPILER == 'clang' && env.VERSION >= 13
+
       - name: Setup dependencies for Linux GCC (versioned package)
         run: |
           sudo apt-get install -y "gcc-${VERSION}"
@@ -412,7 +416,7 @@ jobs:
           if [[ $COMPILER == "gcc" ]]; then
             export CC="gcc-${VERSION}"
             export CXX="g++-${VERSION}"
-            EXTRA_CMAKE_ARGS=()
+            EXTRA_CMAKE_ARGS=("-DMAINTAINER_MODE=ON")
           else
             export CC="clang-${VERSION}"
             export CXX="clang++-${VERSION}"
@@ -423,8 +427,11 @@ jobs:
                   "-DLLVMNM_EXECUTABLE=/usr/bin/llvm-nm-${VERSION}" \
                   "-DLLVMRANLIB_EXECUTABLE=/usr/bin/llvm-ranlib-${VERSION}")
             fi
+            if [[ $VERSION -ge 13 ]]; then
+              EXTRA_CMAKE_ARGS=("${EXTRA_CMAKE_ARGS[@]}" "-DMAINTAINER_MODE=ON")
+            fi
           fi
-          cmake "$GITHUB_WORKSPACE" -DSTANDALONE=ON -DFATAL_WARNINGS=ON \
+          cmake "$GITHUB_WORKSPACE" -DSTANDALONE=ON \
               "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
               "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
               "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 Laurynas Biveinis
+# Copyright 2019-2023 Laurynas Biveinis
 cmake_minimum_required(VERSION 3.12)
 
 project(unodb VERSION 0.1
@@ -29,8 +29,9 @@ set_bool(is_any_clang ${is_apple_clang} OR ${is_clang})
 option(STANDALONE
   "Build UnoDB not for linking with outside code. Enables extra global checks")
 
-option(FATAL_WARNINGS "Make warning diagnostics fatal")
-if(FATAL_WARNINGS)
+option(MAINTAINER_MODE
+  "Maintainer mode: compiler warnings are fatal, IWYU required")
+if(MAINTAINER_MODE)
   message(STATUS "Warning diagnostics are fatal")
 else()
   message(STATUS "Warning diagnostics are not fatal")
@@ -416,7 +417,7 @@ set(is_clang_ge_14_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_14}>")
 set(is_gxx_ge_11 "$<AND:${is_gxx_genex},${cxx_ge_11}>")
 set(is_gxx_ge_12 "$<AND:${is_gxx_genex},${cxx_ge_12}>")
 set(has_avx2 "$<BOOL:${AVX2}>")
-set(fatal_warnings_on "$<BOOL:${FATAL_WARNINGS}>")
+set(fatal_warnings_on "$<BOOL:${MAINTAINER_MODE}>")
 set(coverage_on "$<BOOL:${COVERAGE}>")
 set(is_standalone "$<BOOL:${STANDALONE}>")
 set(is_gxx_not_release_standalone
@@ -462,7 +463,7 @@ option(CPPCHECK_AGGRESSIVE "Enable inconclusive cppcheck checks")
 if(CPPCHECK_AGGRESSIVE)
   list(APPEND CPPCHECK_ARGS "--inconclusive")
 endif()
-if(FATAL_WARNINGS)
+if(MAINTAINER_MODE)
   list(APPEND CPPCHECK_ARGS "--error-exitcode=2")
 else()
   list(APPEND CPPCHECK_ARGS "--error-exitcode=0")
@@ -490,14 +491,23 @@ else()
 endif()
 
 option(IWYU "Enable include-what-you-use checking")
-if(IWYU)
-  if(NOT is_any_clang)
-    message(STATUS "Not using include-what-you-use due to non-clang compiler being used")
+if(IWYU OR MAINTAINER_MODE)
+  if(NOT is_any_clang OR is_windows)
+    message(STATUS
+      "Not using include-what-you-use due to non-clang compiler or Windows being used")
   else()
+    if(MAINTAINER_MODE AND NOT IWYU)
+      message(STATUS
+        "Forcing include-what-you-use because maintainer mode is on")
+    endif()
     find_program(IWYU_EXE NAMES "include-what-you-use"
       DOC "Path to include-what-you-use executable")
     if(NOT IWYU_EXE)
-      message(STATUS "include-what-you-use not found")
+      if(MAINTAINER_MODE)
+        message(FATAL_ERROR "include-what-you-use not found")
+      else()
+        message(STATUS "include-what-you-use not found")
+      endif()
     else()
       execute_process(COMMAND "${IWYU_EXE}" "--version" OUTPUT_VARIABLE
         IWYU_VERSION_OUTPUT)
@@ -659,7 +669,7 @@ endif()
 
 message(STATUS "User-set CMake options:")
 message(STATUS "STANDALONE: ${STANDALONE}")
-message(STATUS "FATAL_WARNINGS: ${FATAL_WARNINGS}")
+message(STATUS "MAINTAINER_MODE: ${MAINTAINER_MODE}")
 message(STATUS "AVX2: ${AVX2}")
 message(STATUS "COVERAGE: ${COVERAGE}")
 message(STATUS "GCOV_PATH: ${GCOV_PATH}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,7 @@
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "STANDALONE": "ON",
-                "FATAL_WARNINGS": "ON"
+                "MAINTAINER_MODE": "ON"
             }
         },
         {
@@ -70,13 +70,6 @@
             }
         },
         {
-            "name": "iwyu",
-            "hidden": true,
-            "cacheVariables": {
-                "IWYU": "ON"
-            }
-        },
-        {
             "name": "gcc",
             "hidden": true,
             "cacheVariables": {
@@ -124,13 +117,6 @@
             ]
         },
         {
-            "name": "release-iwyu",
-            "inherits": [
-                "release",
-                "iwyu"
-            ]
-        },
-        {
             "name": "debug",
             "inherits": "base-unix",
             "cacheVariables": {
@@ -156,13 +142,6 @@
             "inherits": [
                 "debug",
                 "ubsan"
-            ]
-        },
-        {
-            "name": "debug-iwyu",
-            "inherits": [
-                "debug",
-                "iwyu"
             ]
         },
         {
@@ -401,11 +380,6 @@
             "inherits": "base"
         },
         {
-            "name": "release-iwyu",
-            "configurePreset": "release-iwyu",
-            "inherits": "base"
-        },
-        {
             "name": "debug",
             "configurePreset": "debug",
             "inherits": "base"
@@ -423,11 +397,6 @@
         {
             "name": "debug-ubsan",
             "configurePreset": "debug-ubsan",
-            "inherits": "base"
-        },
-        {
-            "name": "debug-iwyu",
-            "configurePreset": "debug-iwyu",
             "inherits": "base"
         },
         {

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ When building this project alone and not as a part of another project, add
 require whole programs to be compiled with them. Currently this consists of
 libstdc+++ debug mode.
 
-To make compiler warnings fatal, add `-DFATAL_WARNINGS=ON` CMake option.
+To enable maintainer diagnostics, add `-DMAINTAINER_MODE=ON` CMake option.
+Currently it makes compilation and `include-what-you-use` warnings fatal.
 
 clang-tidy, cppcheck, and cpplint will be invoked automatically during build if
 found. Currently the diagnostic level for them as well as for compiler warnings


### PR DESCRIPTION
- Convert CMake option FATAL_WARNINGS to MAINTAINER_MODE
- Require include-what-you-use if maintainer mode is enabled
- Install iwyu on all regular CI runners, remove it from the experimental build one.
- Remove iwyu-specific CMake presets.