### PR TITLE
Bump C++ dialect version to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ set(CLANG_CXX_WARNING_FLAGS
   "-Wself-assign" "-Wshadow-all"
   # Individual warnings
   "-Wabstract-vbase-init" "-Warray-bounds-pointer-arithmetic" "-Wassign-enum"
-  "-Watomic-implicit-seq-cst" "-Wbad-function-cast" "-Wc++2a-compat"
-  "-Wc++2a-extensions" "-Wcast-align" "-Wcast-qual" "-Wclass-varargs" "-Wcomma"
+  "-Watomic-implicit-seq-cst" "-Wbad-function-cast"
+  "-Wcast-align" "-Wcast-qual" "-Wclass-varargs" "-Wcomma"
   "-Wconditional-uninitialized" "-Wcovered-switch-default" "-Wdate-time"
   "-Wdeprecated-implementations" "-Wdisabled-macro-expansion"
   "-Wdouble-promotion" "-Wduplicate-decl-specifier" "-Wduplicate-enum"
@@ -597,7 +597,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 function(COMMON_TARGET_PROPERTIES TARGET)
   cmake_parse_arguments(PARSE_ARGV 1 CTP "SKIP_CHECKS" "" "")
-  target_compile_features(${TARGET} PUBLIC cxx_std_17)
+  target_compile_features(${TARGET} PUBLIC cxx_std_20)
   set_target_properties(${TARGET} PROPERTIES CXX_EXTENSIONS OFF)
   target_compile_definitions(${TARGET} PRIVATE
     "$<${is_standalone}:UNODB_DETAIL_STANDALONE>"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ideas. I am describing some of the things I learned at my [blog](https://of-code
 
 ## Requirements
 
-UnoDB source code is written in C++17, and relies on the following
+UnoDB source code is written in C++20, and relies on the following
 platform-specific features:
 
 * On Intel platforms, it requires SSE4.1 intrinsics (Nehalem and higher), AVX

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstring>
 #include <iterator>
+#include <ranges>
 #include <type_traits>
 #include <utility>
 
@@ -234,27 +235,12 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
   pointer ptr{nullptr};
 };
 
-}  // namespace unodb
-
-namespace std {
-
-template <typename T>
-struct iterator_traits<unodb::qsbr_ptr<T>> {
-  using difference_type = ptrdiff_t;
-  using value_type = T;
-  using pointer = T *;
-  using reference = T &;
-  using iterator_category = random_access_iterator_tag;
-};
-
-}  // namespace std
-
-namespace unodb {
+static_assert(std::random_access_iterator<unodb::qsbr_ptr<std::byte>>);
 
 // A gsl::span (or std::span), but with qsbr_ptr instead of raw pointer.
 // Implemented bare minimum to get things to work, expand as necessary.
 template <class T>
-class qsbr_ptr_span {
+class qsbr_ptr_span : public std::ranges::view_base {
  public:
   UNODB_DETAIL_RELEASE_CONSTEXPR
   qsbr_ptr_span() noexcept : start{nullptr}, length{0} {}
@@ -302,6 +288,11 @@ class qsbr_ptr_span {
 
 template <class T>
 qsbr_ptr_span(const gsl::span<T> &) -> qsbr_ptr_span<T>;
+
+static_assert(
+    std::ranges::random_access_range<unodb::qsbr_ptr_span<std::byte>>);
+static_assert(std::ranges::common_range<unodb::qsbr_ptr_span<std::byte>>);
+static_assert(std::ranges::view<unodb::qsbr_ptr_span<std::byte>>);
 
 }  // namespace unodb
 

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -10,17 +10,20 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <iterator>
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
 
-#include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <gsl/span>
+#include <iterator>
 #include <utility>
+
+#include <gsl/span>
+
+#include <gtest/gtest.h>
+
 #include "gtest_utils.hpp"
 #include "qsbr_ptr.hpp"
 
@@ -269,24 +272,21 @@ TEST(QSBRPtr, Get) {
 TEST(QSBRPtrSpan, CopyGslSpanCtor) {
   const unodb::qsbr_ptr_span span{gsl_span};
 
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span), std::cend(span),
-                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span, gsl_span));
 }
 
 TEST(QSBRPtrSpan, CopyCtor) {
   const unodb::qsbr_ptr_span span{gsl_span};
   const unodb::qsbr_ptr_span span2{span};
 
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span));
 }
 
 TEST(QSBRPtrSpan, MoveCtor) {
   unodb::qsbr_ptr_span span{gsl_span};
   const unodb::qsbr_ptr_span span2{std::move(span)};
 
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span));
   UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
 }
 
@@ -295,15 +295,12 @@ TEST(QSBRPtrSpan, CopyAssignment) {
   const unodb::qsbr_ptr_span span{gsl_span};
   unodb::qsbr_ptr_span span2{gsl_span2};
 
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span2), std::cend(gsl_span2)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span2));
   span2 = span;
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span));
 
   span2 = span2;  // -V570
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span));
 }
 UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
@@ -311,11 +308,9 @@ TEST(QSBRPtrSpan, MoveAssignment) {
   unodb::qsbr_ptr_span span{gsl_span};
   unodb::qsbr_ptr_span span2{gsl_span2};
 
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span2), std::cend(gsl_span2)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span2));
   span2 = std::move(span);
-  UNODB_ASSERT_TRUE(std::equal(std::cbegin(span2), std::cend(span2),
-                               std::cbegin(gsl_span), std::cend(gsl_span)));
+  UNODB_ASSERT_TRUE(std::ranges::equal(span2, gsl_span));
   UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Development**
	- Updated project's C++ standard from C++17 to C++20.
	- Modified project documentation to reflect new C++ version requirement.
	- Enhanced functionality in `qsbr_ptr` with new static assertions for range compatibility.
	- Updated test cases to utilize modern range comparison methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->