### PR TITLE
Disable bugprone-exception-escape clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,22 +1,39 @@
 # The following are disabled because:
-# -clang-analyzer-core.CallAndMessage, clang-analyzer-core.NonNullParamChecker,
+# - clang-analyzer-core.CallAndMessage, clang-analyzer-core.NonNullParamChecker,
 # clang-analyzer-unix.Malloc:
 #   clang static analysis is run separately from clang-tidy, and this one gives
 #   false positives under clang-tidy.
-# -bugprone-easily-swappable-parameters: too many suppressions for otherwise
+# - bugprone-easily-swappable-parameters: too many suppressions for otherwise
 #   unfixable signatures
-# -cppcoreguidelines-avoid-c-arrays: duplicated by modernize-avoid-c-arrays
-# -cppcoreguidelines-macro-usage: does not respect __LINE__ in macro definition
-# -cppcoreguidelines-pro-bounds-pointer-arithmetic: because leaf nodes are
+# - bugprone-exception-escape: buggy, revisit after the following are fixed:
+#   - https://github.com/llvm/llvm-project/issues/55143 (clang-tidy:
+#     bugprone-exception-escape: explicitly defined move constructor may not
+#     thhrow)
+#   - https://github.com/llvm/llvm-project/issues/54956
+#     ([clang-tidy][ExceptionAnalyzer] Does not model noexcept bounds)
+#   - https://github.com/llvm/llvm-project/issues/54668 ([clang-tidy]
+#     bugprone-exception-escape reported for structs with std::string)
+#   - https://github.com/llvm/llvm-project/issues/51596
+#     (bugprone-exception-escape in std::variant::operator=())
+#   - https://github.com/llvm/llvm-project/issues/49151
+#     (bugprone-exception-escape reported for boost::beast::http::response)
+#   - https://github.com/llvm/llvm-project/issues/43667
+#     (bugprone-exception-escape false positive with is_nothrow_invokable)
+#   - https://github.com/llvm/llvm-project/issues/40583
+#     (bugprone-exception-escape generated for destructor marked with
+#     noexcept(false))
+# - cppcoreguidelines-avoid-c-arrays: duplicated by modernize-avoid-c-arrays
+# - cppcoreguidelines-macro-usage: does not respect __LINE__ in macro definition
+# - cppcoreguidelines-pro-bounds-pointer-arithmetic: because leaf nodes are
 #   std::byte arrays
-# -cppcoreguidelines-pro-type-const-cast: because VALGRIND_MALLOCLIKE_BLOCK
+# - cppcoreguidelines-pro-type-const-cast: because VALGRIND_MALLOCLIKE_BLOCK
 #   expands a to C-style cast, and we have -Wold-style-cast anyway
-# -hicpp-avoid-c-arrays: duplicated by modernize-avoid-c-arrays
-# -hicpp-explicit-conversions: duplicated by google-explicit-constructor
-# -hicpp-no-assembler: Valgrind client requests
-# -modernize-use-equals-default: until foo() noexcept = default is accepted by
+# - hicpp-avoid-c-arrays: duplicated by modernize-avoid-c-arrays
+# - hicpp-explicit-conversions: duplicated by google-explicit-constructor
+# - hicpp-no-assembler: Valgrind client requests
+# - modernize-use-equals-default: until foo() noexcept = default is accepted by
 #   clang
-Checks: '*,-altera-id-dependent-backward-branch,-altera-struct-pack-align,-altera-unroll-loops,-bugprone-easily-swappable-parameters,-bugprone-use-after-move,-clang-diagnostic-error,-clang-analyzer-core.CallAndMessage,-clang-analyzer-core.NonNullParamChecker,-clang-analyzer-cplusplus.Move,-clang-analyzer-unix.Malloc,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-cppcoreguidelines-macro-usage,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-union-access,-fuchsia-default-arguments-calls,-fuchsia-default-arguments-declarations,-fuchsia-overloaded-operator,-google-readability-braces-around-statements,-google-runtime-references,-hicpp-avoid-c-arrays,-hicpp-braces-around-statements,-hicpp-explicit-conversions,-hicpp-invalid-access-moved,-hicpp-member-init,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-no-assembler,-hicpp-use-equals-default,-llvm-include-order,-llvmlibc*,-misc-no-recursion,-misc-non-private-member-variables-in-classes,-modernize-use-equals-default,-modernize-use-trailing-return-type,-portability-simd-intrinsics,-readability-braces-around-statements,-readability-function-cognitive-complexity,-readability-identifier-length,-readability-named-parameter,-readability-magic-numbers'
+Checks: '*,-altera-id-dependent-backward-branch,-altera-struct-pack-align,-altera-unroll-loops,-bugprone-easily-swappable-parameters,-bugprone-exception-escape,-bugprone-use-after-move,-clang-diagnostic-error,-clang-analyzer-core.CallAndMessage,-clang-analyzer-core.NonNullParamChecker,-clang-analyzer-cplusplus.Move,-clang-analyzer-unix.Malloc,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-init-variables,-cppcoreguidelines-macro-usage,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-const-cast,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-union-access,-fuchsia-default-arguments-calls,-fuchsia-default-arguments-declarations,-fuchsia-overloaded-operator,-google-readability-braces-around-statements,-google-runtime-references,-hicpp-avoid-c-arrays,-hicpp-braces-around-statements,-hicpp-explicit-conversions,-hicpp-invalid-access-moved,-hicpp-member-init,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-no-assembler,-hicpp-use-equals-default,-llvm-include-order,-llvmlibc*,-misc-no-recursion,-misc-non-private-member-variables-in-classes,-modernize-use-equals-default,-modernize-use-trailing-return-type,-portability-simd-intrinsics,-readability-braces-around-statements,-readability-function-cognitive-complexity,-readability-identifier-length,-readability-named-parameter,-readability-magic-numbers'
 WarningsAsErrors: '*'
 CheckOptions:
   - key: performance-unnecessary-value-param.AllowedTypes

--- a/art.cpp
+++ b/art.cpp
@@ -246,11 +246,9 @@ std::optional<detail::node_ptr *> impl_helpers::remove_or_choose_subtree(
 
 namespace unodb {
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 db::~db() noexcept { delete_root_subtree(); }
 
 template <class INode>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::increment_inode_count() noexcept {
   static_assert(inode_defs::is_inode<INode>());
 
@@ -259,7 +257,6 @@ constexpr void db::increment_inode_count() noexcept {
 }
 
 template <class INode>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::decrement_inode_count() noexcept {
   static_assert(inode_defs::is_inode<INode>());
   UNODB_DETAIL_ASSERT(node_counts[as_i<INode::type>] > 0);
@@ -269,7 +266,6 @@ constexpr void db::decrement_inode_count() noexcept {
 }
 
 template <node_type NodeType>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::account_growing_inode() noexcept {
   static_assert(NodeType != node_type::LEAF);
 
@@ -279,7 +275,6 @@ constexpr void db::account_growing_inode() noexcept {
 }
 
 template <node_type NodeType>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void db::account_shrinking_inode() noexcept {
   static_assert(NodeType != node_type::LEAF);
 
@@ -288,7 +283,6 @@ constexpr void db::account_shrinking_inode() noexcept {
                       growing_inode_counts[internal_as_i<NodeType>]);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 db::get_result db::get(key search_key) const noexcept {
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) return {};
 
@@ -432,7 +426,6 @@ bool db::remove(key remove_key) {
   }
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void db::delete_root_subtree() noexcept {
   if (root != nullptr) art_policy::delete_subtree(root, *this);
 
@@ -441,7 +434,6 @@ void db::delete_root_subtree() noexcept {
   UNODB_DETAIL_ASSERT(node_counts[as_i<node_type::LEAF>] == 0);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void db::clear() noexcept {
   delete_root_subtree();
 

--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -30,7 +30,6 @@ struct [[nodiscard]] olc_node_header {
   }
 
 #ifndef NDEBUG
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   static void check_on_dealloc(const void *ptr) noexcept {
     static_cast<const olc_node_header *>(ptr)->m_lock.check_on_dealloc();
   }
@@ -161,7 +160,6 @@ template <class INode>
 }
 
 template <class T>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] T &obsolete(T &t UNODB_DETAIL_LIFETIMEBOUND,
                           unodb::optimistic_lock::write_guard &guard) noexcept {
   UNODB_DETAIL_ASSERT(guard.guards(lock(t)));
@@ -174,7 +172,6 @@ template <class T>
   return t;
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] inline auto obsolete_child_by_index(
     std::uint8_t child UNODB_DETAIL_LIFETIMEBOUND,
     unodb::optimistic_lock::write_guard &guard) noexcept {
@@ -188,7 +185,6 @@ template <class T>
 namespace unodb {
 
 template <class INode>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void olc_db::increment_inode_count() noexcept {
   static_assert(olc_inode_defs::is_inode<INode>());
 
@@ -251,7 +247,6 @@ class [[nodiscard]] olc_inode_4 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(unodb::detail::art_key k1, unodb::detail::art_key shifted_k2,
             unodb::detail::tree_depth depth, leaf *child1,
             olc_db_leaf_unique_ptr &&child2) noexcept {
@@ -283,14 +278,12 @@ class [[nodiscard]] olc_inode_4 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
     basic_inode_4::remove(child_index, db_instance);
   }
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] auto leave_last_child(std::uint8_t child_to_delete,
                                       unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_obsoleted_by_this_thread());
@@ -333,7 +326,6 @@ class [[nodiscard]] olc_inode_16 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_4 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             olc_db_leaf_unique_ptr &&child,
@@ -344,7 +336,6 @@ class [[nodiscard]] olc_inode_16 final
     UNODB_DETAIL_ASSERT_INACTIVE(source_node_guard);
   }
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_48 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             std::uint8_t child_to_delete,
@@ -366,7 +357,6 @@ class [[nodiscard]] olc_inode_16 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
@@ -428,7 +418,6 @@ class [[nodiscard]] olc_inode_48 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_16 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             olc_db_leaf_unique_ptr &&child,
@@ -439,7 +428,6 @@ class [[nodiscard]] olc_inode_48 final
     UNODB_DETAIL_ASSERT_INACTIVE(source_node_guard);
   }
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_256 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             std::uint8_t child_to_delete,
@@ -461,7 +449,6 @@ class [[nodiscard]] olc_inode_48 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
@@ -491,7 +478,6 @@ static_assert(sizeof(olc_inode_48) == 656 + 32);
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_inode_16::init(
     db &db_instance, olc_inode_48 &source_node,
     unodb::optimistic_lock::write_guard &source_node_guard,
@@ -518,7 +504,6 @@ class [[nodiscard]] olc_inode_256 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void init(db &db_instance, olc_inode_48 &source_node,
             unodb::optimistic_lock::write_guard &source_node_guard,
             olc_db_leaf_unique_ptr &&child,
@@ -545,7 +530,6 @@ class [[nodiscard]] olc_inode_256 final
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   void remove(std::uint8_t child_index, unodb::olc_db &db_instance) noexcept {
     UNODB_DETAIL_ASSERT(::lock(*this).is_write_locked());
 
@@ -570,7 +554,6 @@ static_assert(sizeof(olc_inode_256) == 2064 + 24);
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26434)
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_inode_48::init(
     db &db_instance, olc_inode_256 &source_node,
     unodb::optimistic_lock::write_guard &source_node_guard,
@@ -793,7 +776,6 @@ namespace unodb {
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(4189)
 template <class INode>
-// NOLINTNEXTLINE(bugprone-exception-escape)
 constexpr void olc_db::decrement_inode_count() noexcept {
   static_assert(olc_inode_defs::is_inode<INode>());
 
@@ -821,7 +803,6 @@ constexpr void olc_db::account_shrinking_inode() noexcept {
       1, std::memory_order_relaxed);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 olc_db::~olc_db() noexcept {
   UNODB_DETAIL_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
@@ -843,7 +824,6 @@ olc_db::get_result olc_db::get(key search_key) const noexcept {
   return *result;
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
   auto parent_critical_section = root_pointer_lock.try_read_lock();
   if (UNODB_DETAIL_UNLIKELY(parent_critical_section.must_restart())) {
@@ -1214,7 +1194,6 @@ olc_db::try_update_result_type olc_db::try_remove(detail::art_key k) {
   }
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::delete_root_subtree() noexcept {
   UNODB_DETAIL_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
@@ -1226,7 +1205,6 @@ void olc_db::delete_root_subtree() noexcept {
       node_counts[as_i<node_type::LEAF>].load(std::memory_order_relaxed) == 0);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::clear() noexcept {
   UNODB_DETAIL_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
@@ -1244,7 +1222,6 @@ void olc_db::clear() noexcept {
 
 UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=cold")
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::increase_memory_use(std::size_t delta) noexcept {
   UNODB_DETAIL_ASSERT(delta > 0);
 
@@ -1253,7 +1230,6 @@ void olc_db::increase_memory_use(std::size_t delta) noexcept {
 
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void olc_db::decrease_memory_use(std::size_t delta) noexcept {
   UNODB_DETAIL_ASSERT(delta > 0);
   UNODB_DETAIL_ASSERT(delta <=

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -20,7 +20,6 @@ namespace unodb::detail {
 
 struct set_qsbr_per_thread_in_main_thread {
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   set_qsbr_per_thread_in_main_thread() noexcept {
     try {
       auto main_thread_qsbr_reclamator_instance =
@@ -69,7 +68,6 @@ thread_local std::unique_ptr<qsbr_per_thread>
 }
 // LCOV_EXCL_STOP
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] auto qsbr_state::atomic_fetch_dec_threads_in_previous_epoch(
     std::atomic<qsbr_state::type> &word) noexcept {
   const auto old_word = word.fetch_sub(1, std::memory_order_acq_rel);
@@ -169,7 +167,6 @@ void free_orphan_list(detail::dealloc_vector_list_node *list) noexcept {
 
 }  // namespace
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void qsbr_per_thread::orphan_deferred_requests() noexcept {
   add_to_orphan_list(
       qsbr::instance().orphaned_previous_interval_dealloc_requests,
@@ -189,7 +186,6 @@ void qsbr_per_thread::orphan_deferred_requests() noexcept {
   UNODB_DETAIL_ASSERT(current_interval_orphan_list_node == nullptr);
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 qsbr_epoch qsbr::register_thread() noexcept {
   auto old_state = get_state();
 
@@ -364,7 +360,6 @@ void qsbr::thread_epoch_change_barrier() noexcept {
 #endif
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 qsbr_epoch qsbr::remove_thread_from_previous_epoch(
     qsbr_epoch current_global_epoch
 #ifndef NDEBUG
@@ -442,7 +437,6 @@ void qsbr::epoch_change_barrier_and_handle_orphans(
   }
 }
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
 qsbr_epoch qsbr::change_epoch(qsbr_epoch current_global_epoch,
                               bool single_thread_mode) noexcept {
   epoch_change_barrier_and_handle_orphans(single_thread_mode);

--- a/test/qsbr_gtest_utils.cpp
+++ b/test/qsbr_gtest_utils.cpp
@@ -16,7 +16,6 @@ QSBRTestBase::QSBRTestBase() {
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
-// NOLINTNEXTLINE(bugprone-exception-escape)
 QSBRTestBase::~QSBRTestBase() noexcept {
   if (is_qsbr_paused()) unodb::this_thread().qsbr_resume();
   unodb::this_thread().quiescent();

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -12,7 +12,6 @@
 namespace unodb::test {
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
-// NOLINTNEXTLINE(bugprone-exception-escape)
 void expect_idle_qsbr() noexcept {
   const auto state = unodb::qsbr::instance().get_state();
   UNODB_EXPECT_EQ(

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -28,7 +28,6 @@ template <class Db>
 class ARTConcurrencyTest : public ::testing::Test {
  public:
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ~ARTConcurrencyTest() noexcept override {
     if constexpr (std::is_same_v<Db, unodb::olc_db>) {
       unodb::this_thread().quiescent();
@@ -38,7 +37,6 @@ class ARTConcurrencyTest : public ::testing::Test {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
  protected:
-  // NOLINTNEXTLINE(bugprone-exception-escape)
   ARTConcurrencyTest() noexcept {
     if constexpr (std::is_same_v<Db, unodb::olc_db>)
       unodb::test::expect_idle_qsbr();


### PR DESCRIPTION
While it would be very beneficial here, it has too many false positives that have been suppressed inline. Stop doing that, disable the check, and revisit after some of the known issues are addressed:

- https://github.com/llvm/llvm-project/issues/55143 (clang-tidy: bugprone-exception-escape: explicitly defined move constructor may not thhrow)
- https://github.com/llvm/llvm-project/issues/54956 ([clang-tidy][ExceptionAnalyzer] Does not model  noexcept bounds)
- https://github.com/llvm/llvm-project/issues/54668 ([clang-tidy] bugprone-exception-escape reported for structs with std::string)
- https://github.com/llvm/llvm-project/issues/51596 (bugprone-exception-escape in std::variant::operator=())
- https://github.com/llvm/llvm-project/issues/49151 (bugprone-exception-escape reported for boost::beast::http::response)
- https://github.com/llvm/llvm-project/issues/43667 (bugprone-exception-escape false positive with is_nothrow_invokable)
- https://github.com/llvm/llvm-project/issues/40583 (bugprone-exception-escape generated for destructor marked with noexcept(false))