### PR TITLE
Do not inject OOMs in debug diagnostic code paths

### DIFF
--- a/assert.hpp
+++ b/assert.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Laurynas Biveinis
+// Copyright 2022-2023 Laurynas Biveinis
 #ifndef UNODB_DETAIL_ASSERT_HPP
 #define UNODB_DETAIL_ASSERT_HPP
 
@@ -16,6 +16,8 @@
 #endif
 #include <boost/stacktrace.hpp>
 
+#include "test_heap.hpp"
+
 namespace unodb::detail {
 
 // LCOV_EXCL_START
@@ -24,6 +26,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 [[noreturn, gnu::cold]] UNODB_DETAIL_NOINLINE inline void msg_stacktrace_abort(
     const std::string &msg) noexcept {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
   buf << msg << boost::stacktrace::stacktrace();
   std::cerr << buf.str();
@@ -32,6 +35,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 [[noreturn, gnu::cold]] UNODB_DETAIL_NOINLINE inline void crash(
     const char *file, int line, const char *func) noexcept {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
   buf << "Crash requested at " << file << ':' << line << ", function \"" << func
       << "\", thread " << std::this_thread::get_id() << '\n';
@@ -47,6 +51,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 [[noreturn, gnu::cold]] UNODB_DETAIL_NOINLINE inline void assert_failure(
     const char *file, int line, const char *func,
     const char *condition) noexcept {
+  unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
   std::ostringstream buf;
   buf << "Assertion \"" << condition << "\" failed at " << file << ':' << line
       << ", function \"" << func << "\", thread " << std::this_thread::get_id()
@@ -56,6 +61,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 [[noreturn]] inline void cannot_happen(const char *file, int line,
                                        const char *func) noexcept {
+  unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
   std::ostringstream buf;
   buf << "Execution reached an unreachable point at " << file << ':' << line
       << ": function \"" << func << "\", thread " << std::this_thread::get_id()

--- a/heap.hpp
+++ b/heap.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 Laurynas Biveinis
+// Copyright 2020-2023 Laurynas Biveinis
 #ifndef UNODB_DETAIL_HEAP_HPP
 #define UNODB_DETAIL_HEAP_HPP
 
@@ -6,10 +6,8 @@
 
 #include <algorithm>
 #ifndef NDEBUG
-#include <atomic>
 #include <cerrno>
 #endif
-#include <cstdint>
 #include <cstdlib>
 #include <new>
 
@@ -18,51 +16,7 @@
 #endif
 
 #include "assert.hpp"
-
-namespace unodb::test {
-
-class allocation_failure_injector final {
- public:
-  static void reset() noexcept {
-#ifndef NDEBUG
-    fail_on_nth_allocation_.store(0, std::memory_order_relaxed);
-    allocation_counter.store(0, std::memory_order_release);
-#endif
-  }
-
-  static void fail_on_nth_allocation(
-      std::uint64_t n UNODB_DETAIL_USED_IN_DEBUG) noexcept {
-#ifndef NDEBUG
-    fail_on_nth_allocation_.store(n, std::memory_order_release);
-#endif
-  }
-
-#ifndef NDEBUG
-
-  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wanalyzer-malloc-leak")
-
-  static void maybe_fail() {
-    const auto fail_counter =
-        fail_on_nth_allocation_.load(std::memory_order_acquire);
-    if (UNODB_DETAIL_UNLIKELY(fail_counter != 0) &&
-        (allocation_counter.fetch_add(1, std::memory_order_relaxed) >=
-         fail_counter - 1)) {
-      throw std::bad_alloc{};
-    }
-  }
-
-  UNODB_DETAIL_RESTORE_GCC_WARNINGS()
-
- private:
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-  inline static std::atomic<std::uint64_t> allocation_counter{0};
-  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-  inline static std::atomic<std::uint64_t> fail_on_nth_allocation_{0};
-
-#endif  // #ifndef NDEBUG
-};
-
-}  // namespace unodb::test
+#include "test_heap.hpp"
 
 namespace unodb::detail {
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -30,11 +30,13 @@
 #include "art.hpp"
 #include "art_common.hpp"
 #include "assert.hpp"
-#include "heap.hpp"
 #include "mutex_art.hpp"
 #include "node_type.hpp"
 #include "olc_art.hpp"
 #include "qsbr.hpp"
+#ifndef NDEBUG
+#include "test_heap.hpp"
+#endif
 
 namespace unodb::test {
 
@@ -246,7 +248,9 @@ class [[nodiscard]] tree_verifier final {
                       node_counts_before[as_i<unodb::node_type::LEAF>] + 1);
 
     if (!bypass_verifier) {
+#ifndef NDEBUG
       allocation_failure_injector::reset();
+#endif
       const auto [pos, insert_succeeded] = values.try_emplace(k, v);
       (void)pos;
       UNODB_ASSERT_TRUE(insert_succeeded);
@@ -374,7 +378,9 @@ class [[nodiscard]] tree_verifier final {
 
   void clear() {
     test_db.clear();
+#ifndef NDEBUG
     allocation_failure_injector::reset();
+#endif
     assert_empty();
 
     values.clear();

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -18,9 +18,9 @@
 #include "art.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
-#include "heap.hpp"
 #include "mutex_art.hpp"
 #include "olc_art.hpp"
+#include "test_heap.hpp"
 
 namespace {
 

--- a/test/test_qsbr_oom.cpp
+++ b/test/test_qsbr_oom.cpp
@@ -12,9 +12,9 @@
 #include <gtest/gtest.h>
 
 #include "gtest_utils.hpp"
-#include "heap.hpp"
 #include "qsbr.hpp"
 #include "qsbr_gtest_utils.hpp"
+#include "test_heap.hpp"
 #include "thread_sync.hpp"
 
 namespace {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -1,10 +1,10 @@
-// Copyright 2022 Laurynas Biveinis
+// Copyright 2022-2023 Laurynas Biveinis
 #ifndef UNODB_DETAIL_TEST_UTILS_HPP
 #define UNODB_DETAIL_TEST_UTILS_HPP
 
 #include "global.hpp"
 
-#include "heap.hpp"
+#include "test_heap.hpp"
 
 namespace unodb::test {
 
@@ -15,14 +15,14 @@ template <typename TestAction>
 std::invoke_result_t<TestAction> must_not_allocate(
     TestAction test_action) noexcept(noexcept(test_action())) {
   if constexpr (!std::is_void_v<std::invoke_result_t<TestAction>>) {
-    unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
+    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(1);
     auto result = test_action();
-    unodb::test::allocation_failure_injector::reset();
+    UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR();
     return result;
   } else {
-    unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
+    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(1);
     test_action();
-    unodb::test::allocation_failure_injector::reset();
+    UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR();
   }
 }
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()

--- a/test_heap.cpp
+++ b/test_heap.cpp
@@ -1,6 +1,8 @@
-// Copyright 2022 Laurynas Biveinis
+// Copyright 2022-2023 Laurynas Biveinis
 
 #include "global.hpp"  // IWYU pragma: keep
+
+#include "test_heap.hpp"
 
 // - ASan/TSan do not work with replaced global new/delete:
 //   https://github.com/llvm/llvm-project/issues/20034
@@ -13,8 +15,6 @@
 #include <cstddef>
 #include <cstdlib>
 #include <new>
-
-#include "heap.hpp"
 
 void* operator new(std::size_t count) {
   unodb::test::allocation_failure_injector::maybe_fail();

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -1,0 +1,65 @@
+// Copyright 2023 Laurynas Biveinis
+#ifndef UNODB_DETAIL_TEST_HEAP_HPP
+#define UNODB_DETAIL_TEST_HEAP_HPP
+
+#include "global.hpp"  // IWYU pragma: keep
+
+#ifndef NDEBUG
+
+#include <atomic>
+#include <cstdint>
+#include <new>
+
+namespace unodb::test {
+
+class allocation_failure_injector final {
+ public:
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(4514)
+
+  static void reset() noexcept {
+    fail_on_nth_allocation_.store(0, std::memory_order_relaxed);
+    allocation_counter.store(0, std::memory_order_release);
+  }
+
+  static void fail_on_nth_allocation(
+      std::uint64_t n UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+    fail_on_nth_allocation_.store(n, std::memory_order_release);
+  }
+
+  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wanalyzer-malloc-leak")
+
+  static void maybe_fail() {
+    const auto fail_counter =
+        fail_on_nth_allocation_.load(std::memory_order_acquire);
+    if (UNODB_DETAIL_UNLIKELY(fail_counter != 0) &&
+        (allocation_counter.fetch_add(1, std::memory_order_relaxed) >=
+         fail_counter - 1)) {
+      throw std::bad_alloc{};
+    }
+  }
+
+  UNODB_DETAIL_RESTORE_GCC_WARNINGS()
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+ private:
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  inline static std::atomic<std::uint64_t> allocation_counter{0};
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  inline static std::atomic<std::uint64_t> fail_on_nth_allocation_{0};
+};
+
+}  // namespace unodb::test
+
+#define UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR() \
+  unodb::test::allocation_failure_injector::reset()
+#define UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(n) \
+  unodb::test::allocation_failure_injector::fail_on_nth_allocation(n)
+
+#else  // !NDEBUG
+
+#define UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR()
+#define UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(n)
+
+#endif  // !NDEBUG
+
+#endif  // UNODB_DETAIL_TEST_HEAP_HPP


### PR DESCRIPTION
If assert and co are about to collect the stacktrace and print diagnostics, allow them to use the C++ heap even if the test asked for std::bad_alloc being thrown on the next allocation, because the debug diagnostics are more important. Implement this by splitting test_heap.hpp out of heap.hpp, including it in assert.hpp, & disabling OOM injections in all the relevant functions.