### PR TITLE
Make read_critical_section::lock mutable in debug builds

### DIFF
--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Laurynas Biveinis
+// Copyright (C) 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_OPTIMISTIC_LOCK_HPP
 #define UNODB_DETAIL_OPTIMISTIC_LOCK_HPP
 
@@ -242,7 +242,7 @@ class [[nodiscard]] optimistic_lock final {
     // the version that was used to construct this
     // read_critical_section.
     [[nodiscard, gnu::flatten]] UNODB_DETAIL_FORCE_INLINE bool try_read_unlock()
-        UNODB_DETAIL_RELEASE_CONST noexcept {
+        const noexcept {
       const auto result = lock->try_read_unlock(version);
 #ifndef NDEBUG
       lock = nullptr;
@@ -269,7 +269,7 @@ class [[nodiscard]] optimistic_lock final {
     //
     // @return true if the version is unchanged and false if the
     // caller MUST restart because the version has been changed.
-    [[nodiscard]] bool check() UNODB_DETAIL_RELEASE_CONST noexcept {
+    [[nodiscard]] bool check() const noexcept {
       const auto result = lock->check(version);
 #ifndef NDEBUG
       if (UNODB_DETAIL_UNLIKELY(!result)) lock = nullptr;  // LCOV_EXCL_LINE
@@ -307,7 +307,11 @@ class [[nodiscard]] optimistic_lock final {
     read_critical_section &operator=(const read_critical_section &) = delete;
 
    private:
-    optimistic_lock *lock{nullptr};
+#ifndef NDEBUG
+    mutable
+#endif
+        optimistic_lock *lock{nullptr};
+
     version_type version{0};
 
     friend class write_guard;


### PR DESCRIPTION
This reflects usage and allows making try_read_unlock and check methods
unconditionally const instead of const-in-release-build-only.

This, in turn allows making the cs argument to olc_art.cpp:UNLOCK const, fixing
a cppcheck error [1]. At the same time rename UNLOCK to unlock_to_return, mark
the function nodiscard and noexcept.

[1]:

olc_art.cpp:97:67: style: Parameter 'cs' can be declared as reference to const [constParameterReference]
inline bool UNLOCK(unodb::optimistic_lock::read_critical_section &cs,
                                                                  ^
