### PR TITLE
Add LLVM 18 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,11 +51,11 @@ jobs:
                   curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
                     | sudo apt-key add -
                   echo \
-                    'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main' \
+                    'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' \
                     | sudo tee -a /etc/apt/sources.list
                   sudo apt-get update
-                  sudo NEEDRESTART_MODE=a apt-get install -y clang-17 \
-                    clang-tidy-17 iwyu
+                  sudo NEEDRESTART_MODE=a apt-get install -y clang-18 \
+                    clang-tidy-18 iwyu
       - when:
           condition:
             and:
@@ -65,8 +65,8 @@ jobs:
             - run:
                 name: Installing dependencies (LLVM Release)
                 command: |
-                  sudo NEEDRESTART_MODE=a apt-get install -y libomp5-17 \
-                    llvm-17 lld-17
+                  sudo NEEDRESTART_MODE=a apt-get install -y libomp5-18 \
+                    llvm-18 lld-18
       - run:
           name: Create build environment
           command: mkdir build
@@ -85,7 +85,7 @@ jobs:
               export CXX=g++-$V
               EXTRA_CMAKE_ARGS=()
             elif [[ $COMPILER == "clang" ]]; then
-              V=17
+              V=18
               export CC=clang-$V
               export CXX=clang++-$V
               if [[ $BUILD_TYPE == "Release" ]]; then
@@ -179,42 +179,42 @@ workflows:
           compiler: gcc
           ubsan: true
       - build:
-          name: clang 17 Debug
+          name: clang 18 Debug
           build_type: Debug
           compiler: clang
       - build:
-          name: clang 17 Debug with ASan
+          name: clang 18 Debug with ASan
           build_type: Debug
           compiler: clang
           asan: true
       - build:
-          name: clang 17 Debug with TSan
+          name: clang 18 Debug with TSan
           build_type: Debug
           compiler: clang
           tsan: true
       - build:
-          name: clang 17 Debug with UBSan
+          name: clang 18 Debug with UBSan
           build_type: Debug
           compiler: clang
           ubsan: true
       - build:
-          name: clang 17 Release
+          name: clang 18 Release
           build_type: Release
           compiler: clang
       # Test crashes that look like a codegen issue:
       # https://github.com/laurynas-biveinis/unodb/issues/563
       # - build:
-      #     name: clang 17 Release with ASan
+      #     name: clang 18 Release with ASan
       #     build_type: Release
       #     compiler: clang
       #     asan: true
       - build:
-          name: clang 17 Release with TSan
+          name: clang 18 Release with TSan
           build_type: Release
           compiler: clang
           tsan: true
       - build:
-          name: clang 17 Release with UBSan
+          name: clang 18 Release with UBSan
           build_type: Release
           compiler: clang
           ubsan: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,59 +95,59 @@ jobs:
             os: ubuntu-22.04
             COMPILER: gcc
 
-          - name: clang 17 Release
+          - name: clang 18 Release
             os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
 
-          - name: clang 17 Release with ASan
+          - name: clang 18 Release with ASan
             os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
 
-          - name: clang 17 Release with TSan
+          - name: clang 18 Release with TSan
             os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
 
-          - name: clang 17 Release with UBSan
+          - name: clang 18 Release with UBSan
             os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
 
-          - name: clang 17 Debug
+          - name: clang 18 Debug
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
 
-          - name: clang 17 Debug with ASan
+          - name: clang 18 Debug with ASan
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
 
-          - name: clang 17 Debug with TSan
+          - name: clang 18 Debug with TSan
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
 
-          - name: clang 17 Debug with UBSan
+          - name: clang 18 Debug with UBSan
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
 
-          - name: clang 17 Release static analysis
+          - name: clang 18 Release static analysis
             os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             STATIC_ANALYSIS: ON
 
-          - name: clang 17 Debug static analysis
+          - name: clang 18 Debug static analysis
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
@@ -249,26 +249,26 @@ jobs:
         run: |
           curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
             | sudo apt-key add -
-          echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main' \
+          echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main' \
             | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          sudo apt-get install -y clang-17 iwyu
+          sudo apt-get install -y clang-18 iwyu
         if: runner.os == 'Linux' && env.COMPILER == 'clang'
 
       - name: Setup dependencies for Linux LLVM (Release)
-        run: sudo apt-get install -y libomp5-17 llvm-17 lld-17
+        run: sudo apt-get install -y libomp5-18 llvm-18 lld-18
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
           && env.BUILD_TYPE == 'Release'
 
       - name: Setup dependencies for Linux LLVM (static analysis)
-        run: sudo apt-get install -y clang-tools-17
+        run: sudo apt-get install -y clang-tools-18
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
           && env.STATIC_ANALYSIS == 'ON'
 
       - name: Setup dependencies for Linux LLVM (not static analysis)
-        run: sudo apt-get install -y clang-tidy-17
+        run: sudo apt-get install -y clang-tidy-18
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
           && env.STATIC_ANALYSIS != 'ON'
@@ -321,7 +321,7 @@ jobs:
             export CC=gcc-$V
             export CXX=g++-$V
           elif [[ $COMPILER == "clang" ]]; then
-            V=17
+            V=18
             export CC=clang-$V
             export CXX=clang++-$V
             if [[ $BUILD_TYPE == "Release" ]]; then
@@ -362,7 +362,7 @@ jobs:
       - name: clang static analysis
         working-directory: ${{github.workspace}}/build
         run: |
-          /usr/bin/scan-build-17 --status-bugs -stats -analyze-headers \
+          /usr/bin/scan-build-18 --status-bugs -stats -analyze-headers \
             --force-analyze-debug-code make -j3;
         if: env.STATIC_ANALYSIS == 'ON' && env.COMPILER == 'clang'
 

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -348,6 +348,60 @@ jobs:
             COMPILER: clang
             VERSION: 16
 
+          - name: clang 17 Release
+            os: ubuntu-22.04
+            BUILD_TYPE: Release
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Release with ASan
+            os: ubuntu-22.04
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Release with TSan
+            os: ubuntu-22.04
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Release with UBSan
+            os: ubuntu-22.04
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Debug
+            os: ubuntu-22.04
+            BUILD_TYPE: Debug
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Debug with ASan
+            os: ubuntu-22.04
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Debug with TSan
+            os: ubuntu-22.04
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 17
+
+          - name: clang 17 Debug with UBSan
+            os: ubuntu-22.04
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 17
+
           - name: GCC 10 Release
             os: ubuntu-22.04
             BUILD_TYPE: Release
@@ -533,7 +587,7 @@ jobs:
                 "clang-${VERSION}" "clang-tidy-${VERSION}"
         if: runner.os == 'Linux' && env.COMPILER == 'clang' && env.VERSION < 13
 
-      - name: Setup dependencies for Linux LLVM 13, 15, & 16
+      - name: Setup dependencies for Linux LLVM 13 & 15+
         run: |
           curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
             | sudo apt-key add -
@@ -545,7 +599,7 @@ jobs:
                 "clang-${VERSION}" "clang-tidy-${VERSION}"
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
-          && (env.VERSION == 13 || env.VERSION == 15 || env.VERSION == 16)
+          && (env.VERSION == 13 || env.VERSION >= 15)
 
       - name: Setup dependencies for Linux LLVM 13+
         run: sudo apt-get install -y iwyu

--- a/art.cpp
+++ b/art.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 Laurynas Biveinis
+// Copyright 2019-2024 Laurynas Biveinis
 
 // IWYU pragma: no_include <__type_traits/is_empty.h>
 // IWYU pragma: no_include <__utility/forward.h>
@@ -194,8 +194,8 @@ template <class INode>
 detail::node_ptr *impl_helpers::add_or_choose_subtree(
     INode &inode, std::byte key_byte, art_key k, value_view v, db &db_instance,
     tree_depth depth, detail::node_ptr *node_in_parent) {
-  auto *const child = unwrap_fake_critical_section(
-      static_cast<INode &>(inode).find_child(key_byte).second);
+  auto *const child =
+      unwrap_fake_critical_section(inode.find_child(key_byte).second);
 
   if (child != nullptr) return child;
 

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Laurynas Biveinis
+// Copyright 2021-2024 Laurynas Biveinis
 
 // IWYU pragma: no_include <__algorithm/count_if.h>
 // IWYU pragma: no_include <__iterator/advance.h>
@@ -41,7 +41,7 @@ constexpr auto max_thread_id{102400};
 
 constexpr std::uint64_t object_mem = 0xAABBCCDD22446688ULL;
 
-enum class [[nodiscard]] thread_operation{
+enum class [[nodiscard]] thread_operation : std::uint8_t{
     ALLOCATE_POINTER,       DEALLOCATE_POINTER, TAKE_ACTIVE_POINTER,
     RELEASE_ACTIVE_POINTER, QUIESCENT_STATE,    QUIT_THREAD,
     PAUSE_THREAD,           RESUME_THREAD,      RESET_STATS};

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2023 Laurynas Biveinis
+// Copyright (C) 2021-2024 Laurynas Biveinis
 #ifndef UNODB_DETAIL_QSBR_PTR_HPP
 #define UNODB_DETAIL_QSBR_PTR_HPP
 
@@ -98,8 +98,7 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-  [[nodiscard, gnu::pure]] constexpr std::add_lvalue_reference_t<T> operator*()
-      const {
+  [[nodiscard]] constexpr std::add_lvalue_reference_t<T> operator*() const {
     return *ptr;
   }
 


### PR DESCRIPTION
- Remove a redundant cast as diagnosed by LLVM 18
- Remove gnu::pure attribute from a method template, as it's being instantiated with void too, where the attribute is illegal. Do not bother specializing the template for the void case.
- Use LLVM 18 for main CircleCI and GitHub Actions runs
- Add LLVM 17 to GitHub Actions old compilers run