### PR TITLE
Bump minimum CMake version to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright 2019-2025 Laurynas Biveinis
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 
 # Set to new once Boost 1.70 is the minimum oldest version
 if(POLICY CMP0167)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated minimum required CMake version to 3.16 for improved project compatibility and potential access to newer CMake features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->