### PR TITLE
Adds scan support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,11 @@ jobs:
       - run:
           name: Build
           working_directory: build
-          command: make -j2
+          command: make -j2 -k
       - run:
           name: Examples
           working_directory: build
-          command: make examples
+          command: make -k examples
       - run:
           name: Correctness test
           working_directory: build
@@ -125,7 +125,7 @@ jobs:
             - run:
                 name: Benchmark correctness test
                 working_directory: build
-                command: make quick_benchmarks
+                command: make -k quick_benchmarks
       - when:
           condition:
             not:
@@ -139,7 +139,7 @@ jobs:
                 working_directory: build
                 command: |
                   sudo NEEDRESTART_MODE=a apt-get install -y valgrind
-                  make valgrind
+                  make -k valgrind
 
   build-macos:
     parameters:
@@ -187,11 +187,11 @@ jobs:
       - run:
           name: Build
           working_directory: build
-          command: make -j3
+          command: make -j3 -k
       - run:
           name: Examples
           working_directory: build
-          command: make examples
+          command: make -k examples
       - run:
           name: Correctness test
           working_directory: build
@@ -206,7 +206,7 @@ jobs:
             - run:
                 name: Benchmark correctness test
                 working_directory: build
-                command: make quick_benchmarks
+                command: make -k quick_benchmarks
 
 workflows:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 ---
 name: build
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   DEFAULT_COMPILER: gcc
@@ -412,19 +416,19 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -j3 -k
         if: env.STATIC_ANALYSIS != 'ON' || env.COMPILER != 'clang'
 
       - name: clang static analysis
         working-directory: ${{github.workspace}}/build
         run: |
           /usr/bin/scan-build-19 --status-bugs -stats -analyze-headers \
-            --force-analyze-debug-code make -j3;
+            --force-analyze-debug-code make -j3 -k;
         if: env.STATIC_ANALYSIS == 'ON' && env.COMPILER == 'clang'
 
       - name: Examples
         working-directory: ${{github.workspace}}/build
-        run: make examples
+        run: make -k examples
         if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
 
       - name: Correctness test
@@ -434,12 +438,12 @@ jobs:
 
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
-        run: make quick_benchmarks
+        run: make -k quick_benchmarks
         if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
 
       - name: DeepState 1 minute fuzzing
         working-directory: ${{github.workspace}}/build
-        run: make -j2 deepstate_1m
+        run: make -j2 -k deepstate_1m
         if: >
           env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
           && (runner.os != 'macOS'
@@ -447,7 +451,7 @@ jobs:
 
       - name: DeepState libfuzzer 1 minute fuzzing
         working-directory: ${{github.workspace}}/build
-        run: make -j2 deepstate_lf_1m
+        run: make -j2 -k deepstate_lf_1m
         if: >
           env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
           && env.COMPILER == 'clang' && env.BUILD_TYPE != 'Release'
@@ -458,7 +462,7 @@ jobs:
         run: |
           sudo apt-get install -y libc6-dbg
           sudo snap install --classic valgrind
-          make valgrind
+          make -k valgrind
         if: >
           env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
           && env.SANITIZE_UB != 'ON' && env.STATIC_ANALYSIS != 'ON'
@@ -467,7 +471,7 @@ jobs:
       - name: Gather coverage data
         working-directory: ${{github.workspace}}/build
         run: |
-          make -j3 coverage
+          make -j3 -k coverage
         if: env.COVERAGE == 'ON'
 
       - name: Upload coverage data

--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -1,7 +1,11 @@
 ---
 name: experimental-build
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: { }
 
@@ -51,5 +55,5 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -j3 -k
         continue-on-error: true

--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -1,7 +1,11 @@
 ---
 name: msvc-build
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: { }
 

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -1,7 +1,11 @@
 ---
 name: build-with-old-compilers
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   DEFAULT_SANITIZE_ADDRESS: OFF
@@ -511,11 +515,11 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -j3 -k
 
       - name: Examples
         working-directory: ${{github.workspace}}/build
-        run: make examples
+        run: make -k examples
 
       - name: Correctness test
         working-directory: ${{github.workspace}}/build
@@ -523,14 +527,14 @@ jobs:
 
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
-        run: make quick_benchmarks
+        run: make -k quick_benchmarks
 
       - name: Valgrind test
         working-directory: ${{github.workspace}}/build
         run: |
           sudo apt-get install -y libc6-dbg
           sudo snap install --classic valgrind
-          make valgrind
+          make -k valgrind
         if: >
           env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
           && env.SANITIZE_UB != 'ON'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,7 +1,11 @@
 ---
 name: sonarcloud
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: { }
 

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,8 +1,11 @@
 ---
 name: Super-Linter
 
-# Run this workflow every time a new commit pushed to your repository
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: { }
 

--- a/.github/workflows/ubuntu-20.04.yml
+++ b/.github/workflows/ubuntu-20.04.yml
@@ -1,7 +1,11 @@
 ---
 name: build-ubuntu-20.04
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 env:
   DEFAULT_SANITIZE_ADDRESS: OFF
@@ -226,11 +230,11 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -j3 -k
 
       - name: Examples
         working-directory: ${{github.workspace}}/build
-        run: make examples
+        run: make -k examples
 
       - name: Correctness test
         working-directory: ${{github.workspace}}/build
@@ -238,14 +242,14 @@ jobs:
 
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
-        run: make quick_benchmarks
+        run: make -k quick_benchmarks
 
       - name: Valgrind test
         working-directory: ${{github.workspace}}/build
         run: |
           sudo apt-get install -y libc6-dbg
           sudo snap install --classic valgrind
-          make valgrind
+          make -k valgrind
         if: >
           env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
           && env.SANITIZE_UB != 'ON'

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@
 # MSVC
 /.vs
 /out
+
+**/*~
+**/*#*
+
+run-cmake.sh
+loop-test.sh

--- a/README.md
+++ b/README.md
@@ -122,8 +122,11 @@ All the declarations live in the `unodb` namespace, which is omitted in the
 descriptions below.
 
 The only currently supported key type is `std::uint64_t`, aliased as `key`. To
-add new key types, instantiate `art_key` type with the desired type, and
-specialize `art_key::make_binary_comparable` according to the ART paper.
+add a new simple key type, instantiate `art_key` type with the desired type, and
+specialize `art_key::make_binary_comparable` according to the ART paper. Compound
+keys or Unicode data should be handled by specifying gsl::span<std::byte> as the
+key type.  In this case, the application must provide a span suitably encoded for
+lexicographic comparisons (that is, one which is already binary compatible).
 
 Values are treated opaquely. For `unodb::db`, they are passed as non-owning
 objects of `value_view` (a `gsl::span<std::byte>`), and insertion copies them
@@ -142,6 +145,11 @@ All ART classes share the same API:
 * `clear()` empties the tree. For `olc_db`, it must be called from a
   single-threaded context.
 * `bool empty()` returns whether the tree is empty.
+* `template <FN> scan(), scan_from(...), scan_range()` a family of
+  scan methods, including forward and reverse scans and scans with a
+  from_key and an exclusive upper bound to_key where fn is a lambda
+  accepting a visitor and returning a bool indicating whether the scan
+  should halt (bool halt).  See `examples/examples_art.cpp`.
 * `void dump(std::ostream &)` outputs the tree representation.
 * Several getters provide tree info, such as current memory use, and internal
   operation counters (e.g. number of times Node4 grew to Node16, key prefix was

--- a/art.cpp
+++ b/art.cpp
@@ -1,12 +1,22 @@
 // Copyright 2019-2024 Laurynas Biveinis
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>
 
 #include "art.hpp"
 
 #include <cstddef>
+#include <cstdint>
+#include <iomanip>
 #include <iostream>  // IWYU pragma: keep
 #include <optional>
 #include <type_traits>
@@ -19,38 +29,9 @@
 #include "in_fake_critical_section.hpp"
 #include "node_type.hpp"
 
-namespace unodb::detail {
-
-struct [[nodiscard]] node_header {};
-
-static_assert(std::is_empty_v<node_header>);
-
-}  // namespace unodb::detail
-
 namespace {
 
-class inode;
-class inode_4;
-class inode_16;
-class inode_48;
-class inode_256;
-
-using inode_defs = unodb::detail::basic_inode_def<inode, inode_4, inode_16,
-                                                  inode_48, inode_256>;
-
-template <class INode>
-using db_inode_deleter =
-    unodb::detail::basic_db_inode_deleter<INode, unodb::db>;
-
-using art_policy = unodb::detail::basic_art_policy<
-    unodb::db, unodb::in_fake_critical_section, unodb::detail::node_ptr,
-    inode_defs, db_inode_deleter, unodb::detail::basic_db_leaf_deleter>;
-
-using inode_base = unodb::detail::basic_inode_impl<art_policy>;
-
 using leaf = unodb::detail::basic_leaf<unodb::detail::node_header>;
-
-class inode : public inode_base {};
 
 }  // namespace
 
@@ -76,12 +57,8 @@ struct impl_helpers {
   impl_helpers() = delete;
 };
 
-}  // namespace unodb::detail
-
-namespace {
-
 class [[nodiscard]] inode_4 final
-    : public unodb::detail::basic_inode_4<art_policy> {
+    : public unodb::detail::basic_inode_4<unodb::detail::art_policy> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   using basic_inode_4::basic_inode_4;
@@ -108,7 +85,7 @@ static_assert(sizeof(inode_4) == 56);
 #endif
 
 class [[nodiscard]] inode_16 final
-    : public unodb::detail::basic_inode_16<art_policy> {
+    : public unodb::detail::basic_inode_16<unodb::detail::art_policy> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   using basic_inode_16::basic_inode_16;
@@ -129,7 +106,7 @@ class [[nodiscard]] inode_16 final
 static_assert(sizeof(inode_16) == 160);
 
 class [[nodiscard]] inode_48 final
-    : public unodb::detail::basic_inode_48<art_policy> {
+    : public unodb::detail::basic_inode_48<unodb::detail::art_policy> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   using basic_inode_48::basic_inode_48;
@@ -154,7 +131,7 @@ static_assert(sizeof(inode_48) == 656);
 #endif
 
 class [[nodiscard]] inode_256 final
-    : public unodb::detail::basic_inode_256<art_policy> {
+    : public unodb::detail::basic_inode_256<unodb::detail::art_policy> {
  public:
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   using basic_inode_256::basic_inode_256;
@@ -173,6 +150,10 @@ class [[nodiscard]] inode_256 final
 };
 
 static_assert(sizeof(inode_256) == 2064);
+
+}  // namespace unodb::detail
+
+namespace {
 
 // Because we cannot dereference, load(), & take address of - it is a temporary
 // by then
@@ -196,13 +177,13 @@ detail::node_ptr *impl_helpers::add_or_choose_subtree(
 
   if (child != nullptr) return child;
 
-  auto leaf = art_policy::make_db_leaf_ptr(k, v, db_instance);
+  auto aleaf = art_policy::make_db_leaf_ptr(k, v, db_instance);
   const auto children_count = inode.get_children_count();
 
   if constexpr (!std::is_same_v<INode, inode_256>) {
     if (UNODB_DETAIL_UNLIKELY(children_count == INode::capacity)) {
       auto larger_node{INode::larger_derived_type::create(
-          db_instance, inode, std::move(leaf), depth)};
+          db_instance, inode, std::move(aleaf), depth)};
       *node_in_parent =
           node_ptr{larger_node.release(), INode::larger_derived_type::type};
 #ifdef UNODB_DETAIL_WITH_STATS
@@ -212,7 +193,7 @@ detail::node_ptr *impl_helpers::add_or_choose_subtree(
       return child;
     }
   }
-  inode.add_to_nonfull(std::move(leaf), depth, children_count);
+  inode.add_to_nonfull(std::move(aleaf), depth, children_count);
   return child;
 }
 
@@ -228,8 +209,8 @@ std::optional<detail::node_ptr *> impl_helpers::remove_or_choose_subtree(
   if (child_ptr_val.type() != node_type::LEAF)
     return unwrap_fake_critical_section(child_ptr);
 
-  const auto *const leaf{child_ptr_val.template ptr<::leaf *>()};
-  if (!leaf->matches(k)) return {};
+  const auto *const aleaf{child_ptr_val.template ptr<::leaf *>()};
+  if (!aleaf->matches(k)) return {};
 
   if (UNODB_DETAIL_UNLIKELY(inode.is_min_size())) {
     if constexpr (std::is_same_v<INode, inode_4>) {
@@ -262,7 +243,7 @@ db::~db() noexcept { delete_root_subtree(); }
 
 template <class INode>
 constexpr void db::increment_inode_count() noexcept {
-  static_assert(inode_defs::is_inode<INode>());
+  static_assert(unodb::detail::inode_defs::is_inode<INode>());
 
   ++node_counts[as_i<INode::type>];
   increase_memory_use(sizeof(INode));
@@ -270,7 +251,7 @@ constexpr void db::increment_inode_count() noexcept {
 
 template <class INode>
 constexpr void db::decrement_inode_count() noexcept {
-  static_assert(inode_defs::is_inode<INode>());
+  static_assert(unodb::detail::inode_defs::is_inode<INode>());
   UNODB_DETAIL_ASSERT(node_counts[as_i<INode::type>] > 0);
 
   --node_counts[as_i<INode::type>];
@@ -315,7 +296,7 @@ db::get_result db::get(key search_key) const noexcept {
 
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
 
-    auto *const inode{node.ptr<::inode *>()};
+    auto *const inode{node.ptr<detail::inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     if (key_prefix.get_shared_length(remaining_key) < key_prefix_length)
@@ -335,7 +316,7 @@ bool db::insert(key insert_key, value_view v) {
   const auto k = detail::art_key{insert_key};
 
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) {
-    auto leaf = art_policy::make_db_leaf_ptr(k, v, *this);
+    auto leaf = unodb::detail::art_policy::make_db_leaf_ptr(k, v, *this);
     root = detail::node_ptr{leaf.release(), node_type::LEAF};
     return true;
   }
@@ -351,9 +332,9 @@ bool db::insert(key insert_key, value_view v) {
       const auto existing_key{leaf->get_key()};
       if (UNODB_DETAIL_UNLIKELY(k == existing_key)) return false;
 
-      auto new_leaf = art_policy::make_db_leaf_ptr(k, v, *this);
-      auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
-                                    leaf, std::move(new_leaf))};
+      auto new_leaf = unodb::detail::art_policy::make_db_leaf_ptr(k, v, *this);
+      auto new_node{detail::inode_4::create(*this, existing_key, remaining_key,
+                                            depth, leaf, std::move(new_leaf))};
       *node = detail::node_ptr{new_node.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
       account_growing_inode<node_type::I4>();
@@ -364,14 +345,14 @@ bool db::insert(key insert_key, value_view v) {
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
     UNODB_DETAIL_ASSERT(depth < detail::art_key::size);
 
-    auto *const inode{node->ptr<::inode *>()};
+    auto *const inode{node->ptr<detail::inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
     if (shared_prefix_len < key_prefix_length) {
-      auto leaf = art_policy::make_db_leaf_ptr(k, v, *this);
-      auto new_node = inode_4::create(*this, *node, shared_prefix_len, depth,
-                                      std::move(leaf));
+      auto leaf = unodb::detail::art_policy::make_db_leaf_ptr(k, v, *this);
+      auto new_node = detail::inode_4::create(*this, *node, shared_prefix_len,
+                                              depth, std::move(leaf));
       *node = detail::node_ptr{new_node.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
       account_growing_inode<node_type::I4>();
@@ -405,7 +386,8 @@ bool db::remove(key remove_key) {
   if (root.type() == node_type::LEAF) {
     auto *const root_leaf{root.ptr<leaf *>()};
     if (root_leaf->matches(k)) {
-      const auto r{art_policy::reclaim_leaf_on_scope_exit(root_leaf, *this)};
+      const auto r{
+          detail::art_policy::reclaim_leaf_on_scope_exit(root_leaf, *this)};
       root = nullptr;
       return true;
     }
@@ -421,7 +403,7 @@ bool db::remove(key remove_key) {
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
     UNODB_DETAIL_ASSERT(depth < detail::art_key::size);
 
-    auto *const inode{node->ptr<::inode *>()};
+    auto *const inode{node->ptr<detail::inode *>()};
     const auto &key_prefix{inode->get_key_prefix()};
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
@@ -446,7 +428,7 @@ bool db::remove(key remove_key) {
 }
 
 void db::delete_root_subtree() noexcept {
-  if (root != nullptr) art_policy::delete_subtree(root, *this);
+  if (root != nullptr) detail::art_policy::delete_subtree(root, *this);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   // It is possible to reset the counter to zero instead of decrementing it for
@@ -474,7 +456,314 @@ void db::dump(std::ostream &os) const {
 #else
   os << "db dump\n";
 #endif  // UNODB_DETAIL_WITH_STATS
-  art_policy::dump_node(os, root);
+  detail::art_policy::dump_node(os, root);
+}
+
+///
+/// unodb::db::iterator
+///
+
+// LCOV_EXCL_START
+void db::iterator::dump(std::ostream &os) const {
+  if (empty()) {
+    os << "iter::stack:: empty\n";
+    return;
+  }
+  // Create a new stack and copy everything there.  Using the new
+  // stack, print out the stack in top-bottom order.  This avoids
+  // modifications to the existing stack for the iterator.
+  auto tmp = stack_;
+  auto level = tmp.size() - 1;
+  while (!tmp.empty()) {
+    const auto &e = tmp.top();
+    const auto &np = e.node;
+    os << "iter::stack:: level = " << level << ", key_byte=0x" << std::hex
+       << std::setfill('0') << std::setw(2)
+       << static_cast<std::uint64_t>(e.key_byte) << std::dec
+       << ", child_index=0x" << std::hex << std::setfill('0') << std::setw(2)
+       << static_cast<std::uint64_t>(e.child_index) << std::dec << ", ";
+    detail::art_policy::dump_node(os, np, false /*recursive*/);
+    if (np.type() != node_type::LEAF) os << '\n';
+    tmp.pop();
+    level--;
+  }
+}
+// LCOV_EXCL_STOP
+
+// Traverse to the left-most leaf. The stack is cleared first and then
+// re-populated as we step down along the path to the left-most leaf.
+// If the tree is empty, then the result is the same as end().
+db::iterator &db::iterator::first() {
+  invalidate();  // clear the stack
+  if (UNODB_DETAIL_UNLIKELY(db_.root == nullptr)) return *this;  // empty tree.
+  auto node{db_.root};
+  return left_most_traversal(node);
+}
+
+// Traverse to the right-most leaf. The stack is cleared first and then
+// re-populated as we step down along the path to the right-most leaf.
+// If the tree is empty, then the result is the same as end().
+db::iterator &db::iterator::last() {
+  invalidate();  // clear the stack
+  if (UNODB_DETAIL_UNLIKELY(db_.root == nullptr)) return *this;  // empty tree.
+  auto node{db_.root};
+  return right_most_traversal(node);
+}
+
+// Position the iterator on the next leaf in the index.
+db::iterator &db::iterator::next() {
+  while (!empty()) {
+    auto e = top();
+    auto node{e.node};
+    UNODB_DETAIL_ASSERT(node != nullptr);
+    auto node_type = node.type();
+    if (node_type == node_type::LEAF) {
+      pop();     // pop off the leaf
+      continue;  // falls through loop if just a root leaf since stack now
+                 // empty.
+    }
+    auto *inode{node.ptr<detail::inode *>()};
+    auto nxt = inode->next(node_type,
+                           e.child_index);  // next child of that parent.
+    if (!nxt) {
+      pop();     // Nothing more for that inode.
+      continue;  // We will look for the right sibling of the parent inode.
+    }
+    // Fix up stack for new parent node state and left-most descent.
+    UNODB_DETAIL_ASSERT(nxt.has_value());  // value exists for std::optional
+    auto e2 = nxt.value();
+    pop();
+    push(e2);
+    auto child = inode->get_child(node_type, e2.child_index);  // descend
+    return left_most_traversal(child);
+  }
+  return *this;  // stack is empty, so iterator == end().
+}
+
+// Position the iterator on the prior leaf in the index.
+db::iterator &db::iterator::prior() {
+  while (!empty()) {
+    auto e = top();
+    auto node{e.node};
+    UNODB_DETAIL_ASSERT(node != nullptr);
+    auto node_type = node.type();
+    if (node_type == node_type::LEAF) {
+      pop();     // pop off the leaf
+      continue;  // falls through loop if just a root leaf since stack now
+                 // empty.
+    }
+    auto *inode{node.ptr<detail::inode *>()};
+    auto nxt = inode->prior(node_type, e.child_index);  // parent's prev child
+    if (!nxt) {
+      pop();     // Nothing more for that inode.
+      continue;  // We will look for the left sibling of the parent inode.
+    }
+    // Fix up stack for new parent node state and right-most descent.
+    UNODB_DETAIL_ASSERT(nxt.has_value());  // value exists for std::optional
+    auto e2 = nxt.value();
+    pop();
+    push(e2);
+    auto child = inode->get_child(node_type, e2.child_index);  // descend
+    return right_most_traversal(child);
+  }
+  return *this;  // stack is empty, so iterator == end().
+}
+
+// Push the given node onto the stack and traverse from the caller's
+// node to the left-most leaf under that node, pushing nodes onto the
+// stack as they are visited.
+inline db::iterator &db::iterator::left_most_traversal(detail::node_ptr node) {
+  while (true) {
+    UNODB_DETAIL_ASSERT(node != nullptr);
+    const auto node_type = node.type();
+    if (node_type == node_type::LEAF) {
+      push_leaf(node);
+      return *this;  // done
+    }
+    // recursive descent.
+    auto *const inode{node.ptr<detail::inode *>()};
+    auto e = inode->begin(node_type);  // first child of current internal node
+    push(e);                           // push the entry on the stack.
+    node = inode->get_child(node_type, e.child_index);  // get the child
+  }
+  UNODB_DETAIL_CANNOT_HAPPEN();
+}
+
+// Push the given node onto the stack and traverse from the caller's
+// node to the right-most leaf under that node, pushing nodes onto the
+// stack as they are visited.
+inline db::iterator &db::iterator::right_most_traversal(detail::node_ptr node) {
+  while (true) {
+    UNODB_DETAIL_ASSERT(node != nullptr);
+    const auto node_type = node.type();
+    if (node_type == node_type::LEAF) {
+      push_leaf(node);
+      return *this;  // done
+    }
+    // recursive descent.
+    auto *const inode{node.ptr<detail::inode *>()};
+    auto e = inode->last(node_type);  // first child of current internal node
+    push(e);                          // push the entry on the stack.
+    node = inode->get_child(node_type, e.child_index);  // get the child
+  }
+  UNODB_DETAIL_CANNOT_HAPPEN();
+}
+
+// Note: The basic seek() logic is similar to ::get() as long as the
+// search_key exists in the data.  However, the iterator is positioned
+// instead of returning the value for the key.  Life gets a lot more
+// complicated when the search_key is not in the data and we have to
+// consider the cases for both forward traversal and reverse traversal
+// from a key that is not in the data.
+db::iterator &db::iterator::seek(detail::art_key search_key, bool &match,
+                                 bool fwd) {
+  invalidate();   // invalidate the iterator (clear the stack).
+  match = false;  // unless we wind up with an exact match.
+  if (UNODB_DETAIL_UNLIKELY(db_.root == nullptr)) return *this;  // aka end()
+
+  auto node{db_.root};
+  const detail::art_key k = search_key;
+  auto remaining_key{k};
+
+  while (true) {
+    const auto node_type = node.type();
+    if (node_type == node_type::LEAF) {
+      const auto *const leaf{node.ptr<detail::leaf *>()};
+      push_leaf(node);
+      const auto cmp_ = leaf->cmp(k);
+      if (cmp_ == 0) {
+        match = true;
+        return *this;
+      }
+      if (fwd) {  // GTE semantics
+        // if search_key < leaf, use the leaf, else next().
+        return (cmp_ < 0) ? *this : next();
+      }
+      // LTE semantics: if search_key > leaf, use the leaf, else prior().
+      return (cmp_ > 0) ? *this : prior();
+    }
+    UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
+    auto *const inode{node.ptr<detail::inode *>()};   // some internal node.
+    const auto &key_prefix{inode->get_key_prefix()};  // prefix for that node.
+    const auto key_prefix_length{
+        key_prefix.length()};  // length of that prefix.
+    const auto shared_length = key_prefix.get_shared_length(
+        remaining_key);  // #of prefix bytes matched.
+    if (shared_length < key_prefix_length) {
+      // We have visited an internal node whose prefix is longer than
+      // the bytes in the key that we need to match.  To figure out
+      // whether the search key would be located before or after the
+      // current internal node, we need to compare the respective key
+      // spans lexicographically.  Since we have [shared_length] bytes
+      // in common, we know that the next byte will tell us the
+      // relative ordering of the key vs the prefix. So now we compare
+      // prefix and key and the first byte where they differ.
+      const auto cmp_ = static_cast<int>(remaining_key[shared_length]) -
+                        static_cast<int>(key_prefix[shared_length]);
+      UNODB_DETAIL_ASSERT(cmp_ != 0);
+      if (fwd) {
+        if (cmp_ < 0) {
+          // FWD and the search key is ordered before this node.  We
+          // want the left-most leaf under the node.
+          return left_most_traversal(node);
+        }
+        // FWD and the search key is ordered after this node.  Right
+        // most descent and then next().
+        return right_most_traversal(node).next();
+      }
+      // reverse traversal
+      if (cmp_ < 0) {
+        // REV and the search key is ordered before this node.  We
+        // want the preceeding key.
+        return left_most_traversal(node).prior();
+      }
+      // REV and the search key is ordered after this node.
+      return right_most_traversal(node);
+    }
+    remaining_key.shift_right(key_prefix_length);
+    auto res = inode->find_child(node_type, remaining_key[0]);
+    if (res.second == nullptr) {
+      // We are on a key byte during the descent that is not mapped by
+      // the current node.  Where we go next depends on whether we are
+      // doing forward or reverse traversal.
+      if (fwd) {
+        // FWD: Take the next child_index that is mapped in the data
+        // and then do a left-most descent to land on the key that is
+        // the immediate successor of the desired key in the data.
+        //
+        // Note: We are probing with a key byte which does not appear
+        // in our list of keys (this was verified above) so this will
+        // always be the index the first entry whose key byte is
+        // greater-than the probe value and [false] if there is no
+        // such entry.
+        //
+        // Note: [node] has not been pushed onto the stack yet!
+        auto nxt = inode->gte_key_byte(node_type, remaining_key[0]);
+        if (!nxt) {
+          // Pop entries off the stack until we find one with a
+          // right-sibling of the path we took to this node and then
+          // do a left-most descent under that right-sibling. If there
+          // is no such parent, we will wind up with an empty stack
+          // (aka the end() iterator) and return that state.
+          if (!empty()) pop();
+          while (!empty()) {
+            const auto centry = top();
+            const auto cnode{centry.node};  // possible parent from the stack
+            auto *const icnode{cnode.ptr<detail::inode *>()};
+            const auto cnxt = icnode->next(
+                cnode.type(), centry.child_index);  // right-sibling.
+            if (cnxt) {
+              auto nchild = icnode->get_child(cnode.type(), centry.child_index);
+              return left_most_traversal(nchild);
+            }
+            pop();
+          }
+          return *this;  // stack is empty (aka end()).
+        }
+        auto tmp = nxt.value();  // unwrap.
+        const auto child_index = tmp.child_index;
+        const auto child = inode->get_child(node_type, child_index);
+        push(node, tmp.key_byte, child_index);  // the path we took
+        return left_most_traversal(child);      // left most traversal
+      }
+      // REV: Take the prior child_index that is mapped and then do
+      // a right-most descent to land on the key that is the
+      // immediate precessor of the desired key in the data.
+      auto nxt = inode->lte_key_byte(node_type, remaining_key[0]);
+      if (!nxt) {
+        // Pop off the current entry until we find one with a
+        // left-sibling and then do a right-most descent under that
+        // left-sibling.  In the extreme case there is no such
+        // previous entry and we will wind up with an empty stack.
+        if (!empty()) pop();
+        while (!empty()) {
+          const auto centry = top();
+          const auto cnode{centry.node};  // possible parent from stack
+          auto *const icnode{cnode.ptr<detail::inode *>()};
+          const auto cnxt =
+              icnode->prior(cnode.type(), centry.child_index);  // left-sibling.
+          if (cnxt) {
+            auto nchild = icnode->get_child(cnode.type(), centry.child_index);
+            return right_most_traversal(nchild);
+          }
+          pop();
+        }
+        return *this;  // stack is empty (aka end()).
+      }
+      auto tmp = nxt.value();  // unwrap.
+      const auto child_index{tmp.child_index};
+      const auto child = inode->get_child(node_type, child_index);
+      push(node, tmp.key_byte, child_index);  // the path we took
+      return right_most_traversal(child);     // right most traversal
+    }
+    // Simple case. There is a child for the current key byte.
+    const auto child_index{res.first};
+    const auto *const child{res.second};
+    push(node, remaining_key[0], child_index);
+    node = *child;
+    remaining_key.shift_right(1);
+  }  // while ( true )
+  UNODB_DETAIL_CANNOT_HAPPEN();
 }
 
 }  // namespace unodb

--- a/art.hpp
+++ b/art.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_ART_HPP
 #define UNODB_DETAIL_ART_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>
 // IWYU pragma: no_include <ostream>
@@ -12,33 +20,68 @@
 #include <iosfwd>  // IWYU pragma: keep
 #include <limits>
 #include <optional>
+#include <stack>
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
+#include "art_internal_impl.hpp"
 #include "assert.hpp"
+#include "in_fake_critical_section.hpp"
 #include "node_type.hpp"
 
 namespace unodb {
 
 namespace detail {
 
-struct node_header;
+class inode;
 
-template <class, template <class> class, class, class, template <class> class,
-          template <class, class> class>
-struct basic_art_policy;  // IWYU pragma: keep
+class inode_4;
+class inode_16;
+class inode_48;
+class inode_256;
+
+struct [[nodiscard]] node_header {};
+
+static_assert(std::is_empty_v<node_header>);
+
+template <class,                   // Db
+          template <class> class,  // CriticalSectionPolicy
+          class,                   // Fake lock implementation
+          class,                   // Fake read_critical_section implementation
+          class,                   // NodePtr
+          class,                   // INodeDefs
+          template <class> class,  // INodeReclamator
+          template <class, class> class>  // LeafReclamator
+struct basic_art_policy;                  // IWYU pragma: keep
 
 using node_ptr = basic_node_ptr<node_header>;
 
-template <class Header, class Db>
-[[nodiscard]] auto make_db_leaf_ptr(art_key, value_view, Db &);
-
 struct impl_helpers;
+
+using inode_defs = unodb::detail::basic_inode_def<inode, inode_4, inode_16,
+                                                  inode_48, inode_256>;
+
+template <class INode>
+using db_inode_deleter =
+    unodb::detail::basic_db_inode_deleter<INode, unodb::db>;
+
+using art_policy = unodb::detail::basic_art_policy<
+    unodb::db, unodb::in_fake_critical_section, unodb::fake_lock,
+    unodb::fake_read_critical_section, unodb::detail::node_ptr, inode_defs,
+    db_inode_deleter, unodb::detail::basic_db_leaf_deleter>;
+
+using inode_base = unodb::detail::basic_inode_impl<art_policy>;
+
+using leaf = unodb::detail::basic_leaf<unodb::detail::node_header>;
+
+class inode : public inode_base {};
 
 }  // namespace detail
 
+// A non-thread-safe implementation of the Adaptive Radix Tree (ART).
 class db final {
  public:
+  using value_view = unodb::value_view;
   using get_result = std::optional<value_view>;
 
   // Creation and destruction
@@ -47,25 +90,314 @@ class db final {
   ~db() noexcept;
 
   // TODO(laurynas): implement copy and move operations
-  db(const db &) = delete;
-  db(db &&) = delete;
-  db &operator=(const db &) = delete;
-  db &operator=(db &&) = delete;
+  db(const db&) = delete;
+  db(db&&) = delete;
+  db& operator=(const db&) = delete;
+  db& operator=(db&&) = delete;
 
-  // Querying
+  // Querying for a value associated with a key.
   [[nodiscard, gnu::pure]] get_result get(key search_key) const noexcept;
 
+  // Return true iff the index is empty.
   [[nodiscard, gnu::pure]] auto empty() const noexcept {
     return root == nullptr;
   }
 
-  // Modifying
-  // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
+  // Insert a value under a key iff there is no entry for that key.
+  //
+  // Note: Cannot be called during stack unwinding with
+  // std::uncaught_exceptions() > 0
+  //
+  // @return true iff the key value pair was inserted.
   [[nodiscard]] bool insert(key insert_key, value_view v);
 
+  // Remove the entry associated with the key.
+  //
+  // @return true if the delete was successful (i.e. the key was found
+  // in the tree and the associated index entry was removed).
   [[nodiscard]] bool remove(key remove_key);
 
+  // Removes all entries in the index.
   void clear() noexcept;
+
+  ///
+  /// iterator (the iterator is an internal API, the public API is scan()).
+  ///
+  //
+  // Note: The iterator is backed by a std::stack. This means that the
+  // iterator methods accessing the stack can not be declared as
+  // [[noexcept]].
+  class iterator {
+    friend class db;
+    template <class>
+    friend class visitor;
+
+    // The stack is made up of tuples containing the node pointer, the
+    // key_byte, and the child_index.
+    using stack_entry = detail::inode_base::iter_result;
+
+   protected:
+    // Construct an empty iterator (one that is logically not
+    // positioned on anything and which will report !valid()).
+    explicit iterator(db& tree) : db_(tree) {}
+
+    // iterator is not flyweight. disallow copy and move.
+    iterator(const iterator&) = delete;
+    iterator(iterator&&) = delete;
+    iterator& operator=(const iterator&) = delete;
+    // iterator& operator=(iterator&&) = delete; // test_only_iterator()
+
+   public:  // EXPOSED TO THE TESTS
+    // Position the iterator on the first entry in the index.
+    iterator& first();
+
+    // Advance the iterator to next entry in the index.
+    iterator& next();
+
+    // Position the iterator on the last entry in the index, which can
+    // be used to initiate a reverse traversal.
+    iterator& last();
+
+    // Position the iterator on the previous entry in the index.
+    iterator& prior();
+
+    // Position the iterator on, before, or after the caller's key.
+    // If the iterator can not be positioned, it will be invalidated.
+    // For example, if [fwd:=true] and the [search_key] is GT any key
+    // in the index then the iterator will be invalidated since there
+    // is no index entry greater than the search key.  Likewise, if
+    // [fwd:=false] and the [search_key] is LT any key in the index,
+    // then the iterator will be invalidated since there is no index
+    // entry LT the search key.
+    //
+    // @param search_key The internal key used to position the iterator.
+    //
+    // @param match Will be set to true iff the search key is an exact
+    // match in the index data.  Otherwise, the match is not exact and
+    // the iterator is positioned either before or after the
+    // search_key.
+    //
+    // @param fwd When true, the iterator will be positioned first
+    // entry which orders GTE the search_key and invalidated if there
+    // is no such entry.  Otherwise, the iterator will be positioned
+    // on the last key which orders LTE the search_key and invalidated
+    // if there is no such entry.
+    iterator& seek(detail::art_key search_key, bool& match, bool fwd = true);
+
+    // Iff the iterator is positioned on an index entry, then returns
+    // the decoded key associated with that index entry.
+    [[nodiscard]] std::optional<const key> get_key();
+
+    // Iff the iterator is positioned on an index entry, then returns
+    // the value associated with that index entry.
+    [[nodiscard, gnu::pure]] std::optional<const value_view> get_val() const;
+
+    // Debugging
+    [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os) const;
+
+    // Return true unless the stack is empty (exposed to tests).
+    [[nodiscard]] bool valid() const { return !stack_.empty(); }
+
+   protected:
+    // Push the given node onto the stack and traverse from the
+    // caller's node to the left-most leaf under that node, pushing
+    // nodes onto the stack as they are visited.
+    iterator& left_most_traversal(detail::node_ptr node);
+
+    // Descend from the current state of the stack to the right most
+    // child leaf, updating the state of the iterator during the
+    // descent.
+    iterator& right_most_traversal(detail::node_ptr node);
+
+    // Compare the given key (e.g., the to_key) to the current key in
+    // the internal buffer.
+    //
+    // @return -1, 0, or 1 if this key is LT, EQ, or GT the other key.
+    [[nodiscard]] int cmp(const detail::art_key& akey) const {
+      // TODO(thompsonbry) Explore a cheaper way to handle the
+      // exclusive bound case when developing variable length key
+      // support based on the maintained key buffer.
+      UNODB_DETAIL_ASSERT(!stack_.empty());
+      auto& node = stack_.top().node;
+      UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
+      const auto* const leaf{node.ptr<detail::leaf*>()};
+      return leaf->get_key().cmp(akey);
+    }
+
+    //
+    // stack access methods.
+    //
+
+    // Return true iff the stack is empty.
+    [[nodiscard]] bool empty() const { return stack_.empty(); }
+
+    // Push an entry onto the stack.
+    void push(const stack_entry& e) { stack_.push(e); }
+
+    // Push an entry onto the stack.
+    //
+    // TODO(thompsonbry) handle variable length keys here.
+    void push(detail::node_ptr node, std::byte key_byte,
+              std::uint8_t child_index) {
+      stack_.push({node, key_byte, child_index});
+    }
+
+    // Push a leaf onto the stack.
+    void push_leaf(detail::node_ptr aleaf) {
+      // Mock up a stack entry for the leaf. The [key] and
+      // [child_index] are ignored for a leaf.
+      push(aleaf, static_cast<std::byte>(0xFFU),
+           static_cast<std::uint8_t>(0xFFU));
+    }
+
+    // Pop an entry from the stack.
+    //
+    // TODO(thompsonbry) handle variable length keys here.
+    void pop() { stack_.pop(); }
+
+    // Return the entry (if any) on the top of the stack.
+    [[nodiscard]] stack_entry& top() { return stack_.top(); }
+
+    // Return the node on the top of the stack and nullptr if the
+    // stack is empty (similar to top(), but handles an empty stack).
+    [[nodiscard]] detail::node_ptr current_node() {
+      return stack_.empty() ? detail::node_ptr(nullptr) : stack_.top().node;
+    }
+
+   private:
+    // invalidate the iterator (pops everything off of the stack).
+    iterator& invalidate() {
+      while (!stack_.empty()) stack_.pop();  // clear the stack
+      return *this;
+    }
+
+    // The outer db instance.
+    db& db_;
+
+    // A stack reflecting the parent path from the root of the tree to
+    // the current leaf.  An empty stack corresponds to a logically
+    // empty iterator and the iterator will report !valid().  The
+    // iterator for an empty tree is an empty stack.
+    //
+    // The stack is made up of (node_ptr, key, child_index) entries
+    // defined by [iter_result].
+    //
+    // The [node_ptr] is never [nullptr] and points to the internal
+    // node or leaf for that step in the path from the root to some
+    // leaf.  For the bottom of the stack, [node_ptr] is the root.
+    // For the top of the stack, [node_ptr] is the current leaf. In
+    // the degenerate case where the tree is a single root leaf, then
+    // the stack contains just that leaf.
+    //
+    // The [key] is the [std::byte] along which the path descends from
+    // that [node_ptr].  The [key] has no meaning for a leaf.  The key
+    // byte may be used to reconstruct the full key (along with any
+    // prefix bytes in the nodes along the path).  The key byte is
+    // tracked to avoid having to search the keys of some node types
+    // (N48) when the [child_index] does not directly imply the key
+    // byte.
+    //
+    // The [child_index] is the [std::uint8_t] index position in the
+    // parent at which the [child_ptr] was found.  The [child_index]
+    // has no meaning for a leaf.  In the special case of N48, the
+    // [child_index] is the index into the [child_indexes[]].  For all
+    // other internal node types, the [child_index] is a direct index
+    // into the [children[]].  When finding the successor (or
+    // predecessor) the [child_index] needs to be interpreted
+    // according to the node type.  For N4 and N16, you just look at
+    // the next slot in the children[] to find the successor.  For
+    // N256, you look at the next non-null slot in the children[].
+    // N48 is the oddest of the node types.  For N48, you have to look
+    // at the child_indexes[], find the next mapped key value greater
+    // than the current one, and then look at its entry in the
+    // children[].
+    std::stack<stack_entry> stack_{};
+
+    // A buffer into which visited keys are decoded and materialized
+    // by get_key().
+    //
+    // Note: The internal key is a sequence of unsigned bytes having
+    // the appropriate lexicographic ordering.  The internal key needs
+    // to be decoded to the external key.
+    //
+    // FIXME The current implementation stores the entire key in the
+    // leaf. This works fine for simple primitive keys.  However, it
+    // needs to be modified when the implementation is modified to
+    // support variable length keys. In that situation, the full
+    // internal key needs to be constructed using the [key] byte from
+    // the path stack plus the prefix bytes from the internal nodes
+    // along that path.
+    key key_{};
+  };  // class iterator
+
+  //
+  // end of the iterator API, which is an internal API.
+  //
+
+ public:
+  ///
+  /// public scan API
+  ///
+
+  // Note: The scan() interface is public.  The iterator and the
+  // methods to obtain an iterator are protected (except for tests).
+  // This encapsulation makes it easier to define methods which
+  // operate on external keys (scan()) and those which operate on
+  // internal keys (seek() and the iterator). It also makes life
+  // easier for mutex_db since scan() can take the lock.
+
+  // Scan the tree, applying the caller's lambda to each visited leaf.
+  //
+  // @param fn A function f(unodb::visitor<unodb::db::iterator>&)
+  // returning [bool:halt].  The traversal will halt if the function
+  // returns [true].
+  //
+  // @param fwd When [true] perform a forward scan, otherwise perform
+  // a reverse scan.
+  template <typename FN>
+  inline void scan(FN fn, bool fwd = true);
+
+  // Scan in the indicated direction, applying the caller's lambda to
+  // each visited leaf.
+  //
+  // @param from_key is an inclusive lower bound for the starting point
+  // of the scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::db::iterator>&)
+  // returning [bool:halt].  The traversal will halt if the function
+  // returns [true].
+  //
+  // @param fwd When [true] perform a forward scan, otherwise perform
+  // a reverse scan.
+  template <typename FN>
+  inline void scan_from(key from_key, FN fn, bool fwd = true);
+
+  // Scan a half-open key range, applying the caller's lambda to each
+  // visited leaf.  The scan will proceed in lexicographic order iff
+  // from_key is less than to_key and in reverse lexicographic order iff
+  // to_key is less than from_key.  When from_key < to_key, the scan will
+  // visit all index entries in the half-open range [from_key,to_key) in
+  // forward order.  Otherwise the scan will visit all index entries
+  // in the half-open range (from_key,to_key] in reverse order.
+  //
+  // @param from_key is an inclusive bound for the starting point of
+  // the scan.
+  //
+  // @param to_key is an exclusive bound for the ending point of the
+  // scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::db::iterator>&)
+  // returning [bool:halt].  The traversal will halt if the function
+  // returns [true].
+  template <typename FN>
+  inline void scan_range(key from_key, key to_key, FN fn);
+
+  //
+  // TEST ONLY METHODS
+  //
+
+  // Used to write the iterator tests.
+  auto test_only_iterator() { return iterator(*this); }
 
   // Stats
 
@@ -120,12 +452,12 @@ class db final {
 
   // Public utils
   [[nodiscard, gnu::const]] static constexpr auto key_found(
-      const get_result &result) noexcept {
+      const get_result& result) noexcept {
     return static_cast<bool>(result);
   }
 
   // Debugging
-  [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream &os) const;
+  [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os) const;
 
  private:
   void delete_root_subtree() noexcept;
@@ -190,13 +522,19 @@ class db final {
 
   friend auto detail::make_db_leaf_ptr<detail::node_header, db>(detail::art_key,
                                                                 value_view,
-                                                                db &);
+                                                                db&);
 
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
 
-  template <class, template <class> class, class, class, template <class> class,
-            template <class, class> class>
+  template <class,                   // Db
+            template <class> class,  // CriticalSectionPolicy
+            class,                   // Fake lock implementation
+            class,  // Fake read_critical_section implementation
+            class,  // NodePtr
+            class,  // INodeDefs
+            template <class> class,         // INodeReclamator
+            template <class, class> class>  // LeadReclamator
   friend struct detail::basic_art_policy;
 
   template <class, class>
@@ -204,6 +542,127 @@ class db final {
 
   friend struct detail::impl_helpers;
 };
+
+///
+/// ART Iterator Implementation
+///
+
+inline std::optional<const key> db::iterator::get_key() {
+  // FIXME Eventually this will need to use the stack to reconstruct
+  // the key from the path from the root to this leaf.  Right now it
+  // is relying on the fact that simple fixed width keys are stored
+  // directly in the leaves.
+  if (!valid()) return {};  // not positioned on anything.
+  const auto& e = stack_.top();
+  const auto& node = e.node;
+  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);  // On a leaf.
+  const auto* const leaf{node.ptr<detail::leaf*>()};    // current leaf.
+  key_ = leaf->get_key().decode();  // decode key into buffer.
+  return key_;  // return pointer to the internal key buffer.
+}
+
+inline std::optional<const value_view> db::iterator::get_val() const {
+  if (!valid()) return {};  // not positioned on anything.
+  const auto& e = stack_.top();
+  const auto& node = e.node;
+  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);  // On a leaf.
+  const auto* const leaf{node.ptr<detail::leaf*>()};    // current leaf.
+  return leaf->get_value_view();
+}
+
+///
+/// ART scan implementations.
+///
+
+template <typename FN>
+inline void db::scan(FN fn, bool fwd) {
+  if (fwd) {
+    iterator it(*this);
+    it.first();
+    visitor<db::iterator> v{it};
+    while (it.valid()) {
+      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      it.next();
+    }
+  } else {
+    iterator it(*this);
+    it.last();
+    visitor<db::iterator> v{it};
+    while (it.valid()) {
+      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      it.prior();
+    }
+  }
+}
+
+template <typename FN>
+inline void db::scan_from(key from_key, FN fn, bool fwd) {
+  const detail::art_key from_key_{from_key};  // convert to internal key
+  bool match{};
+  if (fwd) {
+    iterator it(*this);
+    it.seek(from_key_, match, true /*fwd*/);
+    visitor<db::iterator> v{it};
+    while (it.valid()) {
+      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      it.next();
+    }
+  } else {
+    iterator it(*this);
+    it.seek(from_key_, match, false /*fwd*/);
+    visitor<db::iterator> v{it};
+    while (it.valid()) {
+      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      it.prior();
+    }
+  }
+}
+
+template <typename FN>
+inline void db::scan_range(key from_key, const key to_key, FN fn) {
+  constexpr bool debug = false;               // set true to debug scan.
+  const detail::art_key from_key_{from_key};  // convert to internal key
+  const detail::art_key to_key_{to_key};      // convert to internal key
+  const auto ret = from_key_.cmp(to_key_);    // compare the internal keys
+  const bool fwd{ret < 0};                    // from_key is less than to_key
+  if (ret == 0) return;                       // NOP
+  bool match{};
+  if (fwd) {
+    iterator it(*this);
+    it.seek(from_key_, match, true /*fwd*/);
+    if constexpr (debug) {
+      std::cerr << "scan_range:: fwd"
+                << ", from_key=" << from_key << ", to_key=" << to_key << "\n";
+      it.dump(std::cerr);
+    }
+    visitor<db::iterator> v{it};
+    while (it.valid() && it.cmp(to_key_) < 0) {
+      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      it.next();
+      if constexpr (debug) {
+        std::cerr << "scan_range:: next()\n";
+        it.dump(std::cerr);
+      }
+    }
+  } else {  // reverse traversal.
+    iterator it(*this);
+    it.seek(from_key_, match, false /*fwd*/);
+    if constexpr (debug) {
+      std::cerr << "scan_range:: rev"
+                << ", from_key=" << from_key << ", to_key=" << to_key << "\n";
+      it.dump(std::cerr);
+    }
+    visitor<db::iterator> v{it};
+    while (it.valid() && it.cmp(to_key_) > 0) {
+      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      it.prior();
+      if constexpr (debug) {
+        std::cerr << "scan_range:: prior()\n";
+        it.dump(std::cerr);
+      }
+    }
+  }
+}
 
 }  // namespace unodb
 

--- a/art_common.cpp
+++ b/art_common.cpp
@@ -1,6 +1,14 @@
 // Copyright 2021-2022 Laurynas Biveinis
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include "art_common.hpp"
 

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_ART_COMMON_HPP
 #define UNODB_DETAIL_ART_COMMON_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>
 

--- a/art_internal.cpp
+++ b/art_internal.cpp
@@ -1,6 +1,14 @@
 // Copyright 2021-2022 Laurynas Biveinis
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include "art_internal.hpp"
 

--- a/assert.hpp
+++ b/assert.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_ASSERT_HPP
 #define UNODB_DETAIL_ASSERT_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <iostream>
 #include <sstream>

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <memory>
 #include <thread>

--- a/benchmark/micro_benchmark_key_prefix.cpp
+++ b/benchmark/micro_benchmark_key_prefix.cpp
@@ -1,5 +1,13 @@
 // Copyright 2020-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_mutex.cpp
+++ b/benchmark/micro_benchmark_mutex.cpp
@@ -1,5 +1,13 @@
 // Copyright 2019-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n16.cpp
+++ b/benchmark/micro_benchmark_n16.cpp
@@ -1,5 +1,13 @@
 // Copyright 2020-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n256.cpp
+++ b/benchmark/micro_benchmark_n256.cpp
@@ -1,5 +1,13 @@
 // Copyright 2020-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n48.cpp
+++ b/benchmark/micro_benchmark_n48.cpp
@@ -1,5 +1,13 @@
 // Copyright 2020-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <array>
 #include <cstddef>

--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -1,5 +1,13 @@
 // Copyright 2019-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -1,5 +1,13 @@
 // Copyright 2020-2022 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "micro_benchmark_utils.hpp"

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>
 

--- a/heap.hpp
+++ b/heap.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_HEAP_HPP
 #define UNODB_DETAIL_HEAP_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <algorithm>
 #ifndef NDEBUG

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_MUTEX_ART_HPP
 #define UNODB_DETAIL_MUTEX_ART_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <mutex>
 #include <utility>
@@ -14,6 +22,8 @@ namespace unodb {
 
 class mutex_db final {
  public:
+  using value_view = unodb::value_view;
+
   // If the search key was found, that is, the first pair member has a value,
   // then the second member is a locked tree mutex which must be released ASAP
   // after reading the first pair member. Otherwise, the second member is
@@ -55,6 +65,77 @@ class mutex_db final {
     const std::lock_guard guard{mutex};
     db_.clear();
   }
+
+  //
+  // scan API.
+  //
+
+  using iterator = unodb::db::iterator;
+
+  // Scan the tree, applying the caller's lambda to each visited leaf.
+  // The tree remains locked for the duration of the scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::mutex_db::iterator>&)
+  // returning [bool::halt].  The traversal will halt if the function
+  // returns [true].
+  //
+  // @param fwd When [true] perform a forward scan, otherwise perform
+  // a reverse scan.
+  template <typename FN>
+  inline void scan(FN fn, bool fwd = true) noexcept {
+    const std::lock_guard guard{mutex};
+    db_.scan(fn, fwd);
+  }
+
+  // Scan in the indicated direction, applying the caller's lambda to
+  // each visited leaf.  The tree remains locked for the duration of
+  // the scan.
+  //
+  // @param fromKey is an inclusive lower bound for the starting point
+  // of the scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::mutex_db::iterator>&)
+  // returning [bool::halt].  The traversal will halt if the function
+  // returns [true].
+  //
+  // @param fwd When [true] perform a forward scan, otherwise perform
+  // a reverse scan.
+  template <typename FN>
+  inline void scan_from(const key fromKey, FN fn, bool fwd = true) noexcept {
+    const std::lock_guard guard{mutex};
+    db_.scan_from(fromKey, fn, fwd);
+  }
+
+  // Scan a half-open key range, applying the caller's lambda to each
+  // visited leaf.  The tree remains locked for the duration of the
+  // scan.  The scan will proceed in lexicographic order iff fromKey
+  // is less than toKey and in reverse lexicographic order iff toKey
+  // is less than fromKey.  When fromKey < toKey, the scan will visit
+  // all index entries in the half-open range [fromKey,toKey) in
+  // forward order.  Otherwise the scan will visit all index entries
+  // in the half-open range (fromKey,toKey] in reverse order.
+  //
+  // @param fromKey is an inclusive bound for the starting point of
+  // the scan.
+  //
+  // @param toKey is an exclusive bound for the ending point of the
+  // scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::mutex_db::iterator>&)
+  // returning [bool::halt].  The traversal will halt if the function
+  // returns [true].
+  template <typename FN>
+  inline void scan_range(const key fromKey, const key toKey, FN fn) noexcept {
+    const std::lock_guard guard{mutex};
+    db_.scan_range(fromKey, toKey, fn);
+  }
+
+  //
+  // TEST ONLY METHODS
+  //
+
+  // Used to write the iterator tests.
+  auto test_only_iterator() noexcept { return db_.test_only_iterator(); }
 
   // Stats
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_NODE_TYPE_HPP
 #define UNODB_DETAIL_NODE_TYPE_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <array>
 #include <cstddef>

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_OLC_ART_HPP
 #define UNODB_DETAIL_OLC_ART_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>
 // IWYU pragma: no_include <ostream>
@@ -13,10 +21,12 @@
 #include <cstdint>
 #include <iosfwd>  // IWYU pragma: keep
 #include <optional>
+#include <stack>
 #include <tuple>
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
+#include "art_internal_impl.hpp"
 #include "assert.hpp"
 #include "node_type.hpp"
 #include "optimistic_lock.hpp"
@@ -29,11 +39,33 @@ class olc_db;
 
 namespace detail {
 
-template <class, template <class> class, class, class, template <class> class,
-          template <class, class> class>
-struct basic_art_policy;  // IWYU pragma: keep
+// The OLC header contains an [optimistic_lock].
+struct [[nodiscard]] olc_node_header {
+  // Return a reference to the [optimistic_lock].
+  [[nodiscard]] constexpr optimistic_lock& lock() const noexcept {
+    return m_lock;
+  }
 
-struct olc_node_header;
+#ifndef NDEBUG
+  static void check_on_dealloc(const void* ptr) noexcept {
+    static_cast<const olc_node_header*>(ptr)->m_lock.check_on_dealloc();
+  }
+#endif
+
+ private:
+  mutable optimistic_lock m_lock;  // The lock.
+};
+static_assert(std::is_standard_layout_v<olc_node_header>);
+
+class olc_inode;
+class olc_inode_4;
+class olc_inode_16;
+class olc_inode_48;
+class olc_inode_256;
+
+using olc_inode_defs =
+    unodb::detail::basic_inode_def<olc_inode, olc_inode_4, olc_inode_16,
+                                   olc_inode_48, olc_inode_256>;
 
 using olc_node_ptr = basic_node_ptr<olc_node_header>;
 
@@ -44,9 +76,27 @@ template <class, class>
 class db_leaf_qsbr_deleter;  // IWYU pragma: keep
 
 template <class Header, class Db>
-[[nodiscard]] auto make_db_leaf_ptr(art_key, value_view, Db &);
+[[nodiscard]] auto make_db_leaf_ptr(art_key, value_view, Db&);
 
 struct olc_impl_helpers;
+
+using olc_art_policy = unodb::detail::basic_art_policy<
+    unodb::olc_db, unodb::in_critical_section, unodb::optimistic_lock,
+    unodb::optimistic_lock::read_critical_section, unodb::detail::olc_node_ptr,
+    olc_inode_defs, unodb::detail::db_inode_qsbr_deleter,
+    unodb::detail::db_leaf_qsbr_deleter>;
+
+using olc_db_leaf_unique_ptr = olc_art_policy::db_leaf_unique_ptr;
+
+using olc_inode_base = unodb::detail::basic_inode_impl<olc_art_policy>;
+
+class olc_inode : public olc_inode_base {};
+
+using olc_leaf = unodb::detail::olc_art_policy::leaf_type;
+
+//
+//
+//
 
 template <class AtomicArray>
 using non_atomic_array =
@@ -54,7 +104,7 @@ using non_atomic_array =
                std::tuple_size<AtomicArray>::value>;
 
 template <class T>
-inline non_atomic_array<T> copy_atomic_to_nonatomic(T &atomic_array) noexcept {
+inline non_atomic_array<T> copy_atomic_to_nonatomic(T& atomic_array) noexcept {
   non_atomic_array<T> result;
   for (typename decltype(result)::size_type i = 0; i < result.size(); ++i) {
     result[i] = atomic_array[i].load(std::memory_order_relaxed);
@@ -64,6 +114,11 @@ inline non_atomic_array<T> copy_atomic_to_nonatomic(T &atomic_array) noexcept {
 
 using olc_leaf_unique_ptr =
     detail::basic_db_leaf_unique_ptr<detail::olc_node_header, olc_db>;
+
+// Declare internal methods to quiet compiler warnings.
+void create_leaf_if_needed(olc_db_leaf_unique_ptr& cached_leaf,
+                           unodb::detail::art_key k, unodb::value_view v,
+                           unodb::olc_db& db_instance);
 
 }  // namespace detail
 
@@ -77,26 +132,477 @@ using qsbr_value_view = qsbr_ptr_span<const std::byte>;
 // deleted node reclamation, Quiescent State-Based Reclamation is used.
 class olc_db final {
  public:
-  using get_result = std::optional<qsbr_value_view>;
+  using value_view = unodb::qsbr_value_view;
+  using get_result = std::optional<value_view>;
 
   // Creation and destruction
   olc_db() noexcept = default;
 
   ~olc_db() noexcept;
 
-  // Querying
+  // Querying for a value given a key.
   [[nodiscard]] get_result get(key search_key) const noexcept;
 
+  // Return true iff the tree is empty (no root leaf).
   [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
 
-  // Modifying
-  // Cannot be called during stack unwinding with std::uncaught_exceptions() > 0
-  [[nodiscard]] bool insert(key insert_key, value_view v);
+  // Insert a value under a key iff there is no entry for that key.
+  //
+  // Note: Cannot be called during stack unwinding with
+  // std::uncaught_exceptions() > 0
+  //
+  // @return true if the key value pair was inserted.
+  //
+  // FIXME There should be a lambda variant of this to handle
+  // conflicts and support upsert or delete-upsert semantics. This
+  // would call the caller's lambda once the method was positioned on
+  // the leaf.  The caller could then update the value or perhaps
+  // delete the entry under the key.
+  [[nodiscard]] bool insert(key insert_key, unodb::value_view v);
 
+  // Remove the entry associated with the key.
+  //
+  // @return true if the delete was successful (i.e. the key was found
+  // in the tree and the associated index entry was removed).
   [[nodiscard]] bool remove(key remove_key);
 
-  // Only legal in single-threaded context, as destructor
+  // Removes all entries in the index.
+  //
+  // Note: Only legal in single-threaded context, as destructor
   void clear() noexcept;
+
+  ///
+  /// iterator (the iterator is an internal API, the public API is scan()).
+  ///
+
+  // The OLC scan() logic tracks the version tag (a read_critical_section)
+  // for each node in the stack.  This information is required because the
+  // iter_result tuples already contain physical information read from
+  // nodes which may have been invalidated by subsequent mutations.  The
+  // scan is built on iterator methods for seek(), next(), prior(), etc.
+  // These methods must restart (rebuilding the stack and redoing the work)
+  // if they encounter a version tag for an element on the stack which is
+  // no longer valid.  Restart works by performing a seek() to the key for
+  // the leaf on the bottom of the stack.  Restarts can be full (from the
+  // root) or partial (from the first element in the stack which was not
+  // invalidated by the structural modification).
+  //
+  // During scan(), the iterator seek()s to some key and then invokes the
+  // caller's lambda passing a reference to a visitor object.  That visitor
+  // allows the caller to access the key and/or value associated with the
+  // leaf.  If the leaf is concurrently deleted from the structure, the
+  // visitor relies on epoch protection to return the data from the now
+  // invalidated leaf.  This is still the state that the caller would have
+  // observed without the concurrent structural modification.  When next()
+  // is called, it will discover that the leaf on the bottom of the stack
+  // is not valid (it is marked as obsolete) and it will have to restart by
+  // seek() to the key for that leaf and then invoking next() if the key
+  // still exists and otherwise we should already be on the successor of
+  // that leaf.
+  //
+  // Note: The OLC thread safety mechanisms permit concurrent non-atomic
+  // (multi-work) mutations to be applied to nodes.  This means that a
+  // thread can read junk in the middle of some reorganization of a node
+  // (e.g., the keys or children are being reordered to maintain an
+  // invariant for I16).  To protect against reading such junk, the thread
+  // reads the version tag before and after it accesses data in the node
+  // and restarts if the version information has changed.  The thread must
+  // not act on information that it had read until it verifies that the
+  // version tag remained unchanged across the read operation.
+  //
+  // Note: The iterator is backed by a std::stack. This means that the
+  // iterator methods accessing the stack can not be declared as
+  // [[noexcept]].
+  class iterator {
+    friend class olc_db;
+    template <class>
+    friend class visitor;
+
+    // The [node_ptr] is never [nullptr] and points to the internal
+    // node or leaf for that step in the path from the root to some
+    // leaf.  For the bottom of the stack, [node_ptr] is the root.
+    // For the top of the stack, [node_ptr] is the current leaf. In
+    // the degenerate case where the tree is a single root leaf, then
+    // the stack contains just that leaf.
+    //
+    // The [key] is the [std::byte] along which the path descends from
+    // that [node_ptr].  The [key] has no meaning for a leaf.  The key
+    // byte may be used to reconstruct the full key (along with any
+    // prefix bytes in the nodes along the path).  The key byte is
+    // tracked to avoid having to search the keys of some node types
+    // (N48) when the [child_index] does not directly imply the key
+    // byte.
+    //
+    // The [child_index] is the [std::uint8_t] index position in the
+    // parent at which the [child_ptr] was found.  The [child_index]
+    // has no meaning for a leaf.  In the special case of N48, the
+    // [child_index] is the index into the [child_indexes[]].  For all
+    // other internal node types, the [child_index] is a direct index
+    // into the [children[]].  When finding the successor (or
+    // predecessor) the [child_index] needs to be interpreted
+    // according to the node type.  For N4 and N16, you just look at
+    // the next slot in the children[] to find the successor.  For
+    // N256, you look at the next non-null slot in the children[].
+    // N48 is the oddest of the node types.  For N48, you have to look
+    // at the child_indexes[], find the next mapped key value greater
+    // than the current one, and then look at its entry in the
+    // children[].
+    //
+    // The [tag] is the [version_tag_type] from the read_critical_section
+    // and contains the version information that must be valid to use
+    // the [key_byte] and [child_index] data read from the [node].
+    // The version tag is cached when when those data are read from
+    // the node along with the [key_byte] and [child_index] values
+    // that were read.
+    struct stack_entry : public detail::olc_inode_base::iter_result {
+      // The version tag invariant for the node.
+      //
+      // Note: This is just the data for the version tag and not the
+      // read_critical_section (RCS).  Moving the RCS onto the stack
+      // creates problems in the while(...) loops that use parent and
+      // node lock chaining since the RCS in the loop is invalid as
+      // soon as it is moved onto the stack.  Hence, this is just the
+      // data and the while loops continue to use the normal OLC
+      // pattern for lock chaining.
+      version_tag_type version;
+
+      [[nodiscard]] inline bool operator==(
+          const stack_entry& other) const noexcept {
+        return node == other.node && key_byte == other.key_byte &&
+               child_index == other.child_index && version == other.version;
+      }
+    };
+
+   protected:
+    // Construct an empty iterator (one that is logically not
+    // positioned on anything and which will report !valid()).
+    explicit iterator(olc_db& tree) : db_(tree) {}
+
+    // iterator is not flyweight. disallow copy and move.
+    iterator(const iterator&) = delete;
+    iterator(iterator&&) = delete;
+    iterator& operator=(const iterator&) = delete;
+    // iterator& operator=(iterator&&) = delete; // test_only_iterator()
+
+   public:  // EXPOSED TO THE TESTS
+    // Position the iterator on the first entry in the index.
+    iterator& first();
+
+    // Advance the iterator to next entry in the index.
+    iterator& next();
+
+    // Position the iterator on the last entry in the index, which can
+    // be used to initiate a reverse traversal.
+    iterator& last();
+
+    // Position the iterator on the previous entry in the index.
+    iterator& prior();
+
+    // Position the iterator on, before, or after the caller's key.
+    // If the iterator can not be positioned, it will be invalidated.
+    // For example, if [fwd:=true] and the [search_key] is GT any key
+    // in the index then the iterator will be invalidated since there
+    // is no index entry greater than the search key.  Likewise, if
+    // [fwd:=false] and the [search_key] is LT any key in the index,
+    // then the iterator will be invalidated since there is no index
+    // entry LT the search key.
+    //
+    // @param search_key The internal key used to position the iterator.
+    //
+    // @param match Will be set to true iff the search key is an exact
+    // match in the index data.  Otherwise, the match is not exact and
+    // the iterator is positioned either before or after the
+    // search_key.
+    //
+    // @param fwd When true, the iterator will be positioned first
+    // entry which orders GTE the search_key and will be !valid() if
+    // there is no such entry.  Otherwise, the iterator will be
+    // positioned on the last key which orders LTE the search_key and
+    // !valid() if there is no such entry.
+    iterator& seek(detail::art_key search_key, bool& match, bool fwd = true);
+
+    // Iff the iterator is positioned on an index entry, then returns
+    // the decoded key associated with that index entry.
+    [[nodiscard]] std::optional<const key> get_key();
+
+    // Iff the iterator is positioned on an index entry, then returns
+    // the value associated with that index entry.
+    [[nodiscard, gnu::pure]] std::optional<const qsbr_value_view> get_val()
+        const;
+
+    // Debugging
+    [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os) const;
+
+    // Return true unless the stack is empty (exposed to tests)
+    [[nodiscard]] bool valid() const { return !stack_.empty(); }
+
+   protected:
+    // Compare the given key (e.g., the to_key) to the current key in
+    // the internal buffer.
+    //
+    // @return -1, 0, or 1 if this key is LT, EQ, or GT the other key.
+    [[nodiscard]] int cmp(const detail::art_key& akey) const;
+
+    //
+    // stack access methods.
+    //
+
+    // Return true iff the stack is empty.
+    [[nodiscard]] bool empty() const { return stack_.empty(); }
+
+    // Push an entry onto the stack.
+    //
+    // TODO(thompsonbry) handle variable length keys here.
+    void push(const detail::olc_inode_base::iter_result& e,
+              const optimistic_lock::read_critical_section& rcs) {
+      push(e.node, e.key_byte, e.child_index, rcs);
+    }
+
+    // Push an entry onto the stack.
+    void push(detail::olc_node_ptr node, std::byte key_byte,
+              std::uint8_t child_index,
+              const optimistic_lock::read_critical_section& rcs) {
+      stack_.push({{node, key_byte, child_index}, rcs.get()});
+    }
+
+    // Push a leaf onto the stack.
+    void push_leaf(detail::olc_node_ptr aleaf,
+                   const optimistic_lock::read_critical_section& rcs) {
+      // Mock up an iter_result for the leaf. The [key] and
+      // [child_index] are ignored for a leaf.
+      push(aleaf, static_cast<std::byte>(0xFFU),
+           static_cast<std::uint8_t>(0xFFU), rcs);
+    }
+
+    // Pop an entry from the stack.
+    //
+    // TODO(thompsonbry) handle variable length keys here.
+    void pop() { stack_.pop(); }
+
+    // Return the entry (if any) on the top of the stack.
+    [[nodiscard]] stack_entry& top() { return stack_.top(); }
+
+    // Return the node on the top of the stack and nullptr if the
+    // stack is empty (similar to top(), but handles an empty stack).
+    [[nodiscard]] detail::olc_node_ptr current_node() {
+      return stack_.empty() ? detail::olc_node_ptr(nullptr) : stack_.top().node;
+    }
+
+   private:
+    // Invalidate the iterator (pops everything off of the stack).
+    //
+    // post-condition: The iterator is !valid().
+    iterator& invalidate() {
+      while (!stack_.empty()) stack_.pop();  // clear the stack
+      return *this;
+    }
+
+    //
+    // Core logic invoked from retry loops.
+    //
+
+    [[nodiscard]] bool try_first();
+    [[nodiscard]] bool try_last();
+    [[nodiscard]] bool try_next();
+    [[nodiscard]] bool try_prior();
+
+    // Push the given node onto the stack and traverse from the
+    // caller's node to the left-most leaf under that node, pushing
+    // nodes onto the stack as they are visited.
+    [[nodiscard]] bool try_left_most_traversal(
+        detail::olc_node_ptr node,
+        optimistic_lock::read_critical_section& parent_critical_section);
+
+    // Descend from the current state of the stack to the right most
+    // child leaf, updating the state of the iterator during the
+    // descent.
+    [[nodiscard]] bool try_right_most_traversal(
+        detail::olc_node_ptr node,
+        optimistic_lock::read_critical_section& parent_critical_section);
+
+    // Core logic invoked from retry loop.
+    [[nodiscard]] bool try_seek(detail::art_key search_key, bool& match,
+                                bool fwd);
+
+    // The outer db instance.
+    olc_db& db_;
+
+    // A stack reflecting the parent path from the root of the tree to
+    // the current leaf.  An empty stack corresponds to a logically
+    // empty iterator and can be detected using !valid().  The
+    // iterator for an empty tree is an empty stack.
+    //
+    std::stack<stack_entry> stack_{};
+
+    // A buffer into which visited keys are decoded and materialized
+    // by get_key().
+    //
+    // Note: The internal key is a sequence of unsigned bytes having
+    // the appropriate lexicographic ordering.  The internal key needs
+    // to be decoded to the external key.
+    //
+    // TODO(thompsonbry) The current implementation stores the entire
+    // key in the leaf. This works fine for simple primitive keys.
+    // However, it needs to be modified when the implementation is
+    // modified to support variable length keys. In that situation,
+    // the full internal key needs to be constructed using the [key]
+    // byte from the path stack plus the prefix bytes from the
+    // internal nodes along that path.
+    key key_{};
+  };  // class iterator
+
+  //
+  // end of the iterator API, which is an internal API.
+  //
+
+ public:
+  ///
+  /// public scan API
+  ///
+
+  // Note: The scan() interface is public.  The iterator and the
+  // methods to obtain an iterator are protected (except for tests).
+  // This encapsulation makes it easier to define methods which
+  // operate on external keys (scan()) and those which operate on
+  // internal keys (seek() and the iterator). It also makes life
+  // easier for mutex_db since scan() can take the lock.
+
+  // Scan the tree, applying the caller's lambda to each visited leaf.
+  //
+  // @param fn A function f(unodb::visitor<unodb::olc_db::iterator>&)
+  // returning [bool:halt].  The traversal will halt if the function
+  // returns [true].
+  //
+  // @param fwd When [true] perform a forward scan, otherwise perform
+  // a reverse scan.
+  template <typename FN>
+  inline void scan(FN fn, bool fwd = true) noexcept {
+    if (fwd) {
+      iterator it(*this);
+      it.first();
+      visitor<olc_db::iterator> v{it};
+      while (it.valid()) {
+        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        it.next();
+      }
+    } else {
+      iterator it(*this);
+      it.last();
+      visitor<olc_db::iterator> v{it};
+      while (it.valid()) {
+        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        it.prior();
+      }
+    }
+  }
+
+  // Scan in the indicated direction, applying the caller's lambda to
+  // each visited leaf.
+  //
+  // @param from_key is an inclusive lower bound for the starting
+  // point of the scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::olc_db::iterator>&)
+  // returning [bool:halt].  The traversal will halt if the function
+  // returns [true].
+  //
+  // @param fwd When [true] perform a forward scan, otherwise perform
+  // a reverse scan.
+  template <typename FN>
+  inline void scan_from(key from_key, FN fn, bool fwd = true) noexcept {
+    const detail::art_key from_key_{from_key};  // convert to internal key
+    bool match{};
+    if (fwd) {
+      iterator it(*this);
+      it.seek(from_key_, match, true /*fwd*/);
+      visitor<olc_db::iterator> v{it};
+      while (it.valid()) {
+        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        it.next();
+      }
+    } else {
+      iterator it(*this);
+      it.seek(from_key_, match, false /*fwd*/);
+      visitor<olc_db::iterator> v{it};
+      while (it.valid()) {
+        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        it.prior();
+      }
+    }
+  }
+
+  // Scan a half-open key range, applying the caller's lambda to each
+  // visited leaf.  The scan will proceed in lexicographic order iff
+  // from_key is less than to_key and in reverse lexicographic order iff
+  // to_key is less than from_key.  When from_key < to_key, the scan will
+  // visit all index entries in the half-open range [from_key,to_key) in
+  // forward order.  Otherwise the scan will visit all index entries
+  // in the half-open range (from_key,to_key] in reverse order.
+  //
+  // @param from_key is an inclusive bound for the starting point of
+  // the scan.
+  //
+  // @param to_key is an exclusive bound for the ending point of the
+  // scan.
+  //
+  // @param fn A function f(unodb::visitor<unodb::olc_db::iterator>&)
+  // returning [bool:halt].  The traversal will halt if the function
+  // returns [true].
+  template <typename FN>
+  inline void scan_range(key from_key, key to_key, FN fn) noexcept {
+    // TODO(thompsonbry) Explore a cheaper way to handle the exclusive
+    // bound case when developing variable length key support based on
+    // the maintained key buffer.
+    constexpr bool debug = false;               // set true to debug scan.
+    const detail::art_key from_key_{from_key};  // convert to internal key
+    const detail::art_key to_key_{to_key};      // convert to internal key
+    const auto ret = from_key_.cmp(to_key_);    // compare the internal keys.
+    const bool fwd{ret < 0};                    // from key is less than to key
+    if (ret == 0) return;                       // NOP
+    bool match{};
+    if (fwd) {
+      iterator it(*this);
+      it.seek(from_key_, match, true /*fwd*/);
+      if constexpr (debug) {
+        std::cerr << "scan_range:: fwd"
+                  << ", from_key=" << from_key << ", to_key=" << to_key << "\n";
+        it.dump(std::cerr);
+      }
+      visitor<olc_db::iterator> v{it};
+      while (it.valid() && it.cmp(to_key_) < 0) {
+        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        it.next();
+        if constexpr (debug) {
+          std::cerr << "scan: next()\n";
+          it.dump(std::cerr);
+        }
+      }
+    } else {  // reverse traversal.
+      iterator it(*this);
+      it.seek(from_key_, match, false /*fwd*/);
+      if constexpr (debug) {
+        std::cerr << "scan_range:: rev"
+                  << ", from_key=" << from_key << ", to_key=" << to_key << "\n";
+        it.dump(std::cerr);
+      }
+      visitor<olc_db::iterator> v{it};
+      while (it.valid() && it.cmp(to_key_) > 0) {
+        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        it.prior();
+        if constexpr (debug) {
+          std::cerr << "scan: prior()\n";
+          it.dump(std::cerr);
+        }
+      }
+    }
+  }
+
+  //
+  // TEST ONLY METHODS
+  //
+
+  // Used to write the iterator tests.
+  auto test_only_iterator() noexcept { return iterator(*this); }
 
   // Stats
 
@@ -144,17 +650,17 @@ class olc_db final {
 
   // Public utils
   [[nodiscard]] static constexpr auto key_found(
-      const get_result &result) noexcept {
+      const get_result& result) noexcept {
     return static_cast<bool>(result);
   }
 
   // Debugging
-  [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream &os) const;
+  [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os) const;
 
-  olc_db(const olc_db &) noexcept = delete;
-  olc_db(olc_db &&) noexcept = delete;
-  olc_db &operator=(const olc_db &) noexcept = delete;
-  olc_db &operator=(olc_db &&) noexcept = delete;
+  olc_db(const olc_db&) noexcept = delete;
+  olc_db(olc_db&&) noexcept = delete;
+  olc_db& operator=(const olc_db&) noexcept = delete;
+  olc_db& operator=(olc_db&&) noexcept = delete;
 
  private:
   // If get_result is not present, the search was interrupted. Yes, this
@@ -167,8 +673,8 @@ class olc_db final {
   [[nodiscard]] try_get_result_type try_get(detail::art_key k) const noexcept;
 
   [[nodiscard]] try_update_result_type try_insert(
-      detail::art_key k, value_view v,
-      detail::olc_leaf_unique_ptr &cached_leaf);
+      detail::art_key k, unodb::value_view v,
+      detail::olc_leaf_unique_ptr& cached_leaf);
 
   [[nodiscard]] try_update_result_type try_remove(detail::art_key k);
 
@@ -208,10 +714,12 @@ class olc_db final {
 
 #endif  // UNODB_DETAIL_WITH_STATS
 
+  // optimistic lock guarding the [root].
   alignas(
       detail::hardware_destructive_interference_size) mutable optimistic_lock
       root_pointer_lock;
 
+  // The root of the tree, guarded by the [root_pointer_lock].
   in_critical_section<detail::olc_node_ptr> root{detail::olc_node_ptr{nullptr}};
 
   static_assert(sizeof(root_pointer_lock) + sizeof(root) <=
@@ -243,7 +751,7 @@ class olc_db final {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   friend auto detail::make_db_leaf_ptr<detail::olc_node_header, olc_db>(
-      detail::art_key, value_view, olc_db &);
+      detail::art_key, unodb::value_view, olc_db&);
 
   template <class, class>
   friend class detail::basic_db_leaf_deleter;
@@ -254,8 +762,8 @@ class olc_db final {
   template <class>
   friend class detail::db_inode_qsbr_deleter;
 
-  template <class, template <class> class, class, class, template <class> class,
-            template <class, class> class>
+  template <class, template <class> class, class, class, class, class,
+            template <class> class, template <class, class> class>
   friend struct detail::basic_art_policy;
 
   template <class, class>
@@ -263,6 +771,55 @@ class olc_db final {
 
   friend struct detail::olc_impl_helpers;
 };
+
+///
+/// ART iterator implementation.
+///
+
+inline std::optional<const unodb::key> olc_db::iterator::get_key() {
+  // Note: If the iterator is on a leaf, we return the key for that
+  // leaf regardless of whether the leaf has been deleted.  This is
+  // part of the design semantics for the OLC ART scan.
+  //
+  // TODO(thompsonbry) Eventually this will need to use the stack to
+  // reconstruct the key from the path from the root to this leaf.
+  // Right now it is relying on the fact that simple fixed width keys
+  // are stored directly in the leaves.
+  if (!valid()) return {};  // not positioned on anything.
+  const auto& e = stack_.top();
+  const auto& node = e.node;
+  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);     // On a leaf.
+  const auto* const aleaf{node.ptr<detail::olc_leaf*>()};  // current leaf.
+  key_ = aleaf->get_key().decode();  // decode key into iterator's buffer.
+  return key_;  // return pointer to the internal key buffer.
+}
+
+inline std::optional<const qsbr_value_view> olc_db::iterator::get_val() const {
+  // Note: If the iterator is on a leaf, we return the value for
+  // that leaf regardless of whether the leaf has been deleted.
+  // This is part of the design semantics for the OLC ART scan.
+  if (!valid()) return {};  // not positioned on anything.
+  const auto& e = stack_.top();
+  const auto& node = e.node;
+  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);     // On a leaf.
+  const auto* const aleaf{node.ptr<detail::olc_leaf*>()};  // current leaf.
+  return qsbr_ptr_span{aleaf->get_value_view()};
+}
+
+inline int olc_db::iterator::cmp(const detail::art_key& akey) const {
+  // TODO(thompsonbry) Explore a cheaper way to handle the exclusive
+  // bound case when developing variable length key support based on
+  // the maintained key buffer.
+  UNODB_DETAIL_ASSERT(!stack_.empty());
+  auto& node = stack_.top().node;
+  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
+  const auto* const leaf{node.ptr<detail::olc_leaf*>()};
+  return leaf->get_key().cmp(akey);
+}
+
+///
+/// OLC scan implementation
+///
 
 }  // namespace unodb
 

--- a/portability_arch.hpp
+++ b/portability_arch.hpp
@@ -2,6 +2,14 @@
 #ifndef UNODB_DETAIL_PORTABILITY_ARCH_HPP
 #define UNODB_DETAIL_PORTABILITY_ARCH_HPP
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_PORTABILITY_BUILTINS_HPP
 #define UNODB_DETAIL_PORTABILITY_BUILTINS_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <cstdint>
 

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -1,8 +1,16 @@
 // Copyright (C) 2019-2024 Laurynas Biveinis
 
-// IWYU pragma: no_include <__hash_table>
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
-#include "global.hpp"
+// IWYU pragma: no_include <__hash_table>
 
 #include "qsbr.hpp"
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1,8 +1,16 @@
-// Copyright (C) 2019-2024 Laurynas Biveinis
+// Copyright (C) 2019-2025 Laurynas Biveinis
 #ifndef UNODB_DETAIL_QSBR_HPP
 #define UNODB_DETAIL_QSBR_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>
 // IWYU pragma: no_include <boost/fusion/iterator/deref.hpp>
@@ -58,7 +66,9 @@ namespace unodb {
 // constitute a quiescent period, and an epoch change happens at its boundary.
 // At that point all the pending deallocation requests queued before the
 // start of the just-finished quiescent period can be safely executed.
-
+//
+// For a usage example, see example/example_olc_art.cpp.
+//
 // The implementation borrows some of the basic ideas from
 // https://preshing.com/20160726/using-quiescent-states-to-reclaim-memory/
 
@@ -801,6 +811,13 @@ class qsbr final {
     const auto current_state = get_state();
     qsbr_state::assert_invariants(current_state);
     UNODB_DETAIL_ASSERT(qsbr_state::get_thread_count(current_state) <= 1);
+    // Quitting threads may race with epoch changes by design, resulting in
+    // previous epoch orphaned requests not being executed until epoch
+    // changes one more time. If that does not happen, this assert may fire at
+    // the process exit time. While it is possible to handle this silently, by
+    // executing the requests then, this may also result in some memory being
+    // held too long. Thus users are advised to pass through Q state in the
+    // last thread a couple more times at the end.
     UNODB_DETAIL_ASSERT(previous_interval_orphaned_requests_empty());
     UNODB_DETAIL_ASSERT(current_interval_orphaned_requests_empty());
     detail::deallocation_request::assert_zero_instances();
@@ -983,10 +1000,10 @@ inline void qsbr_per_thread::advance_last_seen_epoch(
   // NOLINTNEXTLINE(readability-simplify-boolean-expr)
   UNODB_DETAIL_ASSERT(
       new_seen_epoch == last_seen_epoch.advance()
-      // The current thread is 1) quitting; 2) not having seen
-      // the current epoch yet; 3) it quitting will cause an
-      // epoch advance
+      // The current thread is 1) quitting; 2) not having seen the current epoch
+      // yet; 3) it quitting will cause an epoch advance
       || (!single_thread_mode && new_seen_epoch == last_seen_epoch.advance(2)));
+
   update_requests(single_thread_mode, new_seen_epoch,
                   std::move(new_current_requests));
 }

--- a/qsbr_ptr.cpp
+++ b/qsbr_ptr.cpp
@@ -1,5 +1,13 @@
 // Copyright (C) 2021-2023 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "qsbr_ptr.hpp"  // IWYU pragma: keep

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -2,9 +2,18 @@
 #ifndef UNODB_DETAIL_QSBR_PTR_HPP
 #define UNODB_DETAIL_QSBR_PTR_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -158,8 +167,11 @@ namespace unodb {
 template <class T>
 class qsbr_ptr_span {
  public:
-  UNODB_DETAIL_RELEASE_CONSTEXPR explicit qsbr_ptr_span(
-      const gsl::span<T> &other) noexcept
+  UNODB_DETAIL_RELEASE_CONSTEXPR
+  qsbr_ptr_span() noexcept : start{nullptr}, length{0} {}
+
+  UNODB_DETAIL_RELEASE_CONSTEXPR
+  explicit qsbr_ptr_span(const gsl::span<T> &other) noexcept
       : start{other.data()}, length{static_cast<std::size_t>(other.size())} {}
 
   UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span(
@@ -181,6 +193,17 @@ class qsbr_ptr_span {
     return qsbr_ptr<T>{start.get() + length};
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+  [[nodiscard]] constexpr bool operator==(gsl::span<T> other) const noexcept {
+    if (length != other.size()) return false;      // element count differs?
+    if (start.get() == other.data()) return true;  // same ptr and #of elements
+    if (start.get() == nullptr || other.data() == nullptr) return false;
+    return std::memcmp(start.get(), other.data(), length * sizeof(T)) == 0;
+  }
+
+  [[nodiscard]] constexpr bool operator!=(gsl::span<T> other) const noexcept {
+    return !this->operator==(other);
+  }
 
  private:
   qsbr_ptr<T> start;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,20 +26,32 @@ endfunction()
 
 add_library(db_test_utils STATIC db_test_utils.hpp db_test_utils.cpp)
 common_target_properties(db_test_utils)
-target_link_libraries(db_test_utils PUBLIC unodb gtest_main gmock_main)
+if(AWS_BUILD)
+  target_link_libraries(db_test_utils PUBLIC unodb Googletest::gtest Googletest::gtest_main Googlemock::gmock_main)
+else()
+  target_link_libraries(db_test_utils PUBLIC unodb gtest_main gmock_main)
+endif()
 set_clang_tidy_options(db_test_utils "${DO_CLANG_TIDY}")
 
 add_library(qsbr_test_utils STATIC qsbr_test_utils.hpp qsbr_test_utils.cpp
   qsbr_gtest_utils.hpp qsbr_gtest_utils.cpp)
 common_target_properties(qsbr_test_utils)
-target_link_libraries(qsbr_test_utils PUBLIC gtest_main)
+if(AWS_BUILD)
+  target_link_libraries(qsbr_test_utils PUBLIC Googletest::gtest Googletest::gtest_main)
+else()
+  target_link_libraries(qsbr_test_utils PUBLIC gtest_main)
+endif()
 target_link_libraries(qsbr_test_utils PRIVATE unodb_qsbr)
 set_clang_tidy_options(qsbr_test_utils "${DO_CLANG_TIDY}")
 
 function(ADD_TEST_TARGET TARGET)
   add_executable("${TARGET}" "${TARGET}.cpp")
   common_target_properties("${TARGET}")
-  target_link_libraries("${TARGET}" PRIVATE unodb_qsbr unodb_test gtest_main)
+  if(AWS_BUILD)
+    target_link_libraries("${TARGET}" PRIVATE unodb_qsbr unodb_test Googletest::gtest Googletest::gtest_main)
+  else()
+    target_link_libraries("${TARGET}" PRIVATE unodb_qsbr unodb_test gtest_main)
+  endif()
   set_clang_tidy_options("${TARGET}" "${DO_CLANG_TIDY}")
   add_sanitized_test(NAME "${TARGET}" COMMAND "${TARGET}")
 endfunction()
@@ -53,6 +65,8 @@ add_test_target(test_qsbr_ptr)
 add_test_target(test_qsbr)
 target_link_libraries(test_qsbr PRIVATE qsbr_test_utils)
 add_db_test_target(test_art)
+add_db_test_target(test_art_iter)
+add_db_test_target(test_art_scan)
 add_db_test_target(test_art_concurrency)
 # - Google Test with MSVC standard library tries to allocate memory in the
 # exception-thrown-as-expected-path.
@@ -69,7 +83,7 @@ target_link_libraries(test_art_concurrency PRIVATE qsbr_test_utils)
 
 if(COVERAGE)
   add_custom_target(tests_for_coverage ctest
-    DEPENDS test_art test_art_concurrency test_qsbr_ptr test_qsbr test_art_oom
+    DEPENDS test_art test_art_iter test_art_scan test_art_concurrency test_qsbr_ptr test_qsbr test_art_oom
             test_qsbr_oom)
   add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)
 endif()
@@ -80,5 +94,7 @@ add_custom_target(valgrind_tests
   # not found a way to disable it.
   COMMAND ${VALGRIND_COMMAND} ./test_qsbr;
   COMMAND ${VALGRIND_COMMAND} ./test_art;
+  COMMAND ${VALGRIND_COMMAND} ./test_art_iter;
+  COMMAND ${VALGRIND_COMMAND} ./test_art_scan;
   COMMAND ${VALGRIND_COMMAND} ./test_art_concurrency
-  DEPENDS test_qsbr_ptr test_qsbr test_art test_art_concurrency)
+  DEPENDS test_qsbr_ptr test_qsbr test_art test_art_iter test_art_scan test_art_concurrency)

--- a/test/db_test_utils.cpp
+++ b/test/db_test_utils.cpp
@@ -1,5 +1,13 @@
 // Copyright 2019-2024 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "db_test_utils.hpp"

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_DB_TEST_UTILS_HPP
 #define UNODB_DETAIL_DB_TEST_UTILS_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/sstream.h>
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_GTEST_UTILS_HPP
 #define UNODB_DETAIL_GTEST_UTILS_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <gtest/gtest.h>
 
@@ -147,6 +155,13 @@
   do {                                       \
     UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
     EXPECT_TRUE(cond);                       \
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+  } while (0)
+
+#define UNODB_EXPECT_FALSE(cond)             \
+  do {                                       \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
+    EXPECT_FALSE(cond);                      \
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   } while (0)
 

--- a/test/qsbr_gtest_utils.cpp
+++ b/test/qsbr_gtest_utils.cpp
@@ -1,6 +1,14 @@
 // Copyright 2022-2024 Laurynas Biveinis
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include "qsbr_gtest_utils.hpp"
 

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -5,7 +5,15 @@
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <gtest/gtest.h>
 

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -3,7 +3,15 @@
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include "gtest_utils.hpp"
 #include "qsbr.hpp"

--- a/test/qsbr_test_utils.hpp
+++ b/test/qsbr_test_utils.hpp
@@ -2,6 +2,14 @@
 #ifndef UNODB_DETAIL_QSBR_TEST_UTILS_HPP
 #define UNODB_DETAIL_QSBR_TEST_UTILS_HPP
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 namespace unodb::test {

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -4,7 +4,15 @@
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>
 #include <cstdint>

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -1,17 +1,25 @@
 // Copyright 2021-2024 Laurynas Biveinis
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include <type_traits>
 // IWYU pragma: no_include "gtest/gtest.h"
 
+#include <gtest/gtest.h>
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <random>
-
-#include <gtest/gtest.h>
-
+#include <tuple>
 #include "art_common.hpp"
 #include "assert.hpp"
 #include "db_test_utils.hpp"
@@ -22,6 +30,8 @@
 #include "qsbr_test_utils.hpp"
 
 namespace {
+
+inline bool odd(const unodb::key x) { return static_cast<bool>(x % 2); }
 
 template <class Db>
 class ARTConcurrencyTest : public ::testing::Test {
@@ -42,6 +52,9 @@ class ARTConcurrencyTest : public ::testing::Test {
       unodb::test::expect_idle_qsbr();
   }
 
+  //
+  // TestFn is void( unodb::test::tree_verifier<Db> *verifier, std::size_t
+  // thread_i, std::size_t ops_per_thread)
   template <std::size_t ThreadCount, std::size_t OpsPerThread, typename TestFn>
   void parallel_test(TestFn test_function) {
     if constexpr (std::is_same_v<Db, unodb::olc_db>)
@@ -84,14 +97,71 @@ class ARTConcurrencyTest : public ::testing::Test {
     }
   }
 
+  // test helper for scan() verification.
+  static void do_scan_verification(unodb::test::tree_verifier<Db> *verifier,
+                                   unodb::key key) {
+    const bool fwd = odd(key);  // select scan direction
+    const auto k0 = (key > 100) ? (key - 100) : key;
+    const auto k1 = key + 100;
+    uint64_t n = 0;
+    uint64_t sum = 0;
+    unodb::key prior{};
+    auto fn = [&n, &sum, &fwd, &k0, &k1,
+               &prior](const unodb::visitor<typename Db::iterator> &v) {
+      n++;
+      const auto &akey = v.get_key();  // actual visited key.
+      sum += akey;
+      // const auto expected =  // Note: same value formula as insert().
+      //     unodb::test::test_values[akey %
+      //                              unodb::test::test_values.size()];
+      // const auto actual = v.get_value();
+      // // LCOV_EXCL_START
+      // EXPECT_EQ(actual, expected)
+      //     << "fwd=" << fwd << ", key=" << akey
+      //     << ", k0=" << k0 << ", k1=" << k1
+      //     << ", expected=" << expected
+      //     << ", actual=" << actual
+      //     ;
+      std::ignore = v.get_value();
+      if (fwd) {  // [k0,k1) -- k0 is from_key, k1 is to_key
+        EXPECT_TRUE(akey >= k0 && akey < k1)
+            << "fwd=" << fwd << ", key=" << akey << ", k0=" << k0
+            << ", k1=" << k1;
+      } else {  // (k1,k0]
+        EXPECT_TRUE(akey > k0 && akey <= k1)
+            << "fwd=" << fwd << ", key=" << akey << ", k0=" << k0
+            << ", k1=" << k1;
+      }
+      if (n > 1) {
+        EXPECT_TRUE(fwd ? (akey > prior) : (akey < prior))
+            << "fwd=" << fwd << ", prior=" << prior << ", key=" << akey
+            << ", k0=" << k0 << ", k1=" << k1;
+      }
+      // LCOV_EXCL_STOP
+      prior = akey;
+      return false;
+    };
+    if (fwd) {
+      verifier->get_db().scan_range(k0, k1, fn);
+    } else {
+      verifier->get_db().scan_range(k1, k0, fn);
+    }
+    if constexpr (std::is_same_v<Db, unodb::olc_db>) {
+      unodb::this_thread().quiescent();
+    }
+  }
+
   static void key_range_op_thread(unodb::test::tree_verifier<Db> *verifier,
                                   std::size_t thread_i,
                                   std::size_t ops_per_thread) {
-    unodb::key key = thread_i / 3 * 3;
+    constexpr auto ntasks = 4;  // Note: 4 to enable scan tests.
+    unodb::key key = thread_i / ntasks * ntasks;
     for (decltype(ops_per_thread) i = 0; i < ops_per_thread; ++i) {
-      switch (thread_i % 3) {
-        case 0: /* insert */
-          verifier->try_insert(key, unodb::test::test_value_1);
+      switch (thread_i % ntasks) {
+        case 0: /* insert (same value formula as insert_key_range!) */
+          verifier->try_insert(
+              key,
+              unodb::test::test_values[key % unodb::test::test_values.size()]);
           break;
         case 1: /* remove */
           verifier->try_remove(key);
@@ -99,8 +169,13 @@ class ARTConcurrencyTest : public ::testing::Test {
         case 2: /* get */
           verifier->try_get(key);
           break;
+        case 3: /* scan */
+          do_scan_verification(verifier, key);
+          break;
+          // LCOV_EXCL_START
         default:
           UNODB_DETAIL_CANNOT_HAPPEN();
+          // LCOV_EXCL_STOP
       }
       key++;
     }
@@ -113,11 +188,14 @@ class ARTConcurrencyTest : public ::testing::Test {
     std::random_device rd;
     std::mt19937 gen{rd()};
     std::geometric_distribution<unodb::key> key_generator{0.5};
+    constexpr auto ntasks = 4;  // Note: 4 to enable scan tests.
     for (decltype(ops_per_thread) i = 0; i < ops_per_thread; ++i) {
       const auto key{key_generator(gen)};
-      switch (thread_i % 3) {
-        case 0: /* insert */
-          verifier->try_insert(key, unodb::test::test_value_2);
+      switch (thread_i % ntasks) {
+        case 0: /* insert (same value formula as insert_key_range!) */
+          verifier->try_insert(
+              key,
+              unodb::test::test_values[key % unodb::test::test_values.size()]);
           break;
         case 1: /* remove */
           verifier->try_remove(key);
@@ -125,8 +203,13 @@ class ARTConcurrencyTest : public ::testing::Test {
         case 2: /* get */
           verifier->try_get(key);
           break;
+        case 3: /* scan */
+          do_scan_verification(verifier, key);
+          break;
+          // LCOV_EXCL_START
         default:
           UNODB_DETAIL_CANNOT_HAPPEN();
+          // LCOV_EXCL_STOP
       }
     }
   }
@@ -181,19 +264,68 @@ TYPED_TEST(ARTConcurrencyTest, Node48ParallelOps) {
   this->template key_range_op_test<32, 9, 32>();
 }
 
+// FIXME Is the #of OpsPerThread related to the conditions under which
+// the node would be replaced by a different root node?  And does that
+// change once SCAN is introduced as an operation?  It would seem that
+// the test conditions would likely be Ok since fewer operations would
+// be performed and presumably the OpsPerThread is a maximum before a
+// structural modification would result.
 TYPED_TEST(ARTConcurrencyTest, Node256ParallelOps) {
   this->template key_range_op_test<152, 9, 208>();
 }
 
-TYPED_TEST(ARTConcurrencyTest, ParallelRandomInsertDeleteGet) {
+TYPED_TEST(ARTConcurrencyTest, ParallelRandomInsertDeleteGetScan) {
   constexpr auto thread_count = 4 * 3;
   constexpr auto initial_keys = 2048;
-  constexpr auto ops_per_thread = 10000;
+  constexpr auto ops_per_thread = 10'000;
 
   this->verifier.insert_key_range(0, initial_keys, true);
   this->template parallel_test<thread_count, ops_per_thread>(
       TestFixture::random_op_thread);
 }
+
+// A more challenging test using a smaller key range and the same
+// number of threads and operations per thread.  The goal of this test
+// is to try an increase coverage of the N256 case.
+TYPED_TEST(ARTConcurrencyTest, ParallelRandomInsertDeleteGetScan2) {
+  constexpr auto thread_count = 4 * 3;
+  constexpr auto initial_keys = 152;
+  constexpr auto ops_per_thread = 100'000;
+
+  this->verifier.insert_key_range(0, initial_keys, true);
+  this->template parallel_test<thread_count, ops_per_thread>(
+      TestFixture::random_op_thread);
+}
+
+// A more challenging test using an even smaller key range and the
+// same number of threads and operations per thread.  The goal of this
+// test is to try an increase coverage of the N48 case.
+TYPED_TEST(ARTConcurrencyTest, ParallelRandomInsertDeleteGetScan3) {
+  constexpr auto thread_count = 4 * 3;
+  constexpr auto initial_keys = 32;
+  constexpr auto ops_per_thread = 100'000;
+
+  this->verifier.insert_key_range(0, initial_keys, true);
+  this->template parallel_test<thread_count, ops_per_thread>(
+      TestFixture::random_op_thread);
+}
+
+// Optionally enable this for more confidence in debug builds. Set the
+// thread_count for your machine.  Fewer keys, more threads, and more
+// operations per thread is more challenging.
+//
+// LCOV_EXCL_START
+TYPED_TEST(ARTConcurrencyTest,
+           DISABLED_ParallelRandomInsertDeleteGetScanStressTest) {
+  constexpr auto thread_count = 48;
+  constexpr auto initial_keys = 152;
+  constexpr auto ops_per_thread = 10'000'000;
+
+  this->verifier.insert_key_range(0, initial_keys, true);
+  this->template parallel_test<thread_count, ops_per_thread>(
+      TestFixture::random_op_thread);
+}
+// LCOV_EXCL_STOP
 
 UNODB_END_TESTS()
 

--- a/test/test_art_iter.cpp
+++ b/test/test_art_iter.cpp
@@ -1,0 +1,689 @@
+// Copyright 2019-2024 Laurynas Biveinis
+
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_include <array>
+// IWYU pragma: no_include <string>
+// IWYU pragma: no_include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include "art.hpp"
+#include "art_common.hpp"
+#include "art_internal.hpp"
+#include "db_test_utils.hpp"
+#include "gtest_utils.hpp"
+#include "mutex_art.hpp"
+#include "olc_art.hpp"
+
+namespace unodb {
+
+// Test suite for an ART iterator.
+//
+// TODO(thompsonbry) variable length keys :: unit tests for
+// gsl::span<std::byte>
+template <class Db>
+class ARTIteratorTest : public ::testing::Test {
+ public:
+  using Test::Test;
+};
+
+using ARTTypes = ::testing::Types<unodb::db, unodb::mutex_db, unodb::olc_db>;
+
+UNODB_TYPED_TEST_SUITE(ARTIteratorTest, ARTTypes)
+
+UNODB_START_TYPED_TESTS()
+
+// unit test with an empty tree.
+TYPED_TEST(ARTIteratorTest, emptyTreeForwardScan) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  auto b = db.test_only_iterator();
+  b.first();  // obtain iterator.
+  UNODB_EXPECT_TRUE(!b.valid());
+  UNODB_EXPECT_TRUE(!b.get_key());
+  UNODB_EXPECT_TRUE(!b.get_val());
+}
+
+// unit test with an empty tree.
+TYPED_TEST(ARTIteratorTest, emptyTreeReverseScan) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  auto b = db.test_only_iterator();
+  b.last();  // obtain iterator.
+  UNODB_EXPECT_FALSE(b.valid());
+  UNODB_EXPECT_FALSE(b.get_key());
+  UNODB_EXPECT_FALSE(b.get_val());
+}
+
+// unit test where the root is a single leaf.
+TYPED_TEST(ARTIteratorTest, singleLeafIteratorOneValue) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  auto b = db.test_only_iterator();
+  b.first();  // obtain iterator.
+  UNODB_EXPECT_TRUE(b.valid());
+  const auto k = b.get_key();
+  const auto v = b.get_val();
+  UNODB_EXPECT_TRUE(k && k.value() == 0);
+  UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  b.next();                       // advance.
+  UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
+}
+
+// unit test where the root is an I4 with two leafs under it.
+TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesForwardScan) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  auto b = db.test_only_iterator();
+  b.first();  // obtain iterator.
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  }
+  b.next();  // advance
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 1);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+  }
+  b.next();                       // advance.
+  UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
+}
+
+// unit test where the root is an I4 with two leafs under it.
+TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesReverseScan) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  auto b = db.test_only_iterator();
+  b.last();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 1);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+  }
+  b.prior();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  }
+  b.prior();
+  UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
+}
+
+// unit test for the following tree structure, which is setup by how
+// we choose the keys.
+//
+//       I4
+//   I4     L2
+// L0 L1
+TYPED_TEST(ARTIteratorTest, C0001) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0xaa00, unodb::test::test_values[0]);
+  verifier.insert(0xaa01, unodb::test::test_values[1]);
+  verifier.insert(0xab00, unodb::test::test_values[2]);
+  auto b = db.test_only_iterator();
+  b.first();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  }
+  b.next();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xaa01);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+  }
+  b.next();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xab00);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+  }
+  b.next();
+  UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
+}
+
+// unit test for the following tree structure, which is setup by how
+// we choose the keys.
+//
+//       I4
+//   I4     L2
+// L0 L1
+TYPED_TEST(ARTIteratorTest, C0002) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0xaa00, unodb::test::test_values[0]);
+  verifier.insert(0xaa01, unodb::test::test_values[1]);
+  verifier.insert(0xab00, unodb::test::test_values[2]);
+  auto b = db.test_only_iterator();
+  b.last();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xab00);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+  }
+  b.prior();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xaa01);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+  }
+  b.prior();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  }
+  b.prior();
+  UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
+}
+
+// unit test for the following tree structure, which is setup by how
+// we choose the keys.
+//
+//       I4
+//   L0     I4
+//        L1 L2
+TYPED_TEST(ARTIteratorTest, C0003) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0xaa00, unodb::test::test_values[0]);
+  verifier.insert(0xab0c, unodb::test::test_values[1]);
+  verifier.insert(0xab0d, unodb::test::test_values[2]);
+  auto b = db.test_only_iterator();
+  b.first();  // obtain iterators.
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  }
+  b.next();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xab0c);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+  }
+  b.next();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xab0d);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+  }
+  b.next();
+  UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
+}
+
+// unit test for the following tree structure, which is setup by how we choose
+// the keys.
+//
+//       I4
+//   L0     I4
+//        L1 L2
+TYPED_TEST(ARTIteratorTest, C0004) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0xaa00, unodb::test::test_values[0]);
+  verifier.insert(0xab0c, unodb::test::test_values[1]);
+  verifier.insert(0xab0d, unodb::test::test_values[2]);
+  auto b = db.test_only_iterator();
+  b.last();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xab0d);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+  }
+  b.prior();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xab0c);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+  }
+  b.prior();
+  UNODB_EXPECT_TRUE(b.valid());
+  {
+    const auto k = b.get_key();
+    const auto v = b.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  }
+  b.prior();
+  UNODB_EXPECT_FALSE(b.valid());
+}
+
+//
+// seek()
+//
+
+// unit test with an empty tree.
+TYPED_TEST(ARTIteratorTest, emptyTreeSeek) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  {
+    auto e = db.test_only_iterator();
+    bool match = false;
+    e.seek(unodb::detail::art_key{0}, match, true /*fwd*/);
+    UNODB_EXPECT_FALSE(e.valid());
+    UNODB_EXPECT_EQ(match, false);
+  }
+  {
+    auto e = db.test_only_iterator();
+    bool match = false;
+    e.seek(unodb::detail::art_key{0}, match, false /*fwd*/);
+    UNODB_EXPECT_FALSE(e.valid());
+    UNODB_EXPECT_EQ(match, false);
+  }
+}
+
+// unit test where the root is a single leaf.
+TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[1]);
+  {  // exact match, forward traversal (GTE)
+    auto e = db.test_only_iterator();
+    bool match = false;
+    auto& it = e.seek(unodb::detail::art_key{1}, match, true /*fwd*/);
+    UNODB_EXPECT_TRUE(it.valid());
+    UNODB_EXPECT_EQ(match, true);
+    const auto k = it.get_key();
+    const auto v = it.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 1);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    it.next();
+    UNODB_EXPECT_FALSE(it.valid());
+  }
+  {  // exact match, reverse traversal (LTE)
+    auto e = db.test_only_iterator();
+    bool match = false;
+    auto& it = e.seek(unodb::detail::art_key{1}, match, false /*fwd*/);
+    UNODB_EXPECT_TRUE(it.valid());
+    UNODB_EXPECT_EQ(match, true);
+    const auto k = it.get_key();
+    const auto v = it.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 1);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    it.next();
+    UNODB_EXPECT_FALSE(it.valid());  // nothing more in the iterator.
+  }
+  {  // forward traversal, before the first key in the data.
+    // match=false and iterator is positioned on the first key in the
+    // data.
+    bool match = true;
+    auto it = db.test_only_iterator();
+    it.seek(unodb::detail::art_key{0}, match, true /*fwd*/);
+    UNODB_EXPECT_TRUE(it.valid());
+    UNODB_EXPECT_EQ(match, false);
+    const auto k = it.get_key();
+    const auto v = it.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 1);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    it.next();
+    UNODB_EXPECT_FALSE(it.valid());
+  }
+  {  // forward traversal, after the last key in the data.  match=false
+    // and iterator is invalidated.
+    bool match = true;
+    auto it = db.test_only_iterator();
+    it.seek(unodb::detail::art_key{2}, match, true /*fwd*/);
+    UNODB_EXPECT_FALSE(it.valid());
+    UNODB_EXPECT_EQ(match, false);
+  }
+  {  // reverse traversal, before the first key in the data.
+    // match=false and iterator is invalidated.
+    bool match = true;
+    auto it = db.test_only_iterator();
+    it.seek(unodb::detail::art_key{0}, match, false /*fwd*/);
+    UNODB_EXPECT_FALSE(it.valid());
+    UNODB_EXPECT_EQ(match, false);
+  }
+  {  // reverse traversal, after the last key in the data.  match=false
+    // and iterator is positioned at the last key.
+    bool match = true;
+    auto it = db.test_only_iterator();
+    it.seek(unodb::detail::art_key{2}, match, false /*fwd*/);
+    UNODB_EXPECT_TRUE(it.valid());
+    UNODB_EXPECT_EQ(match, false);
+    const auto k = it.get_key();
+    const auto v = it.get_val();
+    UNODB_EXPECT_TRUE(k && k.value() == 1);
+    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    it.next();
+    UNODB_EXPECT_FALSE(it.valid());
+  }
+}
+
+// unit test for the following tree structure, which is setup by how
+// we choose the keys.
+//
+//       I4
+//   I4     L2
+// L0 L1
+TYPED_TEST(ARTIteratorTest, C101) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  const unodb::key k0 = 0xaa00;
+  const unodb::key k1 = 0xaa10;
+  const unodb::key k2 = 0xab10;
+  verifier.insert(k0, unodb::test::test_values[0]);
+  verifier.insert(k1, unodb::test::test_values[1]);
+  verifier.insert(k2, unodb::test::test_values[2]);
+  {    // exact match, forward traversal
+    {  // exact match, forward traversal (GTE), first key.
+      auto it = db.test_only_iterator();
+      bool match = false;
+      it.seek(unodb::detail::art_key{k0}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k0);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    }
+    {  // exact match, forward traversal (GTE), middle key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k1}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k1);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    }
+    {  // exact match, forward traversal (GTE), last key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k2}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k2);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    }
+  }
+  {    // exact match, reverse traversal
+    {  // exact match, reverse traversal (LTE), first key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k0}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k0);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    }
+    {  // exact match, reverse traversal (LTE), middle key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k1}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k1);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    }
+    {  // exact match, reverse traversal (LTE), last key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k2}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k2);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    }
+  }
+  {    // before and after the first and last key
+    {  // forward traversal, before the first key in the data.
+      // match=false and iterator is positioned on the first key in the
+      // data.
+      bool match = true;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{0}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, false);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k0);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    }
+    {  // forward traversal, after the last key in the data.  match=false
+      // and iterator is invalidated.
+      bool match = true;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{0xffff}, match, true /*fwd*/);
+      UNODB_EXPECT_FALSE(it.valid());
+      UNODB_EXPECT_EQ(match, false);
+    }
+    {  // reverse traversal, before the first key in the data.
+      // match=false and iterator is invalidated.
+      bool match = true;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{0}, match, false /*fwd*/);
+      UNODB_EXPECT_FALSE(it.valid());
+      UNODB_EXPECT_EQ(match, false);
+    }
+    {  // reverse traversal, after the last key in the data.  match=false
+      // and iterator is positioned at the last key.
+      bool match = true;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{0xffff}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, false);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k2);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+      it.next();
+      UNODB_EXPECT_FALSE(it.valid());  // nothing more in the iterator.
+    }
+  }
+}
+
+//    I4
+// L0 L1 L2
+//
+TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
+  constexpr bool debug = false;
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();
+  const unodb::key k0 = 0xaa10;
+  const unodb::key k1 = 0xaa20;
+  const unodb::key k2 = 0xaa30;
+  verifier.insert(k0, unodb::test::test_values[0]);
+  verifier.insert(k1, unodb::test::test_values[1]);
+  verifier.insert(k2, unodb::test::test_values[2]);
+  if (debug) {
+    std::cerr << "db state::\n";
+    db.dump(std::cerr);
+  }
+  {    // exact match, forward traversal
+    {  // exact match, forward traversal (GTE), first key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k0}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k0);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    }
+    {  // exact match, forward traversal (GTE), middle key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k1}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k1);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    }
+    {  // exact match, forward traversal (GTE), last key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k2}, match, true /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k2);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    }
+  }
+  {    // exact match, reverse traversal
+    {  // exact match, reverse traversal (LTE), first key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k0}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k0);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    }
+    {  // exact match, reverse traversal (LTE), middle key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k1}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k1);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    }
+    {  // exact match, reverse traversal (LTE), last key.
+      bool match = false;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{k2}, match, false /*fwd*/);
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, true);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k2);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    }
+  }
+  {    // before and after the first and last key
+    {  // forward traversal, before the first key in the data.
+      // match=false and iterator is positioned on the first key in the
+      // data.
+      bool match = true;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{0}, match, true /*fwd*/);
+      if (debug) {
+        std::cerr << "it.seek(0,&match,true)::\n";
+        it.dump(std::cerr);
+      }
+      UNODB_EXPECT_TRUE(it.valid());
+      UNODB_EXPECT_EQ(match, false);
+      const auto k = it.get_key();
+      const auto v = it.get_val();
+      UNODB_EXPECT_TRUE(k && k.value() == k0);
+      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    }
+    {  // forward traversal, after the last key in the data.
+       // match=false and iterator is invalidated.
+      bool match = true;
+      auto it = db.test_only_iterator();
+      it.seek(unodb::detail::art_key{0xffff}, match, true /*fwd*/);
+      if (debug) {
+        std::cerr << "it.seek(0xffff,&match,true)::\n";
+        it.dump(std::cerr);
+      }
+      UNODB_EXPECT_FALSE(it.valid());
+      UNODB_EXPECT_EQ(match, false);
+    }
+    {
+      {  // reverse traversal, before the first key in the data.
+        // match=false and iterator is invalidated.
+        bool match = true;
+        auto it = db.test_only_iterator();
+        it.seek(unodb::detail::art_key{0}, match, false /*fwd*/);
+        if (debug) {
+          std::cerr << "it.seek(0,&match,true)::\n";
+          it.dump(std::cerr);
+        }
+        UNODB_EXPECT_FALSE(it.valid());
+        UNODB_EXPECT_EQ(match, false);
+      }
+      {  // reverse traversal, after the last key in the data.
+         // match=false and iterator is positioned at the last key.
+        bool match = true;
+        auto it = db.test_only_iterator();
+        it.seek(unodb::detail::art_key{0xffff}, match, false /*fwd*/);
+        if (debug) {
+          std::cerr << "it.seek(0xffff,&match,false)::\n";
+          it.dump(std::cerr);
+        }
+        UNODB_EXPECT_TRUE(it.valid());
+        UNODB_EXPECT_EQ(match, false);
+        const auto k = it.get_key();
+        const auto v = it.get_val();
+        UNODB_EXPECT_TRUE(k && k.value() == k2);
+        UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+        it.next();
+        UNODB_EXPECT_FALSE(it.valid());
+      }
+    }
+  }
+}
+
+UNODB_END_TESTS()
+
+}  // namespace unodb

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -2,6 +2,14 @@
 
 #ifndef NDEBUG
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <array>
@@ -20,6 +28,7 @@
 #include "olc_art.hpp"
 #include "test_heap.hpp"
 
+// TODO(laurynas) OOM tests for the scan API.
 namespace {
 
 template <class TypeParam, typename Init, typename Test, typename CheckAfterOOM,

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -1,0 +1,1028 @@
+// Copyright 2019-2024 Laurynas Biveinis
+
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_include <array>
+// IWYU pragma: no_include <string>
+// IWYU pragma: no_include <iterator>
+// IWYU pragma: no_include "gtest/gtest.h"
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <iostream>
+#include <utility>
+#include <vector>
+#include "art.hpp"
+#include "art_common.hpp"
+#include "db_test_utils.hpp"
+#include "gtest_utils.hpp"
+#include "mutex_art.hpp"
+#include "olc_art.hpp"
+
+namespace {
+
+// Test suite for scan() API for the ART.
+//
+// FIXME variable length keys: unit tests for gsl::span<std::byte>
+//
+template <class Db>
+class ARTScanTest : public ::testing::Test {
+ public:
+  using Test::Test;
+};
+
+// used with conditional compilation for debug.
+//
+// LCOV_EXCL_START
+[[maybe_unused]] void dump(const std::vector<unodb::key>& x) {
+  std::cerr << "[";
+  auto it = x.begin();
+  while (it != x.end()) {
+    std::cerr << *it << " ";
+    it++;
+  }
+  std::cerr << "]\n";
+}
+// LCOV_EXCL_STOP
+
+// Test help creates an index and populates it with the ODD keys in
+// [0:limit] so the first key is always ONE (1).  It then verifies the
+// correct behavior of scan_range(from_key,to_key) against that index.
+// Since the data only contains the ODD keys, you can probe with EVEN
+// keys and verify that the scan() is carried out from the appropriate
+// key in the data when the from_key and/or to_key do not exist in the
+// data.
+//
+// @param from_key
+//
+// @param to_key
+//
+// @param limit The largest key to be installed (ODD).
+template <typename TypeParam>
+void do_scan_range_test(const unodb::key from_key, const unodb::key to_key,
+                        const uint32_t limit) {
+  constexpr bool debug = false;
+  if (!(limit % 2)) FAIL() << "limit=" << limit << " must be odd";
+  if (debug)
+    std::cerr << "from_key=" << from_key << ", to_key=" << to_key
+              << ", limit=" << limit << "\n";
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  // Insert odd keys into the database and into an ordered container.
+  std::vector<unodb::key> expected{};
+  if (from_key < to_key) {
+    for (uint64_t i = 1; i < limit; i += 2) {
+      verifier.insert(i, unodb::test::test_values[0]);
+      if (i >= from_key && i < to_key) {
+        expected.push_back(i);
+      }
+    }
+  } else {  // reverse scan
+    for (auto i = static_cast<std::int64_t>(limit); i >= 0; i -= 2) {
+      const auto j = static_cast<std::uint64_t>(i);
+      verifier.insert(j, unodb::test::test_values[0]);
+      if (j <= from_key && j > to_key) {
+        expected.push_back(j);
+      }
+    }
+  }
+  if constexpr (debug) {
+    std::cerr << "db state::\n";
+    verifier.get_db().dump(std::cerr);
+  }
+  const uint64_t nexpected = expected.size();
+  if constexpr (debug) {
+    std::cerr << "scan_test"
+              << ": from_key=" << from_key << ", to_key=" << to_key
+              << ", limit=" << limit << ", nexpected=" << nexpected
+              << ", expected keys=";
+    dump(expected);
+  }
+  uint64_t nactual{0};  // actual number visited.
+  auto eit = expected.begin();
+  auto eit2 = expected.end();
+  auto fn = [&nactual, &eit,
+             eit2](const unodb::visitor<typename TypeParam::iterator>& v) {
+    if (eit == eit2) {
+      // LCOV_EXCL_START
+      EXPECT_TRUE(false) << "ART scan should have halted.";
+      return true;  // halt early.
+      // LCOV_EXCL_STOP
+    }
+    const auto ekey = *eit;         // expected key to visit
+    const auto akey = v.get_key();  // actual key visited.
+    if constexpr (debug) {
+      std::cerr << "nactual=" << nactual << ", ekey=" << ekey
+                << ", akey=" << akey << "\n";
+    }
+    if (ekey != akey) {
+      // LCOV_EXCL_START
+      EXPECT_EQ(ekey, akey);
+      return true;  // halt early.
+      // LCOV_EXCL_STOP
+    }
+    nactual++;     // count #of visited keys.
+    eit++;         // advance iterator over the expected keys.
+    return false;  // !halt (aka continue scan).
+  };
+  db.scan_range(from_key, to_key, fn);
+  // LCOV_EXCL_START
+  EXPECT_TRUE(eit == eit2)
+      << "Expected iterator should have been fully consumed, but was not (ART "
+         "scan visited too little).";
+  EXPECT_EQ(nactual, nexpected) << ", from_key=" << from_key
+                                << ", to_key=" << to_key << ", limit=" << limit;
+  // LCOV_EXCL_STOP
+}
+
+//
+// template meta parameters.
+//
+using ARTTypes = ::testing::Types<unodb::db, unodb::mutex_db, unodb::olc_db>;
+
+UNODB_TYPED_TEST_SUITE(ARTScanTest, ARTTypes)
+
+UNODB_START_TYPED_TESTS()
+
+//
+// forward scan
+//
+
+TYPED_TEST(ARTScanTest, scanForwardEmptyTree) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  {
+    uint64_t n = 0;
+    auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+      n++;           // LCOV_EXCL_LINE
+      return false;  // LCOV_EXCL_LINE
+    };
+    db.scan(fn);
+    UNODB_EXPECT_EQ(0, n);
+  }
+  {
+    uint64_t n = 0;
+    auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+      n++;           // LCOV_EXCL_LINE
+      return false;  // LCOV_EXCL_LINE
+    };
+    db.scan_from(0x0000, fn);
+    UNODB_EXPECT_EQ(0, n);
+  }
+  {
+    uint64_t n = 0;
+    auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+      n++;           // LCOV_EXCL_LINE
+      return false;  // LCOV_EXCL_LINE
+    };
+    db.scan_range(0x0000, 0xffff, fn);
+    UNODB_EXPECT_EQ(0, n);
+  }
+}
+
+// Scan one leaf, verifying that we visit the leaf and can access its key and
+// value.
+TYPED_TEST(ARTScanTest, scanForwardOneLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  uint64_t n = 0;
+  unodb::key visited_key{~0ULL};
+  typename TypeParam::value_view visited_val{};
+  auto fn = [&n, &visited_key, &visited_val](
+                const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited_key = v.get_key();
+    visited_val = v.get_value();
+    return false;
+  };
+  db.scan(fn);
+  UNODB_EXPECT_EQ(1, n);
+  UNODB_EXPECT_EQ(visited_key, 0);
+  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+}
+
+TYPED_TEST(ARTScanTest, scanFromForwardOneLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  uint64_t n = 0;
+  unodb::key visited_key{~0ULL};
+  typename TypeParam::value_view visited_val{};
+  auto fn = [&n, &visited_key, &visited_val](
+                const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited_key = v.get_key();
+    visited_val = v.get_value();
+    return false;
+  };
+  db.scan_from(0, fn);
+  UNODB_EXPECT_EQ(1, n);
+  UNODB_EXPECT_EQ(visited_key, 0);
+  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeForwardOneLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  uint64_t n = 0;
+  unodb::key visited_key{~0ULL};
+  typename TypeParam::value_view visited_val{};
+  auto fn = [&n, &visited_key, &visited_val](
+                const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited_key = v.get_key();
+    visited_val = v.get_value();
+    return false;
+  };
+  db.scan_range(0, 1, fn);
+  UNODB_EXPECT_EQ(1, n);
+  UNODB_EXPECT_EQ(visited_key, 0);
+  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+}
+
+TYPED_TEST(ARTScanTest, scanForwardTwoLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  uint64_t n = 0;
+  std::vector<std::pair<unodb::key, typename TypeParam::value_view>> visited{};
+  auto fn = [&n,
+             &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited.emplace_back(v.get_key(), v.get_value());
+    return false;
+  };
+  db.scan(fn, true /*fwd*/);
+  UNODB_EXPECT_EQ(2, n);
+  UNODB_EXPECT_EQ(2, visited.size());
+  UNODB_EXPECT_EQ(0, visited[0].first);  // verify visited in forward order.
+  UNODB_EXPECT_EQ(1, visited[1].first);
+}
+
+TYPED_TEST(ARTScanTest, scanFromForwardTwoLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  uint64_t n = 0;
+  std::vector<std::pair<unodb::key, typename TypeParam::value_view>> visited{};
+  auto fn = [&n,
+             &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited.emplace_back(v.get_key(), v.get_value());
+    return false;
+  };
+  db.scan_from(0, fn, true /*fwd*/);
+  UNODB_EXPECT_EQ(2, n);
+  UNODB_EXPECT_EQ(2, visited.size());
+  UNODB_EXPECT_EQ(0, visited[0].first);  // verify visited in forward order.
+  UNODB_EXPECT_EQ(1, visited[1].first);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeForwardTwoLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  uint64_t n = 0;
+  std::vector<std::pair<unodb::key, typename TypeParam::value_view>> visited{};
+  auto fn = [&n,
+             &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited.emplace_back(v.get_key(), v.get_value());
+    return false;
+  };
+  db.scan_range(0, 2, fn);
+  UNODB_EXPECT_EQ(2, n);
+  UNODB_EXPECT_EQ(2, visited.size());
+  UNODB_EXPECT_EQ(0, visited[0].first);  // verify visited in forward order.
+  UNODB_EXPECT_EQ(1, visited[1].first);
+}
+
+TYPED_TEST(ARTScanTest, scanForwardThreeLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan(fn, true /*fwd*/);
+  UNODB_EXPECT_EQ(3, n);
+}
+
+TYPED_TEST(ARTScanTest, scanForwardFourLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan(fn);
+  UNODB_EXPECT_EQ(4, n);
+}
+
+TYPED_TEST(ARTScanTest, scanForwardFiveLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan(fn);
+  UNODB_EXPECT_EQ(5, n);
+}
+
+TYPED_TEST(ARTScanTest, scanForwardFiveLeavesHaltEarly) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;
+    return n == 1;  // halt early!
+  };
+  db.scan(fn);
+  UNODB_EXPECT_EQ(1, n);
+}
+
+TYPED_TEST(ARTScanTest, scanFromForwardFiveLeavesHaltEarly) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;
+    return n == 1;  // halt early!
+  };
+  db.scan_from(1, fn);
+  UNODB_EXPECT_EQ(1, n);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeForwardFiveLeavesHaltEarly) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;
+    return n == 1;  // halt early!
+  };
+  db.scan_range(1, 3, fn);
+  UNODB_EXPECT_EQ(1, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanForward100) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 100);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan(fn);
+  UNODB_EXPECT_EQ(100, n);
+}
+
+TYPED_TEST(ARTScanTest, scanFromForward100) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 100);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan_from(0, fn);
+  UNODB_EXPECT_EQ(100, n);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeForward100) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 100);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan_range(0, 100, fn);
+  UNODB_EXPECT_EQ(100, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanForward1000) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 1000);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan(fn);
+  UNODB_EXPECT_EQ(1000, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanFromForward1000) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 1000);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan_from(0, fn);
+  UNODB_EXPECT_EQ(1000, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanRangeForward1000) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 1000);
+  uint64_t n = 0;
+  uint64_t expected = 0;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected++;
+    return false;
+  };
+  db.scan_range(0, 1000, fn);
+  UNODB_EXPECT_EQ(1000, n);
+}
+
+//
+// reverse scan
+//
+
+TYPED_TEST(ARTScanTest, scanReverseEmptyTree) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;           // LCOV_EXCL_LINE
+    return false;  // LCOV_EXCL_LINE
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(0, n);
+}
+
+// Scan one leaf, verifying that we visit the leaf and can access its
+// key and value.
+TYPED_TEST(ARTScanTest, scanReverseOneLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  uint64_t n = 0;
+  unodb::key visited_key{~0ULL};
+  typename TypeParam::value_view visited_val{};
+  auto fn = [&n, &visited_key, &visited_val](
+                const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited_key = v.get_key();
+    visited_val = v.get_value();
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(1, n);
+  UNODB_EXPECT_EQ(visited_key, 0);
+  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+}
+
+TYPED_TEST(ARTScanTest, scanFromReverseOneLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  uint64_t n = 0;
+  unodb::key visited_key{~0ULL};
+  typename TypeParam::value_view visited_val{};
+  auto fn = [&n, &visited_key, &visited_val](
+                const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited_key = v.get_key();
+    visited_val = v.get_value();
+    return false;
+  };
+  db.scan_from(0, fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(1, n);
+  UNODB_EXPECT_EQ(visited_key, 0);
+  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeReverseOneLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  uint64_t n = 0;
+  unodb::key visited_key{~1ULL};
+  typename TypeParam::value_view visited_val{};
+  auto fn = [&n, &visited_key, &visited_val](
+                const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited_key = v.get_key();
+    visited_val = v.get_value();
+    return false;
+  };
+  db.scan_range(1, 0, fn);
+  UNODB_EXPECT_EQ(1, n);
+  UNODB_EXPECT_EQ(visited_key, 1);
+  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+}
+
+TYPED_TEST(ARTScanTest, scanReverseTwoLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  uint64_t n = 0;
+  std::vector<std::pair<unodb::key, typename TypeParam::value_view>> visited{};
+  auto fn = [&n,
+             &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited.emplace_back(v.get_key(), v.get_value());
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(2, n);
+  UNODB_EXPECT_EQ(2, visited.size());
+  UNODB_EXPECT_EQ(2, visited[0].first);  // make sure visited in reverse order.
+  UNODB_EXPECT_EQ(1, visited[1].first);
+}
+
+TYPED_TEST(ARTScanTest, scanFromReverseTwoLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  uint64_t n = 0;
+  std::vector<std::pair<unodb::key, typename TypeParam::value_view>> visited{};
+  auto fn = [&n,
+             &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited.emplace_back(v.get_key(), v.get_value());
+    return false;
+  };
+  db.scan_from(2, fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(2, n);
+  UNODB_EXPECT_EQ(2, visited.size());
+  UNODB_EXPECT_EQ(2, visited[0].first);  // make sure visited in reverse order.
+  UNODB_EXPECT_EQ(1, visited[1].first);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeReverseTwoLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  uint64_t n = 0;
+  std::vector<std::pair<unodb::key, typename TypeParam::value_view>> visited{};
+  auto fn = [&n,
+             &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    visited.emplace_back(v.get_key(), v.get_value());
+    return false;
+  };
+  db.scan_range(2, 0, fn);
+  UNODB_EXPECT_EQ(2, n);
+  UNODB_EXPECT_EQ(2, visited.size());
+  UNODB_EXPECT_EQ(2, visited[0].first);  // make sure visited in reverse order.
+  UNODB_EXPECT_EQ(1, visited[1].first);
+}
+
+TYPED_TEST(ARTScanTest, scanReverseThreeLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(3, unodb::test::test_values[2]);
+  uint64_t n = 0;
+  uint64_t expected = 3;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(3, n);
+}
+
+TYPED_TEST(ARTScanTest, scanReverseFourLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  uint64_t n = 0;
+  uint64_t expected = 3;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(4, n);
+}
+
+TYPED_TEST(ARTScanTest, scanReverseFiveLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(3, unodb::test::test_values[2]);
+  verifier.insert(4, unodb::test::test_values[3]);
+  verifier.insert(5, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  uint64_t expected = 5;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(5, n);
+}
+
+TYPED_TEST(ARTScanTest, scanFromReverseFiveLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(3, unodb::test::test_values[2]);
+  verifier.insert(4, unodb::test::test_values[3]);
+  verifier.insert(5, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  uint64_t expected = 5;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan_from(5, fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(5, n);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeReverseFiveLeaves) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(3, unodb::test::test_values[2]);
+  verifier.insert(4, unodb::test::test_values[3]);
+  verifier.insert(5, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  uint64_t expected = 5;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan_range(5, 0, fn);
+  UNODB_EXPECT_EQ(5, n);
+}
+
+TYPED_TEST(ARTScanTest, scanReverseFiveLeavesHaltEarly) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;
+    return n == 1;  // halt early!
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(1, n);
+}
+
+TYPED_TEST(ARTScanTest, scanFromReverseFiveLeavesHaltEarly) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;
+    return n == 1;  // halt early!
+  };
+  db.scan_from(3, fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(1, n);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeReverseFiveLeavesHaltEarly) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(4, unodb::test::test_values[4]);
+  uint64_t n = 0;
+  auto fn = [&n](const unodb::visitor<typename TypeParam::iterator>&) {
+    n++;
+    return n == 1;  // halt early!
+  };
+  db.scan_range(4, 1, fn);
+  UNODB_EXPECT_EQ(1, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanReverse100) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 100);
+  uint64_t n = 0;
+  uint64_t expected = 99;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(100, n);
+}
+
+TYPED_TEST(ARTScanTest, scanFromReverse100) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 100);
+  uint64_t n = 0;
+  uint64_t expected = 99;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan_from(100, fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(100, n);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeReverse100) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 100);
+  uint64_t n = 0;
+  uint64_t expected = 99;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan_range(99, 0, fn);
+  UNODB_EXPECT_EQ(99, n);  // only 99 since to_key is exclusive lower bound
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanReverse1000) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 1000);
+  uint64_t n = 0;
+  uint64_t expected = 999;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan(fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(1000, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanFromReverse1000) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 1000);
+  uint64_t n = 0;
+  uint64_t expected = 999;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan_from(1000, fn, false /*fwd*/);
+  UNODB_EXPECT_EQ(1000, n);
+}
+
+// iterator scan test on a larger tree.
+TYPED_TEST(ARTScanTest, scanRangeReverse1000) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert_key_range(0, 1000);
+  uint64_t n = 0;
+  uint64_t expected = 999;
+  auto fn = [&n,
+             &expected](const unodb::visitor<typename TypeParam::iterator>& v) {
+    n++;
+    auto key = v.get_key();
+    UNODB_EXPECT_EQ(expected, key);
+    expected--;
+    return false;
+  };
+  db.scan_range(1000, 0, fn);
+  UNODB_EXPECT_EQ(999, n);  // only 999 since to_key is exclusive lower bound
+}
+
+// Tests for edge cases for scan_range() including first key missing,
+// last key missing, both end keys missing, both end keys are the same
+// (and both exist or one exists or both are missing), etc.
+//
+// Check the edge conditions for the single leaf iterator (limit=1, so
+// only ONE (1) is installed into the ART index).  Check all iterator
+// flavors for this.
+TYPED_TEST(ARTScanTest, scanRangeC100) {
+  do_scan_range_test<TypeParam>(0, 1, 1);
+}  // nothing
+TYPED_TEST(ARTScanTest, scanRangeC102) {
+  do_scan_range_test<TypeParam>(1, 2, 1);
+}  // one key
+TYPED_TEST(ARTScanTest, scanRangeC103) {
+  do_scan_range_test<TypeParam>(2, 3, 1);
+}  // nothing
+TYPED_TEST(ARTScanTest, scanRangeC104) {
+  do_scan_range_test<TypeParam>(0, 2, 1);
+}  // one key
+TYPED_TEST(ARTScanTest, scanRangeC105) {
+  do_scan_range_test<TypeParam>(2, 2, 1);
+}  // nothing
+
+// fromKey is odd (exists); toKey is even (hence does not exist).
+TYPED_TEST(ARTScanTest, scanRangeC110) {
+  do_scan_range_test<TypeParam>(1, 2, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC111) {
+  do_scan_range_test<TypeParam>(1, 4, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC112) {
+  do_scan_range_test<TypeParam>(1, 6, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC113) {
+  do_scan_range_test<TypeParam>(2, 1, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC114) {
+  do_scan_range_test<TypeParam>(4, 1, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC115) {
+  do_scan_range_test<TypeParam>(6, 1, 5);
+}
+// fromKey is odd (exists); toKey is odd (exists).
+TYPED_TEST(ARTScanTest, scanRangeC120) {
+  do_scan_range_test<TypeParam>(1, 1, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC121) {
+  do_scan_range_test<TypeParam>(1, 3, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC122) {
+  do_scan_range_test<TypeParam>(1, 5, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC123) {
+  do_scan_range_test<TypeParam>(3, 1, 5);
+}
+TYPED_TEST(ARTScanTest, scanRangeC124) {
+  do_scan_range_test<TypeParam>(5, 1, 5);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeC130) {
+  do_scan_range_test<TypeParam>(0, 9, 9);
+}
+TYPED_TEST(ARTScanTest, scanRangeC131) {
+  do_scan_range_test<TypeParam>(9, 0, 9);
+}
+
+TYPED_TEST(ARTScanTest, scanRangeC140) {
+  do_scan_range_test<TypeParam>(1, 999, 999);
+}
+TYPED_TEST(ARTScanTest, scanRangeC141) {
+  do_scan_range_test<TypeParam>(999, 1, 999);
+}
+TYPED_TEST(ARTScanTest, scanRangeC142) {
+  do_scan_range_test<TypeParam>(247, 823, 999);
+}
+TYPED_TEST(ARTScanTest, scanRangeC143) {
+  do_scan_range_test<TypeParam>(823, 247, 999);
+}
+
+UNODB_END_TESTS()
+
+}  // namespace

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -1,6 +1,14 @@
 // Copyright 2020-2024 Laurynas Biveinis
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/sstream.h>
 // IWYU pragma: no_include <__math/traits.h>

--- a/test/test_qsbr_oom.cpp
+++ b/test/test_qsbr_oom.cpp
@@ -2,6 +2,14 @@
 
 #ifndef NDEBUG
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <array>

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_TEST_UTILS_HPP
 #define UNODB_DETAIL_TEST_UTILS_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include "test_heap.hpp"
 

--- a/test_heap.cpp
+++ b/test_heap.cpp
@@ -1,5 +1,13 @@
 // Copyright 2022-2023 Laurynas Biveinis
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "test_heap.hpp"  // IWYU pragma: keep

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -2,6 +2,14 @@
 #ifndef UNODB_DETAIL_TEST_HEAP_HPP
 #define UNODB_DETAIL_TEST_HEAP_HPP
 
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
 #ifndef NDEBUG

--- a/thread_sync.hpp
+++ b/thread_sync.hpp
@@ -2,7 +2,15 @@
 #ifndef UNODB_DETAIL_THREAD_SYNC_HPP
 #define UNODB_DETAIL_THREAD_SYNC_HPP
 
-#include "global.hpp"
+//
+// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
+// HEADER FILES !!!
+//
+// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
+// DEBUG builds.  If some standard headers are included before and
+// after those symbols are defined, then that results in different
+// container internal structure layouts and that is Not Good.
+#include "global.hpp"  // IWYU pragma: keep
 
 #include <array>
 #include <condition_variable>


### PR DESCRIPTION
This feature branch adds scan support for the single threaded and thread-safe ART variants, including full forward and reverse scans, scans from a key, and scans in a half-open key range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added scanning capabilities to the database, including forward and reverse scans with support for full tree and key range traversals.
	- Enhanced iterator functionality with methods for first, last, next, and prior operations.
	- Improved key handling and comparison methods.
	- Introduced new classes and methods for enhanced locking mechanisms and critical section management.
	- New methods for removing entries and clearing the index in the database.
	- Added support for equality and inequality comparisons between `qsbr_ptr_span` and `gsl::span`.
	- Introduced a visitor function for scanning the database tree in examples.
	- Enhanced benchmark capabilities with new functions for measuring performance during scans.

- **Bug Fixes**
	- Refined node traversal and locking mechanisms.
	- Improved error handling in memory allocation scenarios.

- **Documentation**
	- Updated README with clearer instructions on key types and scanning methods.
	- Added cautionary comments regarding the inclusion order of headers to prevent issues in debug builds.

- **Refactor**
	- Restructured internal namespaces and class hierarchies.
	- Improved type consistency across implementation.
	- Enhanced code organization in ART (Adaptive Radix Tree) implementation.

- **Tests**
	- Added comprehensive test suites for iterators, scanning, and out-of-memory scenarios.
	- Expanded concurrency and edge case testing.
	- Introduced tests for the equality and inequality operators in `qsbr_ptr_span`.
	- Enhanced benchmark tests for scanning functions.

- **Chores**
	- Updated build workflows to improve build resilience.
	- Modified GitHub Actions to continue builds despite partial failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->