### PR TITLE
CMake: remove IWYU from MAINTAINER_MODE, fixes #629

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -407,7 +407,8 @@ jobs:
             export CC=clang
             export CXX=clang++
           fi
-          cmake "$GITHUB_WORKSPACE" "$CBT" -DSTANDALONE=ON -DMAINTAINER_MODE=ON \
+          cmake "$GITHUB_WORKSPACE" "$CBT" -DSTANDALONE=ON \
+              -DMAINTAINER_MODE=ON -DIWYU=ON \
               "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
               "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \
               "-DSANITIZE_UB=${SANITIZE_UB}" \

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -471,10 +471,6 @@ jobs:
           env.COMPILER == 'clang'
           && (env.VERSION == 13 || env.VERSION >= 15)
 
-      - name: Setup dependencies for LLVM 13+
-        run: sudo apt-get install -y iwyu
-        if: env.COMPILER == 'clang' && env.VERSION >= 13
-
       - name: Setup dependencies for GCC 12 (versioned package)
         run: |
           sudo apt-get install -y "gcc-${VERSION}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,7 @@ set_bool(is_not_msvc_clang ${is_clang} AND NOT ${is_msvc_clang})
 option(STANDALONE
   "Build UnoDB not for linking with outside code. Enables extra global checks")
 
-option(MAINTAINER_MODE
-  "Maintainer mode: compiler warnings are fatal, IWYU required")
+option(MAINTAINER_MODE "Maintainer mode: compiler warnings are fatal")
 if(MAINTAINER_MODE)
   message(STATUS "Warning diagnostics are fatal")
 else()
@@ -575,23 +574,15 @@ else()
 endif()
 
 option(IWYU "Enable include-what-you-use checking")
-if(IWYU OR MAINTAINER_MODE)
+if(IWYU)
   if(NOT is_any_clang OR is_windows)
     message(STATUS
       "Not using include-what-you-use due to non-clang compiler or Windows being used")
   else()
-    if(MAINTAINER_MODE AND NOT IWYU)
-      message(STATUS
-        "Forcing include-what-you-use because maintainer mode is on")
-    endif()
     find_program(IWYU_EXE NAMES "include-what-you-use"
       DOC "Path to include-what-you-use executable")
     if(NOT IWYU_EXE)
-      if(MAINTAINER_MODE)
-        message(FATAL_ERROR "include-what-you-use not found")
-      else()
-        message(STATUS "include-what-you-use not found")
-      endif()
+      message(FATAL_ERROR "include-what-you-use not found")
     else()
       execute_process(COMMAND "${IWYU_EXE}" "--version" OUTPUT_VARIABLE
         IWYU_VERSION_OUTPUT)

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ feature, do `git config --local include.path ../.gitconfig`. If you need to
 temporarily disable it, run `git config  --local --unset include.path`.
 
 To enable maintainer diagnostics, add `-DMAINTAINER_MODE=ON` CMake option. This
-makes compilation and `include-what-you-use` warnings fatal.
+makes compilation warnings fatal.
 
 clang-tidy, cppcheck, and cpplint will be invoked automatically during the build
 if found. The current diagnostic level for them, as well as for compiler
@@ -247,9 +247,8 @@ To enable GCC or MSVC compiler static analysis, add the `-DSTATIC_ANALYSIS=ON`
 CMake option. For LLVM static analysis, no special CMake option is needed;
 instead prepend `scan-build` to `make`.
 
-To invoke include-what-you-use without enabling the whole of maintainer mode,
-add the `-DIWYU=ON` CMake option. It will take effect if CMake configures to
-build project with clang.
+To use include-what-you-use, add the `-DIWYU=ON` CMake option. It will take
+effect if CMake configures to build project with clang.
 
 To enable inconclusive cppcheck diagnostics, add the `-DCPPCHECK_AGGRESSIVE=ON`
 CMake option. These diagnostics will not fail a build.


### PR DESCRIPTION
- Only setup IWYU if the IWYU option is given, instead of either IWYU or
  MAINTAINER_MODE
- Explicitly enable IWYU in the main GitHub Actions workflow
- Remove redundant IWYU installation in the old compilers GitHub Actions
  workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Updates**
	- Modified GitHub Actions build configuration.
	- Removed IWYU setup for older compiler configurations.

- **Build Configuration**
	- Updated CMake options for Include What You Use (IWYU).
	- Simplified IWYU and maintainer mode settings.

- **Documentation**
	- Updated README with clearer build configuration instructions.
	- Clarified CMake option descriptions for compilation warnings and IWYU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->