### PR TITLE
Reproduces a data race (demonstration) when we do not check the parent

### DIFF
--- a/olc_art.cpp
+++ b/olc_art.cpp
@@ -884,12 +884,12 @@ olc_db::try_get_result_type olc_db::try_get(detail::art_key k) const noexcept {
 
   auto remaining_key{k};
 
-  if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.check())) {
-    // LCOV_EXCL_START
-    spin_wait_loop_body();
-    return {};
-    // LCOV_EXCL_STOP
-  }
+  // if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.check())) {
+  //   // LCOV_EXCL_START
+  //   spin_wait_loop_body();
+  //   return {};
+  //   // LCOV_EXCL_STOP
+  // }
 
   while (true) {
     auto node_critical_section = node_ptr_lock(node).try_read_lock();

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -27,7 +27,7 @@ namespace unodb {
 inline void spin_wait_loop_body() noexcept {
 #ifdef UNODB_DETAIL_THREAD_SANITIZER
 
-  std::this_thread::yield();
+  // std::this_thread::yield();
 
 #else  // UNODB_DETAIL_THREAD_SANITIZER
 


### PR DESCRIPTION
RCS before the while() loop against master.

Note: The thread yield is disabled in the spin_wait_loop_body() in this branch.  However, I HAVE NOT tried (yet) to demonstrate that disabling that yield is required to demonstrate this data race.

See olc_db::try_get() for the critical code change.

cmake .. -DSTANDALONE=ON \
         -DMAINTAINER_MODE=ON \
         -DSPINLOCK_LOOP=EMPTY \
         -DCMAKE_BUILD_TYPE=Debug \
         -DIWYU=OFF \
         -DSANITIZE_UB=OFF \
         -DSANITIZE_THREAD=ON \
         -DSTATS=ON

Sample stack trace

WARNING: ThreadSanitizer: data race (pid=6191)
  Atomic write of size 8 at 0x7b3000020588 by thread T168:
    #0 std::__atomic_base<long>::fetch_add(long, std::memory_order) /usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/bits/atomic_base.h:548:16 (test_art_concurrency+0x173e54)
    #1 unodb::optimistic_lock::inc_read_lock_count() const /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/optimistic_lock.hpp:389:21 (test_art_concurrency+0x173e54)
    #2 unodb::optimistic_lock::try_read_lock() /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/optimistic_lock.hpp:303:9 (test_art_concurrency+0x171675)
    #3 unodb::olc_db::try_get(unodb::detail::basic_art_key<unsigned long>) const /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/olc_art.cpp:895:54 (test_art_concurrency+0x14cd6b)
    #4 unodb::olc_db::get(unsigned long) const /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/olc_art.cpp:855:14 (test_art_concurrency+0x14c74a)
    #5 unodb::test::tree_verifier<unodb::olc_db>::try_get(unsigned long) const /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/test/db_test_utils.hpp:459:25 (test_art_concurrency+0x1280a2)
    #6 (anonymous namespace)::ARTConcurrencyTest<unodb::olc_db>::random_op_thread(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/test/test_art_concurrency.cpp:130:21 (test_art_concurrency+0x1046db)
    #7 auto auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::tes\
t::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::operator()<void (*)(unodb::test::tree_verifier<unodb::olc_db>*, u\ nsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&) /home/bryant/p8/src/Neptune-Playground/sr\ c/hash/unodb/./qsbr.hpp:1240:11 (test_art_concurrency+0x1237be)
    #8 void (*&std::__invoke_impl<void, auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long\
, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&), void (*)(unodb::test::tree_verifier<u\ nodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>(std::__invoke_other, auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db\
>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tr\
ee_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)&&, void (*&&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&&, unsigned long&&))(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long) /\ usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/bits/invoke.h:60:14 (test_art_concurrency+0x1236b5)
    #9 std::__invoke_result<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>::type std::__invoke<auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsig\
ned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifi\ er<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&), void (*)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>(void (*&)(unodb::tes\ t::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&) /usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/bits/invoke.h:95:14 (test_art_concurrency+0x1234f5)
    #10 void std::thread::_Invoker<std::tuple<auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigne\
d long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&), void (*)(unodb::test::tree_veri\ fier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>>::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) /usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/thread:264:13 (test_art_concurrency+0x\ 123475)
    #11 std::thread::_Invoker<std::tuple<auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned lon\
g, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&), void (*)(unodb::test::tree_verifier<\ unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>>::operator()() /usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/thread:271:11 (test_art_concurrency+0x1233e5)
    #12 std::thread::_State_impl<std::thread::_Invoker<std::tuple<auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unod\
b::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&), void (*)(un\ odb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>>>::_M_run() /usr/lib/gcc/x86_64-redhat-linux/10/../../../../include/c++/10/thread:215:13 (test_art_concurrency+0x122d89)
    #13 <null> <null> (libstdc++.so.6+0xbaace) (BuildId: e1d686aa3d57d86f36d49ad1a6bd923f038edc9a)

  Previous write of size 8 at 0x7b3000020588 by thread T161:
    #0 posix_memalign /home/bryant/install/llvm-project/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp:856:3 (test_art_concurrency+0x44355)
    #1 unodb::detail::allocate_aligned(unsigned long, unsigned long) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/heap.hpp:39:20 (test_art_concurrency+0x148483)
    #2 auto unodb::detail::basic_art_policy<unodb::olc_db, unodb::in_critical_section, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>, unodb::detail::basic_inode_def<(anonymous namespace)::olc_inode, (anonymous namespace)::olc_inode_4, (anonymous namespace)::olc_inode_16, (anonymous namespace)\
::olc_inode_48, (anonymous namespace)::olc_inode_256>, unodb::detail::db_inode_qsbr_deleter, unodb::detail::db_leaf_qsbr_deleter>::make_db_inode_unique_ptr<(anonymous namespace)::olc_inode_16, (anonymous namespace)::olc_inode_48&>(unodb::olc_db&, (anonymous namespace)::olc_inode_48&) /home/bryant/p8/src/Nept\ une-Playground/src/hash/unodb/art_internal_impl.hpp:261:9 (test_art_concurrency+0x16a59a)
    #3 auto unodb::detail::basic_inode<unodb::detail::basic_art_policy<unodb::olc_db, unodb::in_critical_section, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>, unodb::detail::basic_inode_def<(anonymous namespace)::olc_inode, (anonymous namespace)::olc_inode_4, (anonymous namespace)::olc_inod\
e_16, (anonymous namespace)::olc_inode_48, (anonymous namespace)::olc_inode_256>, unodb::detail::db_inode_qsbr_deleter, unodb::detail::db_leaf_qsbr_deleter>, 5u, 16u, (unodb::node_type)2, (anonymous namespace)::olc_inode_4, (anonymous namespace)::olc_inode_48, (anonymous namespace)::olc_inode_16>::create<(an\ onymous namespace)::olc_inode_48&>(unodb::olc_db&, (anonymous namespace)::olc_inode_48&) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/art_internal_impl.hpp:740:12 (test_art_concurrency+0x16a135)
    #4 std::optional<bool> unodb::detail::olc_impl_helpers::remove_or_choose_subtree<(anonymous namespace)::olc_inode_48>((anonymous namespace)::olc_inode_48&, std::byte, unodb::detail::basic_art_key<unsigned long>, unodb::olc_db&, unodb::optimistic_lock::read_critical_section&, unodb::optimistic_lock::read_\
critical_section&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>*, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>**, unodb::optimistic_lock::read_critical_section*, unodb::node_type*, unodb::detail::basic_node_ptr<unodb::d\ etail::olc_node_header>*) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/olc_art.cpp:775:23 (test_art_concurrency+0x169cdb)
    #5 auto (anonymous namespace)::olc_inode_48::remove_or_choose_subtree<std::byte, unodb::detail::basic_art_key<unsigned long>&, unodb::olc_db&, unodb::optimistic_lock::read_critical_section&, unodb::optimistic_lock::read_critical_section&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::de\
tail::olc_node_header>>*&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>**, unodb::optimistic_lock::read_critical_section*, unodb::node_type*, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>*>(std::byte&&, unodb::detail::basic_art_key<unsigned long>&,\
 unodb::olc_db&, unodb::optimistic_lock::read_critical_section&, unodb::optimistic_lock::read_critical_section&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>*&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>**&&, unodb::o\
ptimistic_lock::read_critical_section*&&, unodb::node_type*&&, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>*&&) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/olc_art.cpp:472:12 (test_art_concurrency+0x1617fd)
    #6 std::optional<bool> unodb::detail::basic_inode_impl<unodb::detail::basic_art_policy<unodb::olc_db, unodb::in_critical_section, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>, unodb::detail::basic_inode_def<(anonymous namespace)::olc_inode, (anonymous namespace)::olc_inode_4, (anonymous \
namespace)::olc_inode_16, (anonymous namespace)::olc_inode_48, (anonymous namespace)::olc_inode_256>, unodb::detail::db_inode_qsbr_deleter, unodb::detail::db_leaf_qsbr_deleter>>::remove_or_choose_subtree<std::optional<bool>, std::byte, unodb::detail::basic_art_key<unsigned long>&, unodb::olc_db&, unodb::opti\ mistic_lock::read_critical_section&, unodb::optimistic_lock::read_critical_section&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>*&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>**, unodb::optimistic_lock::read_critical_\ section*, unodb::node_type*, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>*>(unodb::node_type, std::byte&&, unodb::detail::basic_art_key<unsigned long>&, unodb::olc_db&, unodb::optimistic_lock::read_critical_section&, unodb::optimistic_lock::read_critical_section&, unodb::in_critical_section<\ unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>*&, unodb::in_critical_section<unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>>**&&, unodb::optimistic_lock::read_critical_section*&&, unodb::node_type*&&, unodb::detail::basic_node_ptr<unodb::detail::olc_node_header>*&&) /home/bryan\ t/p8/src/Neptune-Playground/src/hash/unodb/art_internal_impl.hpp:627:51 (test_art_concurrency+0x15289f)
    #7 unodb::olc_db::try_remove(unodb::detail::basic_art_key<unsigned long>) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/olc_art.cpp:1215:16 (test_art_concurrency+0x1523ac)
    #8 unodb::olc_db::remove(unsigned long) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/olc_art.cpp:1120:14 (test_art_concurrency+0x150f65)
    #9 unodb::test::tree_verifier<unodb::olc_db>::try_remove(unsigned long) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/test/db_test_utils.hpp:444:25 (test_art_concurrency+0x127f8a)
    #10 (anonymous namespace)::ARTConcurrencyTest<unodb::olc_db>::random_op_thread(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long) /home/bryant/p8/src/Neptune-Playground/src/hash/unodb/test/test_art_concurrency.cpp:127:21 (test_art_concurrency+0x1046c1)
    #11 auto auto unodb::qsbr_thread::make_qsbr_thread<void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long&, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::te\
st::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::'lambda'(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&)::operator()<void (*)(unodb::test::tree_verifier<unodb::olc_db>*, \ unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long>(void (*&)(unodb::test::tree_verifier<unodb::olc_db>*, unsigned long, unsigned long), unodb::test::tree_verifier<unodb::olc_db>*&&, unsigned long&, unsigned long&&) /home/bryant/p8/src/Neptune-Playground/s\ rc/hash/unodb/./qsbr.hpp:1240:11 (test_art_concurrency+0x1237be)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted error handling logic in database operations
	- Modified thread synchronization mechanisms

- **Tests**
	- Enhanced concurrency test suite with new test cases
	- Improved test value selection for concurrent operations
	- Added stress test scenarios for parallel database operations

- **Refactor**
	- Updated thread wait loop behavior
	- Simplified critical section error checking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->