### PR TITLE
Add a more stressful concurrent test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,11 @@ jobs:
       - run:
           name: Build
           working_directory: build
-          command: make -j2
+          command: make -j2 -k
       - run:
           name: Examples
           working_directory: build
-          command: make examples
+          command: make -k examples
       - run:
           name: Correctness test
           working_directory: build
@@ -125,7 +125,7 @@ jobs:
             - run:
                 name: Benchmark correctness test
                 working_directory: build
-                command: make quick_benchmarks
+                command: make -k quick_benchmarks
       - when:
           condition:
             not:
@@ -139,7 +139,7 @@ jobs:
                 working_directory: build
                 command: |
                   sudo NEEDRESTART_MODE=a apt-get install -y valgrind
-                  make valgrind
+                  make -k valgrind
 
   build-macos:
     parameters:
@@ -187,11 +187,11 @@ jobs:
       - run:
           name: Build
           working_directory: build
-          command: make -j3
+          command: make -j3 -k
       - run:
           name: Examples
           working_directory: build
-          command: make examples
+          command: make -k examples
       - run:
           name: Correctness test
           working_directory: build
@@ -206,7 +206,7 @@ jobs:
             - run:
                 name: Benchmark correctness test
                 working_directory: build
-                command: make quick_benchmarks
+                command: make -k quick_benchmarks
 
 workflows:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,34 +416,36 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -j3 -k
         if: env.STATIC_ANALYSIS != 'ON' || env.COMPILER != 'clang'
 
       - name: clang static analysis
         working-directory: ${{github.workspace}}/build
         run: |
           /usr/bin/scan-build-19 --status-bugs -stats -analyze-headers \
-            --force-analyze-debug-code make -j3;
+            --force-analyze-debug-code make -j3 -k;
         if: env.STATIC_ANALYSIS == 'ON' && env.COMPILER == 'clang'
 
       - name: Examples
         working-directory: ${{github.workspace}}/build
-        run: make examples
+        run: make -k examples
         if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
 
       - name: Correctness test
         working-directory: ${{github.workspace}}/build
+        env:
+          GTEST_ALSO_RUN_DISABLED_TESTS: 1
         run: ctest -j3 -V
         if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
 
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
-        run: make quick_benchmarks
+        run: make -k quick_benchmarks
         if: env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
 
       - name: DeepState 1 minute fuzzing
         working-directory: ${{github.workspace}}/build
-        run: make -j2 deepstate_1m
+        run: make -k -j2 deepstate_1m
         if: >
           env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
           && (runner.os != 'macOS'
@@ -451,7 +453,7 @@ jobs:
 
       - name: DeepState libfuzzer 1 minute fuzzing
         working-directory: ${{github.workspace}}/build
-        run: make -j2 deepstate_lf_1m
+        run: make -k -j2 deepstate_lf_1m
         if: >
           env.STATIC_ANALYSIS != 'ON' && env.COVERAGE != 'ON'
           && env.COMPILER == 'clang' && env.BUILD_TYPE != 'Release'
@@ -462,7 +464,7 @@ jobs:
         run: |
           sudo apt-get install -y libc6-dbg
           sudo snap install --classic valgrind
-          make valgrind
+          make -k valgrind
         if: >
           env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
           && env.SANITIZE_UB != 'ON' && env.STATIC_ANALYSIS != 'ON'
@@ -471,7 +473,7 @@ jobs:
       - name: Gather coverage data
         working-directory: ${{github.workspace}}/build
         run: |
-          make -j3 coverage
+          make -k -j3 coverage
         if: env.COVERAGE == 'ON'
 
       - name: Upload coverage data

--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -55,5 +55,5 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -k -j3
         continue-on-error: true

--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -100,6 +100,8 @@ jobs:
             && (matrix.preset != 'msvc-static-analysis-debug')
 
       - name: Correctness test
+        env:
+          GTEST_ALSO_RUN_DISABLED_TESTS: 1
         run: ctest -V --preset "${{ matrix.preset }}"
         if: >
             (matrix.preset != 'msvc-static-analysis-release')

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -528,26 +528,28 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -k -j3
 
       - name: Examples
         working-directory: ${{github.workspace}}/build
-        run: make examples
+        run: make -k examples
 
       - name: Correctness test
         working-directory: ${{github.workspace}}/build
+        env:
+          GTEST_ALSO_RUN_DISABLED_TESTS: 1
         run: ctest -j3 -V
 
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
-        run: make quick_benchmarks
+        run: make -k quick_benchmarks
 
       - name: Valgrind test
         working-directory: ${{github.workspace}}/build
         run: |
           sudo apt-get install -y libc6-dbg
           sudo snap install --classic valgrind
-          make valgrind
+          make -k valgrind
         if: >
           env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
           && env.SANITIZE_UB != 'ON'

--- a/.github/workflows/ubuntu-20.04.yml
+++ b/.github/workflows/ubuntu-20.04.yml
@@ -230,26 +230,28 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3
+        run: make -k -j3
 
       - name: Examples
         working-directory: ${{github.workspace}}/build
-        run: make examples
+        run: make -k examples
 
       - name: Correctness test
         working-directory: ${{github.workspace}}/build
+        env:
+          GTEST_ALSO_RUN_DISABLED_TESTS: 1
         run: ctest -j3 -V
 
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
-        run: make quick_benchmarks
+        run: make -k quick_benchmarks
 
       - name: Valgrind test
         working-directory: ${{github.workspace}}/build
         run: |
           sudo apt-get install -y libc6-dbg
           sudo snap install --classic valgrind
-          make valgrind
+          make -k valgrind
         if: >
           env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
           && env.SANITIZE_UB != 'ON'


### PR DESCRIPTION
Add a large stress test to test_art_concurrency.cpp,
ParallelRandomInsertDeleteStressGet. Keep it disabled by default, and modify the
CI jobs to run it.

At the same time, add -k to make args in CI jobs to get more compilation errors
in a single iteration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to continue build process even if some targets fail by introducing `-k` flag in build commands.
	- Enabled execution of disabled tests in test suites.

- **Chores**
	- Updated build configurations across multiple CI/CD workflow files.
	- Enhanced test robustness and error handling in continuous integration pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->