### PR TITLE
Clarify how to free the last released memory by QSBR threads

### DIFF
--- a/examples/example_olc_art.cpp
+++ b/examples/example_olc_art.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 Laurynas Biveinis
+// Copyright 2024-2025 Laurynas Biveinis
 
 // A simple example showing unodb::olc_db parallelism. For simplicity &
 // self-containedness does not concern with exception handling and refactoring
@@ -125,6 +125,15 @@ int main() {
   threads[0].join();
   threads[1].join();
   threads[2].join();
+
+  // Quitting threads may race with epoch changes by design, resulting in
+  // previous epoch orphaned requests not being executed until epoch
+  // changes one more time. If that does not happen, some memory might be
+  // held too long. Thus users are advised to pass through Q state in the
+  // last thread a couple more times at the end.
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+  unodb::this_thread().quiescent();
 
 #ifdef UNODB_DETAIL_WITH_STATS
   std::cerr << "Final tree memory use: " << tree.get_current_memory_use()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced thread state management for quiescent state handling in concurrent environments
	- Improved initialization of QSBR (Quiescent-State Based Reclamation) mechanism

- **Documentation**
	- Updated comments to clarify thread lifecycle and epoch change behaviors
	- Added usage example reference in documentation

- **Bug Fixes**
	- Corrected initialization of thread pause state to prevent potential race conditions
	- Expanded comments to clarify behavior of quitting threads in relation to epoch changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->