### PR TITLE
Add cppcheck 2.14 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 Laurynas Biveinis
+# Copyright 2019-2024 Laurynas Biveinis
 cmake_minimum_required(VERSION 3.12)
 
 project(unodb VERSION 0.1
@@ -463,7 +463,10 @@ set(CPPCHECK_ARGS
   "--suppress=unreadVariable"
   # False positives on structured bindings with 2.5
   "--suppress=unassignedVariable"
-  "--suppress=unusedVariable")
+  "--suppress=unusedVariable"
+  # Informational message that fails the build. Remove once cppcheck 2.11 is the
+  # minimum
+  "--suppress=normalCheckLevelMaxBranches")
 
 option(CPPCHECK_AGGRESSIVE "Enable inconclusive cppcheck checks")
 if(CPPCHECK_AGGRESSIVE)

--- a/art.hpp
+++ b/art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Laurynas Biveinis
+// Copyright 2019-2024 Laurynas Biveinis
 #ifndef UNODB_DETAIL_ART_HPP
 #define UNODB_DETAIL_ART_HPP
 
@@ -76,6 +76,7 @@ class db final {
     return node_counts[as_i<NodeType>];
   }
 
+  // cppcheck-suppress returnByReference
   [[nodiscard, gnu::pure]] constexpr auto get_node_counts() const noexcept {
     return node_counts;
   }
@@ -86,6 +87,7 @@ class db final {
     return growing_inode_counts[internal_as_i<NodeType>];
   }
 
+  // cppcheck-suppress returnByReference
   [[nodiscard, gnu::pure]] constexpr auto get_growing_inode_counts()
       const noexcept {
     return growing_inode_counts;
@@ -97,6 +99,7 @@ class db final {
     return shrinking_inode_counts[internal_as_i<NodeType>];
   }
 
+  // cppcheck-suppress returnByReference
   [[nodiscard, gnu::pure]] constexpr auto get_shrinking_inode_counts()
       const noexcept {
     return shrinking_inode_counts;

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Laurynas Biveinis
+// Copyright (C) 2019-2024 Laurynas Biveinis
 #ifndef UNODB_DETAIL_QSBR_HPP
 #define UNODB_DETAIL_QSBR_HPP
 
@@ -861,7 +861,6 @@ class qsbr final {
 static_assert(std::atomic<std::size_t>::is_always_lock_free);
 static_assert(std::atomic<double>::is_always_lock_free);
 
-// cppcheck-suppress uninitMemberVar
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26455)
 inline qsbr_per_thread::qsbr_per_thread()
     : last_seen_quiescent_state_epoch{qsbr::instance().register_thread()},

--- a/thread_sync.hpp
+++ b/thread_sync.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2023 Laurynas Biveinis
+// Copyright 2020-2024 Laurynas Biveinis
 #ifndef UNODB_DETAIL_THREAD_SYNC_HPP
 #define UNODB_DETAIL_THREAD_SYNC_HPP
 
@@ -35,7 +35,6 @@ class [[nodiscard]] thread_sync final {
 
   void wait() {
     std::unique_lock lock{sync_mutex};
-    // cppcheck-suppress assignBoolToPointer
     sync.wait(lock, [&inner_flag = flag] { return inner_flag; });
     flag = false;
     lock.unlock();


### PR DESCRIPTION
- Suppress normalCheckLevelMaxBranches diagnostic which is informational but nevertheless fails the build
- Suppress new returnByReference diagnostics where return by value intentional
- Remove suppressions that seem to be no longer needed