### PR TITLE
Factor our qsbr_state::dec_thread_count_threads_in_previous_epoch_may…

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -279,11 +279,9 @@ void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
 
     const auto new_state =
         UNODB_DETAIL_UNLIKELY(remove_thread_from_old_epoch)
-            ? (UNODB_DETAIL_UNLIKELY(advance_epoch)
-                   ? qsbr_state::inc_epoch_dec_thread_count_reset_previous(
-                         old_state)
-                   : qsbr_state::dec_thread_count_and_threads_in_previous_epoch(
-                         old_state))
+            ? qsbr_state::
+                  dec_thread_count_threads_in_previous_epoch_maybe_advance(
+                      old_state, advance_epoch)
             : qsbr_state::dec_thread_count(old_state);
 
     if (UNODB_DETAIL_UNLIKELY(remove_thread_from_old_epoch)) {

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -328,6 +328,14 @@ struct qsbr_state {
     return result;
   }
 
+  [[nodiscard]] static constexpr auto
+  dec_thread_count_threads_in_previous_epoch_maybe_advance(
+      type word, bool advance_epoch) noexcept {
+    return UNODB_DETAIL_UNLIKELY(advance_epoch)
+               ? inc_epoch_dec_thread_count_reset_previous(word)
+               : dec_thread_count_and_threads_in_previous_epoch(word);
+  }
+
   [[nodiscard]] static auto atomic_fetch_dec_threads_in_previous_epoch(
       std::atomic<type> &word) noexcept;
 


### PR DESCRIPTION
…be_advance

This simplifies the nested ternary operator in qsbr::unregister_thread.