### PR TITLE
Bump minimum CMake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2019-2025 Laurynas Biveinis
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 
 # Set to new once Boost 1.70 is the minimum oldest version
 if(POLICY CMP0167)
@@ -136,11 +136,6 @@ else()
 endif()
 
 option(STATS "Whether to compile in the statistics counters" ON)
-
-if(MSVC)
-  # Remove it once CMake minimum is bumped to 3.15 or greater
-  string(REGEX REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-endif()
 
 # Disable the following warnings for MSVC:
 # - "C4324: '...': structure was padded due to alignment specifier"


### PR DESCRIPTION
Remove an MSVC /W3-removing hack becoming redundant at this version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated minimum required CMake version from 3.14 to 3.15
	- Simplified CMake configuration for build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->