### PR TITLE
Fix race condition in QSBR.TwoThreadsBothPaused test

### DIFF
--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -105,15 +105,17 @@ TEST_F(QSBR, TwoThreadsFirstPaused) {
 TEST_F(QSBR, TwoThreadsBothPaused) {
   unodb::qsbr_thread second_thread([] {
     UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2);
-    thread_syncs[0].notify();
+    thread_syncs[0].notify();  // 1 ->
     qsbr_pause();
-    thread_syncs[1].wait();
+    thread_syncs[1].wait();  // 2 <-
     UNODB_EXPECT_EQ(get_qsbr_thread_count(), 0);
     unodb::this_thread().qsbr_resume();
+    thread_syncs[0].notify();  // 3 ->
   });
-  thread_syncs[0].wait();
+  thread_syncs[0].wait();  // 1 <-
   qsbr_pause();
-  thread_syncs[1].notify();
+  thread_syncs[1].notify();  // 2 ->
+  thread_syncs[0].wait();    // 3 <-
   join(second_thread);
   unodb::this_thread().qsbr_resume();
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -11,6 +11,11 @@ namespace unodb::test {
 // warning C26496: The variable 'result' does not change after construction,
 // mark it as const (con.4) - but that may preclude move on RVO.
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26496)
+// While the purpose of the function is to test that the single given action
+// does not allocate heap memory, its implementation is global, and no other
+// threads may allocate at the same time. IMHO a simpler global state (and the
+// need to debug some racy testcases) is the right trade-off vs. thread local
+// allocation-forbidding state.
 template <typename TestAction>
 std::invoke_result_t<TestAction> must_not_allocate(
     TestAction test_action) noexcept(noexcept(test_action())) {


### PR DESCRIPTION
qsbr_resume in the second thread raced with the first thread joining it. The join asserts that it must not allocate heap memory, whereas qsbr_resume will do that. Fix by serializing the two.