### PR TITLE
Remove redundant -E from ctest invocation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 target_link_libraries(test_art_concurrency PRIVATE qsbr_test_utils)
 
 if(COVERAGE)
-  add_custom_target(tests_for_coverage ctest -E
+  add_custom_target(tests_for_coverage ctest
     DEPENDS test_art test_art_concurrency test_qsbr_ptr test_qsbr test_art_oom
             test_qsbr_oom)
   add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)


### PR DESCRIPTION
This should fix coverage failures in GitHub Actions
