### PR TITLE
Make qsbr_ptr::operator* and friend operator+(difference_type, qsbr_ptr) noexcept

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,7 +12,8 @@
             "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "STANDALONE": "ON",
-                "MAINTAINER_MODE": "ON"
+                "MAINTAINER_MODE": "ON",
+                "IWYU": "ON"
             }
         },
         {

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -109,7 +109,7 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-  [[nodiscard]] constexpr reference operator*() const { return *ptr; }
+  [[nodiscard]] constexpr reference operator*() const noexcept { return *ptr; }
 
   [[nodiscard]] constexpr reference operator[](
       difference_type n) const noexcept {
@@ -170,7 +170,7 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
   }
 
   [[nodiscard]] friend constexpr qsbr_ptr operator+(difference_type n,
-                                                    qsbr_ptr other) {
+                                                    qsbr_ptr other) noexcept {
     return other + n;
   }
 


### PR DESCRIPTION
At the same time add IYWU=ON to CMake presets, where it was missing since IWYU
split from MAINTAINER_MODE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added IWYU (Include What You Use) configuration option in CMake presets.

- **Improvements**
	- Enhanced error handling by adding `noexcept` specifications to pointer operations in `qsbr_ptr` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->