### PR TITLE
Replace gsl::narrow_cast with plain static_cast

### DIFF
--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 Laurynas Biveinis
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -16,7 +16,6 @@
 
 #include <deepstate/DeepState.h>
 #include <deepstate/DeepState.hpp>
-#include <gsl/util>
 
 #include "art.hpp"
 #include "art_common.hpp"
@@ -43,7 +42,7 @@ using oracle_type = std::unordered_map<unodb::key, unodb::value_view>;
     // Ideally we would take random bytes from DeepState, but we'd end up
     // exhausting their default source len too soon. Do something deterministic
     // that has embedded zero bytes to shake out any C string API use
-    result[i] = gsl::narrow_cast<std::byte>(i % 256);
+    result[i] = static_cast<std::byte>(i % 256);
   }
   return result;
 }

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_PORTABILITY_BUILTINS_HPP
 #define UNODB_DETAIL_PORTABILITY_BUILTINS_HPP
 
@@ -13,8 +13,7 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstdint>
-
-#include <gsl/util>
+#include <type_traits>
 
 #ifdef UNODB_DETAIL_MSVC
 #include <intrin.h>
@@ -42,31 +41,31 @@ template <typename T>
 
   if constexpr (std::is_same_v<unsigned, T>) {
 #ifndef UNODB_DETAIL_MSVC
-    return gsl::narrow_cast<std::uint8_t>(__builtin_ctz(x));
+    return static_cast<std::uint8_t>(__builtin_ctz(x));
 #else
     unsigned long result;  // NOLINT(runtime/int)
     _BitScanForward(&result, x);
-    return gsl::narrow_cast<std::uint8_t>(result);
+    return static_cast<std::uint8_t>(result);
 #endif
   }
   // NOLINTNEXTLINE(google-runtime-int)
   if constexpr (std::is_same_v<unsigned long, T>) {  // NOLINT(runtime/int)
 #ifndef UNODB_DETAIL_MSVC
-    return gsl::narrow_cast<std::uint8_t>(__builtin_ctzl(x));
+    return static_cast<std::uint8_t>(__builtin_ctzl(x));
 #else
     unsigned long result;  // NOLINT(runtime/int)
     _BitScanForward(&result, x);
-    return gsl::narrow_cast<std::uint8_t>(result);
+    return static_cast<std::uint8_t>(result);
 #endif
   }
   // NOLINTNEXTLINE(google-runtime-int)
   if constexpr (std::is_same_v<unsigned long long, T>) {  // NOLINT(runtime/int)
 #ifndef UNODB_DETAIL_MSVC
-    return gsl::narrow_cast<std::uint8_t>(__builtin_ctzll(x));
+    return static_cast<std::uint8_t>(__builtin_ctzll(x));
 #else
     unsigned long result;  // NOLINT(runtime/int)
     _BitScanForward64(&result, x);
-    return gsl::narrow_cast<std::uint8_t>(result);
+    return static_cast<std::uint8_t>(result);
 #endif
   }  // cppcheck-suppress missingReturn
 }

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2025 Laurynas Biveinis
+// Copyright (C) 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_QSBR_HPP
 #define UNODB_DETAIL_QSBR_HPP
 
@@ -35,8 +35,6 @@
 #endif
 #include <utility>
 #include <vector>
-
-#include <gsl/util>
 
 #ifdef UNODB_DETAIL_WITH_STATS
 
@@ -102,8 +100,7 @@ class [[nodiscard]] qsbr_epoch final {
     assert_invariant();
 #endif
 
-    return qsbr_epoch{
-        gsl::narrow_cast<epoch_type>((epoch_val + by) % max_count)};
+    return qsbr_epoch{static_cast<epoch_type>((epoch_val + by) % max_count)};
   }
 
   [[nodiscard]] constexpr auto operator==(qsbr_epoch other) const noexcept {
@@ -175,11 +172,11 @@ struct qsbr_state {
  private:
   [[nodiscard]] static constexpr auto do_get_epoch(type word) noexcept {
     return qsbr_epoch{
-        gsl::narrow_cast<qsbr_epoch::epoch_type>(word >> epoch_in_word_offset)};
+        static_cast<qsbr_epoch::epoch_type>(word >> epoch_in_word_offset)};
   }
 
   [[nodiscard]] static constexpr auto do_get_thread_count(type word) noexcept {
-    const auto result = gsl::narrow_cast<qsbr_thread_count_type>(
+    const auto result = static_cast<qsbr_thread_count_type>(
         (word & thread_count_in_word_mask) >> thread_count_in_word_offset);
     UNODB_DETAIL_ASSERT(result <= max_qsbr_threads);
     return result;
@@ -187,7 +184,7 @@ struct qsbr_state {
 
   [[nodiscard]] static constexpr auto do_get_threads_in_previous_epoch(
       type word) noexcept {
-    const auto result = gsl::narrow_cast<qsbr_thread_count_type>(
+    const auto result = static_cast<qsbr_thread_count_type>(
         word & threads_in_previous_epoch_in_word_mask);
     UNODB_DETAIL_ASSERT(result <= max_qsbr_threads);
     return result;


### PR DESCRIPTION
In preparation to dropping GSL dependency, replace gsl::narrow_cast uses with
plain static_cast. Do not introduce own template as it does not enforce anything
about the value ranges and is just documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Copyright**
  - Updated copyright years to 2025 for multiple files
  - Transitioned copyright attribution to "UnoDB contributors"

- **Dependency Management**
  - Removed `<gsl/util>` include directives from several files
  - Replaced with standard C++ headers like `<type_traits>`

- **Code Refactoring**
  - Standardized type casting from `gsl::narrow_cast` to `static_cast`
  - Updated type conversion methods across multiple implementation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->