### PR TITLE
Split out Ubuntu 20.04-specific test job in GitHub Actions [circle skip]

### DIFF
--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -12,7 +12,7 @@ permissions: { }
 
 jobs:
   build:
-    runs-on: ${{matrix.os}}
+    runs-on: ubuntu-22.04
 
     env:
       BUILD_TYPE: ${{matrix.BUILD_TYPE}}
@@ -26,595 +26,369 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: clang 11 Release
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Release with ASan
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            SANITIZE_ADDRESS: ON
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Release with TSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            SANITIZE_THREAD: ON
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Release with UBSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            SANITIZE_UB: ON
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Debug
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Debug with ASan
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            SANITIZE_ADDRESS: ON
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Debug with TSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            SANITIZE_THREAD: ON
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 11 Debug with UBSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            SANITIZE_UB: ON
-            COMPILER: clang
-            VERSION: 11
-
-          - name: clang 12 Release
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Release with ASan
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            SANITIZE_ADDRESS: ON
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Release with TSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            SANITIZE_THREAD: ON
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Release with UBSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Release
-            SANITIZE_UB: ON
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Debug
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Debug with ASan
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            SANITIZE_ADDRESS: ON
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Debug with TSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            SANITIZE_THREAD: ON
-            COMPILER: clang
-            VERSION: 12
-
-          - name: clang 12 Debug with UBSan
-            os: ubuntu-20.04
-            BUILD_TYPE: Debug
-            SANITIZE_UB: ON
-            COMPILER: clang
-            VERSION: 12
-
           - name: clang 13 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 13
 
           - name: clang 13 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 13
 
           - name: clang 14 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 14
 
           - name: clang 14 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 14
 
           - name: clang 15 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 15
 
           - name: clang 15 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 15
 
           - name: clang 16 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 16
 
           - name: clang 16 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 16
 
           - name: clang 17 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 17
 
           - name: clang 17 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 17
 
           - name: clang 18 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
             VERSION: 18
 
           - name: clang 18 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
             VERSION: 18
 
-          - name: GCC 10 Release
-            os: ubuntu-22.04
-            BUILD_TYPE: Release
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Release with ASan
-            os: ubuntu-22.04
-            BUILD_TYPE: Release
-            SANITIZE_ADDRESS: ON
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Release with TSan
-            os: ubuntu-22.04
-            BUILD_TYPE: Release
-            SANITIZE_THREAD: ON
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Release with UBSan
-            os: ubuntu-22.04
-            BUILD_TYPE: Release
-            SANITIZE_UB: ON
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Debug
-            os: ubuntu-22.04
-            BUILD_TYPE: Debug
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Debug with ASan
-            os: ubuntu-22.04
-            BUILD_TYPE: Debug
-            SANITIZE_ADDRESS: ON
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Debug with TSan
-            os: ubuntu-22.04
-            BUILD_TYPE: Debug
-            SANITIZE_THREAD: ON
-            COMPILER: gcc
-            VERSION: 10
-
-          - name: GCC 10 Debug with UBSan
-            os: ubuntu-22.04
-            BUILD_TYPE: Debug
-            SANITIZE_UB: ON
-            COMPILER: gcc
-            VERSION: 10
-
           - name: GCC 11 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 11 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: gcc
             VERSION: 11
 
           - name: GCC 12 Release
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Release with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Release with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Release with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Debug
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Debug with ASan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Debug with TSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: gcc
             VERSION: 12
 
           - name: GCC 12 Debug with UBSan
-            os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: gcc
@@ -625,25 +399,12 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup common dependencies for Linux
+      - name: Setup common dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libboost-dev libc6-dev-i386
-        if: runner.os == 'Linux'
 
-      - name: Setup dependencies for Linux LLVM 11 & 12
-        run: |
-          curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
-            | sudo apt-key add -
-          echo "deb http://apt.llvm.org/focal/ \
-            llvm-toolchain-focal-${VERSION} main" \
-            | sudo tee -a /etc/apt/sources.list
-          sudo apt-get update
-          sudo apt-get install -y "llvm-${VERSION}-linker-tools" \
-                "clang-${VERSION}" "clang-tidy-${VERSION}"
-        if: runner.os == 'Linux' && env.COMPILER == 'clang' && env.VERSION < 13
-
-      - name: Setup dependencies for Linux LLVM 13 & 15+
+      - name: Setup dependencies for LLVM 13 & 15+
         run: |
           curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
             | sudo apt-key add -
@@ -654,26 +415,22 @@ jobs:
           sudo apt-get install -y "llvm-${VERSION}-linker-tools" \
                 "clang-${VERSION}" "clang-tidy-${VERSION}"
         if: >
-          runner.os == 'Linux' && env.COMPILER == 'clang'
+          env.COMPILER == 'clang'
           && (env.VERSION == 13 || env.VERSION >= 15)
 
-      - name: Setup dependencies for Linux LLVM 13+
+      - name: Setup dependencies for LLVM 13+
         run: sudo apt-get install -y iwyu
-        if: runner.os == 'Linux' && env.COMPILER == 'clang' && env.VERSION >= 13
+        if: env.COMPILER == 'clang' && env.VERSION >= 13
 
-      - name: Setup dependencies for Linux GCC (versioned package)
+      - name: Setup dependencies for GCC 12 (versioned package)
         run: |
           sudo apt-get install -y "gcc-${VERSION}"
-        if: >
-          runner.os == 'Linux' && env.COMPILER == 'gcc'
-          && (env.VERSION == '10' || env.VERSION == '12')
+        if: env.COMPILER == 'gcc' && env.VERSION == '12'
 
-      - name: Setup dependencies for Linux GCC (default OS package)
+      - name: Setup dependencies for GCC 11 (default OS package)
         run: |
           sudo apt-get install -y gcc
-        if: >
-          runner.os == 'Linux' && env.COMPILER == 'gcc'
-          && env.VERSION == '11'
+        if: env.COMPILER == 'gcc' && env.VERSION == '11'
 
       - name: Create build environment
         run: mkdir ${{github.workspace}}/build

--- a/.github/workflows/ubuntu-20.04.yml
+++ b/.github/workflows/ubuntu-20.04.yml
@@ -1,0 +1,247 @@
+---
+name: build-ubuntu-20.04
+
+on: [push]
+
+env:
+  DEFAULT_SANITIZE_ADDRESS: OFF
+  DEFAULT_SANITIZE_THREAD: OFF
+  DEFAULT_SANITIZE_UB: OFF
+
+permissions: { }
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    env:
+      BUILD_TYPE: ${{matrix.BUILD_TYPE}}
+      COMPILER: ${{matrix.COMPILER}}
+      VERSION: ${{matrix.VERSION}}
+      SANITIZE_ADDRESS: ${{matrix.SANITIZE_ADDRESS}}
+      SANITIZE_THREAD: ${{matrix.SANITIZE_THREAD}}
+      SANITIZE_UB: ${{matrix.SANITIZE_UB}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: clang 11 Release
+            BUILD_TYPE: Release
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Release with ASan
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Release with TSan
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Release with UBSan
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Debug
+            BUILD_TYPE: Debug
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Debug with ASan
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Debug with TSan
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 11 Debug with UBSan
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 11
+
+          - name: clang 12 Release
+            BUILD_TYPE: Release
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Release with ASan
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Release with TSan
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Release with UBSan
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Debug
+            BUILD_TYPE: Debug
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Debug with ASan
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Debug with TSan
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 12
+
+          - name: clang 12 Debug with UBSan
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 12
+
+          - name: GCC 10 Release
+            BUILD_TYPE: Release
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Release with ASan
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Release with TSan
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Release with UBSan
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Debug
+            BUILD_TYPE: Debug
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Debug with ASan
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Debug with TSan
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: gcc
+            VERSION: 10
+
+          - name: GCC 10 Debug with UBSan
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: gcc
+            VERSION: 10
+
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup common dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-dev libc6-dev-i386
+
+      - name: Setup dependencies for GCC
+        run: |
+          sudo apt-get install -y "gcc-${VERSION}" "gcc-${VERSION}-multilib"
+        if: env.COMPILER == 'gcc'
+
+      - name: Setup dependencies for LLVM (common)
+        run: |
+          sudo apt-get install -y "clang-${VERSION}" "clang-tidy-${VERSION}"
+        if: env.COMPILER == 'clang'
+
+      - name: Setup dependencies for LLVM (Release)
+        run: |
+          sudo apt-get install -y "libomp5-${VERSION}" "llvm-${VERSION}" \
+               "lld-${VERSION}"
+        if: env.COMPILER == 'clang' && env.BUILD_TYPE == 'Release'
+
+      - name: Create build environment
+        run: mkdir ${{github.workspace}}/build
+
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment
+        # variable access regardless of the host operating system
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: |
+          SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-$DEFAULT_SANITIZE_ADDRESS}"
+          SANITIZE_THREAD="${SANITIZE_THREAD:-$DEFAULT_SANITIZE_THREAD}"
+          SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
+          if [[ $COMPILER == "gcc" ]]; then
+            export CC="gcc-${VERSION}"
+            export CXX="g++-${VERSION}"
+            EXTRA_CMAKE_ARGS=("-DMAINTAINER_MODE=ON")
+          else
+            export CC="clang-${VERSION}"
+            export CXX="clang++-${VERSION}"
+            EXTRA_CMAKE_ARGS=("-DCLANG_TIDY_EXE=/usr/bin/clang-tidy-${VERSION}")
+            if [[ $BUILD_TYPE == "Release" ]]; then
+              EXTRA_CMAKE_ARGS=("${EXTRA_CMAKE_ARGS[@]}" \
+                  "-DLLVMAR_EXECUTABLE=/usr/bin/llvm-ar-${VERSION}" \
+                  "-DLLVMNM_EXECUTABLE=/usr/bin/llvm-nm-${VERSION}" \
+                  "-DLLVMRANLIB_EXECUTABLE=/usr/bin/llvm-ranlib-${VERSION}")
+            fi
+          fi
+          cmake "$GITHUB_WORKSPACE" -DSTANDALONE=ON \
+              "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
+              "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
+              "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \
+              "-DSANITIZE_UB=${SANITIZE_UB}" "${EXTRA_CMAKE_ARGS[@]}"
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: make -j3
+
+      - name: Correctness test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -j3 -V
+
+      - name: Benchmark correctness test
+        working-directory: ${{github.workspace}}/build
+        run: make quick_benchmarks
+
+      - name: Valgrind test
+        working-directory: ${{github.workspace}}/build
+        run: |
+          sudo apt-get install -y libc6-dbg
+          sudo snap install --classic valgrind
+          make valgrind
+        if: >
+          env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
+          && env.SANITIZE_UB != 'ON'


### PR DESCRIPTION
Add Ubuntu 20.04 test job and move LLVM 11, 12, & GCC 10 testing there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for automated builds on Ubuntu 20.04, supporting multiple compiler versions and build configurations.
  
- **Improvements**
	- Updated existing build configurations to streamline the environment, focusing on the latest compiler versions on Ubuntu 22.04.
	- Enhanced clarity in workflow steps with updated naming conventions for dependency setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->