### PR TITLE
Downgrade Boost to an optional dependency when possible

### DIFF
--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
+      BOOST: ${{matrix.BOOST}}
       BUILD_TYPE: ${{matrix.BUILD_TYPE}}
       COMPILER: ${{matrix.COMPILER}}
       VERSION: ${{matrix.VERSION}}
@@ -100,6 +101,7 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
+            BOOST: OFF
 
           - name: clang 14 Release with TSan
             BUILD_TYPE: Release
@@ -114,6 +116,7 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
+            BOOST: OFF
 
           - name: clang 14 Debug
             BUILD_TYPE: Debug
@@ -127,6 +130,7 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
+            BOOST: OFF
 
           - name: clang 14 Debug with TSan
             BUILD_TYPE: Debug
@@ -141,6 +145,7 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
+            BOOST: OFF
 
           - name: clang 15 Release
             BUILD_TYPE: Release
@@ -385,6 +390,7 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
+            BOOST: OFF
 
           - name: GCC 12 Release with ASan
             BUILD_TYPE: Release
@@ -399,6 +405,7 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
+            BOOST: OFF
 
           - name: GCC 12 Release with UBSan
             BUILD_TYPE: Release
@@ -412,6 +419,7 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
+            BOOST: OFF
 
           - name: GCC 12 Debug with ASan
             BUILD_TYPE: Debug
@@ -426,6 +434,7 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
+            BOOST: OFF
 
           - name: GCC 12 Debug with UBSan
             BUILD_TYPE: Debug
@@ -442,7 +451,11 @@ jobs:
       - name: Setup common dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libboost-dev libc6-dev-i386
+          sudo apt-get install -y libc6-dev-i386
+
+      - name: Setup optional Boost
+        run: sudo apt-get install -y libboost-dev
+        if: env.BOOST != 'OFF'
 
       - name: Setup dependencies for LLVM 13 & 15+
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,19 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
-find_package(Boost REQUIRED)
 # TODO(laurynas): once the minimum CMake version is at least 3.13, convert to a
 # find_package(Boost) component check
-find_file(HAS_BOOST_STACKTRACE_HPP boost/stacktrace.hpp
-  PATHS "${Boost_INCLUDE_DIRS}")
+find_package(Boost)
+
+if(STATS AND NOT Boost_FOUND)
+  message(FATAL_ERROR
+    "Building with stats requires Boost, install it or use -DSTATS=OFF")
+endif()
+
+if(Boost_FOUND)
+  find_file(HAS_BOOST_STACKTRACE_HPP boost/stacktrace.hpp
+    PATHS "${Boost_INCLUDE_DIRS}")
+endif()
 
 if(HAS_BOOST_STACKTRACE_HPP)
   if (is_gxx AND NOT is_darwin)
@@ -694,15 +702,23 @@ endfunction()
 
 add_library(unodb_util INTERFACE)
 target_include_directories(unodb_util INTERFACE ".")
-target_include_directories(unodb_util SYSTEM INTERFACE "${Boost_INCLUDE_DIRS}")
+if(Boost_FOUND)
+  target_include_directories(unodb_util SYSTEM INTERFACE
+    "${Boost_INCLUDE_DIRS}")
+endif()
 
 add_unodb_library(unodb_qsbr qsbr.cpp qsbr.hpp qsbr_ptr.cpp qsbr_ptr.hpp)
-target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
-target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
+if(Boost_FOUND)
+  target_include_directories(unodb_qsbr SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
+  target_link_libraries(unodb_qsbr PRIVATE "${Boost_LIBRARIES}")
+endif()
 target_link_libraries(unodb_qsbr PUBLIC unodb_util Threads::Threads)
 if(LIBFUZZER_AVAILABLE)
-  target_include_directories(unodb_qsbr_lf SYSTEM PUBLIC "${Boost_INCLUDE_DIRS}")
-  target_link_libraries(unodb_qsbr_lf PRIVATE "${Boost_LIBRARIES}")
+  if(Boost_FOUND)
+    target_include_directories(unodb_qsbr_lf SYSTEM PUBLIC
+      "${Boost_INCLUDE_DIRS}")
+    target_link_libraries(unodb_qsbr_lf PRIVATE "${Boost_LIBRARIES}")
+  endif()
   target_link_libraries(unodb_qsbr_lf PUBLIC unodb_util Threads::Threads)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ platform-specific features:
 * Earliest versions of supported compilers: GCC 10, LLVM 11, XCode 16.1,
   MSVC 2022. Open an issue if you require support for an older version.
 * CMake, at least 3.12
-* Boost library, specifically Boost.Accumulator and optional Boost.Stacktrace.
+* Boost library. If building with statistics counters, then it is a mandatory
+  dependency for Boost.Accumulator. It is also an optional dependency for
+  Boost.Stacktrace.
 
 ### Build dependencies, bundled as git submodules
 


### PR DESCRIPTION
When building without statistics counters, Boost.Accumulator is not needed,
leaving only Boost.Stacktrace, which was an optional dependency already. Thus
allow building without Boost if statistics are off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README to clarify Boost library dependency requirements.
	- Specified Boost.Accumulator as mandatory only when building with statistics counters.

- **Chores**
	- Modified GitHub workflow to add conditional Boost library installation.
	- Updated CMakeLists.txt to improve Boost library configuration and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->