### PR TITLE
Migrate from gsl::span to C++20 std::span

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ platform-specific features:
 
 ### Build dependencies, bundled as git submodules
 
-* Guidelines Support Library for `gsl::span`.
+* Guidelines Support Library.
 * Google Test for tests.
 * Google Benchmark for microbenchmarks.
 * [DeepState][deepstate] for fuzzing tests.
@@ -111,13 +111,14 @@ descriptions below.
 
 The only currently supported key type is `std::uint64_t`, aliased as `key`. To
 add a new simple key type, instantiate `art_key` type with the desired type, and
-specialize `art_key::make_binary_comparable` according to the ART paper. Compound
-keys or Unicode data should be handled by specifying gsl::span<std::byte> as the
-key type.  In this case, the application must provide a span suitably encoded for
-lexicographic comparisons (that is, one which is already binary compatible).
+specialize `art_key::make_binary_comparable` according to the ART paper.
+Compound keys or Unicode data should be handled by specifying
+`std::span<std::byte>` as the key type. In this case, the application must
+provide a span suitably encoded for lexicographic comparisons (that is, one
+which is already binary compatible).
 
 Values are treated opaquely. For `unodb::db`, they are passed as non-owning
-objects of `value_view` (a `gsl::span<std::byte>`), and insertion copies them
+objects of `value_view` (a `std::span<std::byte>`), and insertion copies them
 internally. The same applies for `get`, which returns a non-owning `value_view`.
 For `unodb::olc_db`, `get` returns a `qsbr_value_view`, a `span` guaranteed to
 remain valid until the current thread passes through a quiescent state.

--- a/art.cpp
+++ b/art.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND

--- a/art.hpp
+++ b/art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_ART_HPP
 #define UNODB_DETAIL_ART_HPP
 
@@ -12,15 +12,15 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <__fwd/ostream.h>
-// IWYU pragma: no_include <ostream>
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
 
 #include <cstddef>
 #include <cstdint>
-#include <iosfwd>  // IWYU pragma: keep
+#include <iostream>
 #include <limits>
 #include <optional>
 #include <stack>
+#include <type_traits>
 
 #include "art_common.hpp"
 #include "art_internal.hpp"
@@ -33,7 +33,7 @@ namespace unodb {
 
 namespace detail {
 
-class inode;
+class inode;  // IWYU pragma: keep
 
 class inode_4;
 class inode_16;
@@ -43,16 +43,6 @@ class inode_256;
 struct [[nodiscard]] node_header {};
 
 static_assert(std::is_empty_v<node_header>);
-
-template <class,                   // Db
-          template <class> class,  // CriticalSectionPolicy
-          class,                   // Fake lock implementation
-          class,                   // Fake read_critical_section implementation
-          class,                   // NodePtr
-          class,                   // INodeDefs
-          template <class> class,  // INodeReclamator
-          template <class, class> class>  // LeafReclamator
-struct basic_art_policy;                  // IWYU pragma: keep
 
 using node_ptr = basic_node_ptr<node_header>;
 

--- a/art_common.cpp
+++ b/art_common.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 Laurynas Biveinis
+// Copyright 2021-2025 UnoDB contributors
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -10,10 +10,12 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
+
 #include "art_common.hpp"
 
-#include <iomanip>
-#include <iostream>
+#include <iomanip>   // IWYU pragma: keep
+#include <iostream>  // IWYU pragma: keep
 
 namespace unodb::detail {
 

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_ART_COMMON_HPP
 #define UNODB_DETAIL_ART_COMMON_HPP
 
@@ -13,12 +13,13 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>
+// IWYU pragma: no_include <ostream>
+// IWYU pragma: no_include <ostream.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>  // IWYU pragma: keep
-
-#include <gsl/span>
+#include <span>
 
 namespace unodb {
 
@@ -32,8 +33,8 @@ namespace detail {
 }  // namespace detail
 
 // Values are passed as non-owning pointers to memory with associated length
-// (gsl::span). The memory is copied upon insertion.
-using value_view = gsl::span<const std::byte>;
+// (std::span). The memory is copied upon insertion.
+using value_view = std::span<const std::byte>;
 
 }  // namespace unodb
 

--- a/art_internal.cpp
+++ b/art_internal.cpp
@@ -10,11 +10,13 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
+
 #include "art_internal.hpp"
 
 #include <cstddef>
 #include <iomanip>
-#include <iostream>
+#include <iostream>  // IWYU pragma: keep
 
 namespace unodb::detail {
 

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_ART_INTERNAL_HPP
 #define UNODB_DETAIL_ART_INTERNAL_HPP
 
@@ -14,6 +14,7 @@
 
 // IWYU pragma: no_include <__fwd/ostream.h>
 // IWYU pragma: no_include <_string.h>
+// IWYU pragma: no_include <ostream>
 
 #include <array>
 #include <cstddef>
@@ -39,20 +40,18 @@ class [[nodiscard]] basic_db_leaf_deleter;
 // Internal ART key in binary-comparable format
 template <typename KeyType>
 struct [[nodiscard]] basic_art_key final {
-  // Convert an external key into an internal key supporting
-  // lexicographic comparison.  This is only intended for key types
-  // for which simple conversions are possible.  For complex keys,
-  // including multiple key components or Unicode data, the
-  // application should use a gsl::space<std::byte> which already
-  // supports lexicographic comparison.
+  // Convert an external key into an internal key supporting lexicographic
+  // comparison. This is only intended for key types for which simple
+  // conversions are possible. For complex keys, including multiple key
+  // components or Unicode data, the application should use a
+  // std::span<std::byte> which already supports lexicographic comparison.
   [[nodiscard, gnu::const]] static UNODB_DETAIL_CONSTEXPR_NOT_MSVC KeyType
   make_binary_comparable(KeyType key) noexcept;
 
-  // Convert an internal key into an external key. This is only
-  // intended for key types for which simple conversions are possible.
-  // For complex keys, including multiple key components or Unicode
-  // data, the application should use a gsl::space<std::byte> which
-  // already supports lexicographic comparison.
+  // Convert an internal key into an external key. This is only intended for key
+  // types for which simple conversions are possible. For complex keys,
+  // including multiple key components or Unicode data, the application should
+  // use a std::span<std::byte> which already supports lexicographic comparison.
   [[nodiscard, gnu::const]] static UNODB_DETAIL_CONSTEXPR_NOT_MSVC KeyType
   make_external(KeyType key) noexcept;
 

--- a/benchmark/micro_benchmark.cpp
+++ b/benchmark/micro_benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -11,21 +11,26 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>
+// IWYU pragma: no_include <tuple>
 // IWYU pragma: no_include <vector>
+// IWYU pragma: no_forward_declare unodb::visitor
 
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <utility>  // IWYU pragma: keep
 
 #include <benchmark/benchmark.h>
 
 #include "art.hpp"
 #include "art_common.hpp"
-#include "micro_benchmark_node_utils.hpp"
-#include "micro_benchmark_utils.hpp"
+#include "art_internal.hpp"
 #include "mutex_art.hpp"
 #include "node_type.hpp"
 #include "olc_art.hpp"
+
+#include "micro_benchmark_node_utils.hpp"
+#include "micro_benchmark_utils.hpp"
 
 namespace {
 

--- a/examples/example_art.cpp
+++ b/examples/example_art.cpp
@@ -1,11 +1,11 @@
-// Copyright 2024 Laurynas Biveinis
+// Copyright 2024-2025 UnoDB contributors
 
 // A simple CRUD example for unodb::db. For simplicity &
 // self-containedness does not concern with exception handling and refactoring
 // the duplicated code with other examples.
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>
-// IWYU pragma: no_include <gsl/span>
+// IWYU pragma: no_include <span>
 
 #include "global.hpp"  // IWYU pragma: keep
 
@@ -14,6 +14,8 @@
 #include <string_view>
 
 #include "art.hpp"
+#include "art_common.hpp"
+#include "art_internal.hpp"
 
 namespace {
 

--- a/examples/example_olc_art.cpp
+++ b/examples/example_olc_art.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <string_view>
 
+#include "art_common.hpp"
 #include "olc_art.hpp"
 #include "qsbr.hpp"
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_OLC_ART_HPP
 #define UNODB_DETAIL_OLC_ART_HPP
 
@@ -12,17 +12,17 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <__fwd/ostream.h>
-// IWYU pragma: no_include <ostream>
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
 
 #include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <iosfwd>  // IWYU pragma: keep
+#include <iostream>
 #include <optional>
 #include <stack>
 #include <tuple>
+#include <type_traits>
 
 #include "art_common.hpp"
 #include "art_internal.hpp"

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -12,16 +12,12 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <_string.h>
-
 #include <cstddef>
-#include <cstring>
 #include <iterator>
 #include <ranges>
+#include <span>
 #include <type_traits>
 #include <utility>
-
-#include <gsl/span>
 
 namespace unodb {
 
@@ -237,8 +233,8 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
 
 static_assert(std::random_access_iterator<unodb::qsbr_ptr<std::byte>>);
 
-// A gsl::span (or std::span), but with qsbr_ptr instead of raw pointer.
-// Implemented bare minimum to get things to work, expand as necessary.
+// An std::span, but with qsbr_ptr instead of a raw pointer.
+// Implemented the bare minimum to get things to work, expand as necessary.
 template <class T>
 class qsbr_ptr_span : public std::ranges::view_base {
  public:
@@ -246,7 +242,7 @@ class qsbr_ptr_span : public std::ranges::view_base {
   qsbr_ptr_span() noexcept : start{nullptr}, length{0} {}
 
   UNODB_DETAIL_RELEASE_CONSTEXPR
-  explicit qsbr_ptr_span(const gsl::span<T> &other) noexcept
+  explicit qsbr_ptr_span(const std::span<T> &other) noexcept
       : start{other.data()}, length{static_cast<std::size_t>(other.size())} {}
 
   UNODB_DETAIL_RELEASE_CONSTEXPR qsbr_ptr_span(
@@ -269,25 +265,13 @@ class qsbr_ptr_span : public std::ranges::view_base {
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-  [[nodiscard]] constexpr bool operator==(gsl::span<T> other) const noexcept {
-    if (length != other.size()) return false;      // element count differs?
-    if (start.get() == other.data()) return true;  // same ptr and #of elements
-    if (length == 0) return true;                  // both empty (before ptrs)
-    if (start.get() == nullptr || other.data() == nullptr) return false;
-    return std::memcmp(start.get(), other.data(), length * sizeof(T)) == 0;
-  }
-
-  [[nodiscard]] constexpr bool operator!=(gsl::span<T> other) const noexcept {
-    return !this->operator==(other);
-  }
-
  private:
   qsbr_ptr<T> start;
   std::size_t length;
 };
 
 template <class T>
-qsbr_ptr_span(const gsl::span<T> &) -> qsbr_ptr_span<T>;
+qsbr_ptr_span(const std::span<T> &) -> qsbr_ptr_span<T>;
 
 static_assert(
     std::ranges::random_access_range<unodb::qsbr_ptr_span<std::byte>>);

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_DB_TEST_UTILS_HPP
 #define UNODB_DETAIL_DB_TEST_UTILS_HPP
 
@@ -472,26 +472,6 @@ extern template class tree_verifier<unodb::mutex_db>;
 extern template class tree_verifier<unodb::olc_db>;
 
 using olc_tree_verifier = tree_verifier<unodb::olc_db>;
-
-// Note: gsl::span does not define equality (because in the general
-// case the data pointer do could be modified) but we rely on
-// comparing gsl::span values in the scan test.  Anyway....
-template <typename T>
-bool SAME_SPAN(const gsl::span<T> a, const gsl::span<T> b) {
-  if (a.size() != b.size()) return false;  // element count differs?
-  if (a.data() == b.data()) return true;   // same ptr and #of elements
-  if (a.size() == 0) return true;          // both empty (before ptrs).
-  if (a.data() == nullptr || b.data() == nullptr) return false;
-  return std::memcmp(a.data(), b.data(), a.size() * sizeof(T)) == 0;
-}
-
-// This version compares the visited values for the OLC scan with a
-// span.  You need this for the OLC tests and the version above for
-// the non-OLC tests.
-template <typename T>
-bool SAME_SPAN(const unodb::qsbr_ptr_span<T> a, const gsl::span<T> b) {
-  return a.operator==(b);
-}
 
 }  // namespace unodb::test
 

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -11,24 +11,27 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>
-// IWYU pragma: no_include <type_traits>
-// IWYU pragma: no_include "gtest/gtest.h"
+// IWYU pragma: no_forward_declare unodb::visitor
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
 #include <random>
 #include <tuple>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_internal.hpp"
 #include "assert.hpp"
-#include "db_test_utils.hpp"
-#include "gtest_utils.hpp"
 #include "mutex_art.hpp"
 #include "olc_art.hpp"
 #include "qsbr.hpp"
+
+#include "db_test_utils.hpp"
+#include "gtest_utils.hpp"
 #include "qsbr_test_utils.hpp"
 
 namespace {
@@ -116,7 +119,7 @@ class ARTConcurrencyTest : public ::testing::Test {
           unodb::test::test_values[akey % unodb::test::test_values.size()];
       const auto actual = v.get_value();
       // LCOV_EXCL_START
-      EXPECT_TRUE(unodb::test::SAME_SPAN(actual, expected));
+      EXPECT_TRUE(std::ranges::equal(actual, expected));
       std::ignore = v.get_value();
       if (fwd) {  // [k0,k1) -- k0 is from_key, k1 is to_key
         EXPECT_TRUE(akey >= k0 && akey < k1)

--- a/test/test_art_iter.cpp
+++ b/test/test_art_iter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -10,12 +10,16 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
 // IWYU pragma: no_include <array>
 // IWYU pragma: no_include <string>
-// IWYU pragma: no_include "gtest/gtest.h"
+// IWYU pragma: no_include "art_internal_impl.hpp"
+
+#include <algorithm>
+#include <iostream>
 
 #include <gtest/gtest.h>
-#include <iostream>
+
 #include "art.hpp"
 #include "art_common.hpp"
 #include "art_internal.hpp"
@@ -29,7 +33,7 @@ namespace unodb {
 // Test suite for an ART iterator.
 //
 // TODO(thompsonbry) variable length keys :: unit tests for
-// gsl::span<std::byte>
+// std::span<std::byte>
 template <class Db>
 class ARTIteratorTest : public ::testing::Test {
  public:
@@ -75,7 +79,8 @@ TYPED_TEST(ARTIteratorTest, singleLeafIteratorOneValue) {
   const auto k = b.get_key();
   const auto v = b.get_val();
   UNODB_EXPECT_TRUE(k && k.value() == 0);
-  UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(v.has_value() &&
+                    std::ranges::equal(v.value(), unodb::test::test_values[0]));
   b.next();                       // advance.
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
 }
@@ -93,7 +98,9 @@ TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesForwardScan) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[0]));
   }
   b.next();  // advance
   UNODB_EXPECT_TRUE(b.valid());
@@ -101,7 +108,9 @@ TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesForwardScan) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 1);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
   }
   b.next();                       // advance.
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -120,7 +129,9 @@ TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesReverseScan) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 1);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
@@ -128,7 +139,9 @@ TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesReverseScan) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[0]));
   }
   b.prior();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -153,7 +166,9 @@ TYPED_TEST(ARTIteratorTest, C0001) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[0]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
@@ -161,7 +176,9 @@ TYPED_TEST(ARTIteratorTest, C0001) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xaa01);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
@@ -169,7 +186,9 @@ TYPED_TEST(ARTIteratorTest, C0001) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xab00);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[2]));
   }
   b.next();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -194,7 +213,9 @@ TYPED_TEST(ARTIteratorTest, C0002) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xab00);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[2]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
@@ -202,7 +223,9 @@ TYPED_TEST(ARTIteratorTest, C0002) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xaa01);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
@@ -210,7 +233,9 @@ TYPED_TEST(ARTIteratorTest, C0002) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[0]));
   }
   b.prior();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -235,7 +260,9 @@ TYPED_TEST(ARTIteratorTest, C0003) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[0]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
@@ -243,7 +270,9 @@ TYPED_TEST(ARTIteratorTest, C0003) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xab0c);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
@@ -251,7 +280,9 @@ TYPED_TEST(ARTIteratorTest, C0003) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xab0d);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[2]));
   }
   b.next();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -276,7 +307,9 @@ TYPED_TEST(ARTIteratorTest, C0004) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xab0d);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[2]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
@@ -284,7 +317,9 @@ TYPED_TEST(ARTIteratorTest, C0004) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xab0c);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
@@ -292,7 +327,9 @@ TYPED_TEST(ARTIteratorTest, C0004) {
     const auto k = b.get_key();
     const auto v = b.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 0xaa00);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[0]));
   }
   b.prior();
   UNODB_EXPECT_FALSE(b.valid());
@@ -336,7 +373,9 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     const auto k = it.get_key();
     const auto v = it.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 1);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());
   }
@@ -349,7 +388,9 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     const auto k = it.get_key();
     const auto v = it.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 1);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());  // nothing more in the iterator.
   }
@@ -364,7 +405,9 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     const auto k = it.get_key();
     const auto v = it.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 1);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());
   }
@@ -394,7 +437,9 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     const auto k = it.get_key();
     const auto v = it.get_val();
     UNODB_EXPECT_TRUE(k && k.value() == 1);
-    UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+    UNODB_EXPECT_TRUE(
+        v.has_value() &&
+        std::ranges::equal(v.value(), unodb::test::test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());
   }
@@ -425,7 +470,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k0);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[0]));
     }
     {  // exact match, forward traversal (GTE), middle key.
       bool match = false;
@@ -436,7 +483,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k1);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[1]));
     }
     {  // exact match, forward traversal (GTE), last key.
       bool match = false;
@@ -447,7 +496,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k2);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[2]));
     }
   }
   {    // exact match, reverse traversal
@@ -460,7 +511,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k0);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[0]));
     }
     {  // exact match, reverse traversal (LTE), middle key.
       bool match = false;
@@ -471,7 +524,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k1);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[1]));
     }
     {  // exact match, reverse traversal (LTE), last key.
       bool match = false;
@@ -482,7 +537,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k2);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[2]));
     }
   }
   {    // before and after the first and last key
@@ -497,7 +554,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k0);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[0]));
     }
     {  // forward traversal, after the last key in the data.  match=false
       // and iterator is invalidated.
@@ -525,7 +584,9 @@ TYPED_TEST(ARTIteratorTest, C101) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k2);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[2]));
       it.next();
       UNODB_EXPECT_FALSE(it.valid());  // nothing more in the iterator.
     }
@@ -559,7 +620,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k0);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[0]));
     }
     {  // exact match, forward traversal (GTE), middle key.
       bool match = false;
@@ -570,7 +633,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k1);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[1]));
     }
     {  // exact match, forward traversal (GTE), last key.
       bool match = false;
@@ -581,7 +646,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k2);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[2]));
     }
   }
   {    // exact match, reverse traversal
@@ -594,7 +661,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k0);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[0]));
     }
     {  // exact match, reverse traversal (LTE), middle key.
       bool match = false;
@@ -605,7 +674,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k1);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[1]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[1]));
     }
     {  // exact match, reverse traversal (LTE), last key.
       bool match = false;
@@ -616,7 +687,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k2);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[2]));
     }
   }
   {    // before and after the first and last key
@@ -635,7 +708,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       const auto k = it.get_key();
       const auto v = it.get_val();
       UNODB_EXPECT_TRUE(k && k.value() == k0);
-      UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[0]);
+      UNODB_EXPECT_TRUE(
+          v.has_value() &&
+          std::ranges::equal(v.value(), unodb::test::test_values[0]));
     }
     {  // forward traversal, after the last key in the data.
        // match=false and iterator is invalidated.
@@ -676,7 +751,9 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
         const auto k = it.get_key();
         const auto v = it.get_val();
         UNODB_EXPECT_TRUE(k && k.value() == k2);
-        UNODB_EXPECT_TRUE(v && v.value() == unodb::test::test_values[2]);
+        UNODB_EXPECT_TRUE(
+            v.has_value() &&
+            std::ranges::equal(v.value(), unodb::test::test_values[2]));
         it.next();
         UNODB_EXPECT_FALSE(it.valid());
       }

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -10,28 +10,35 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
 // IWYU pragma: no_include <array>
+// IWYU pragma: no_include <span>
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include <iterator>
-// IWYU pragma: no_include "gtest/gtest.h"
+// IWYU pragma: no_forward_declare unodb::visitor
 
-#include <gtest/gtest.h>
+#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
+
+#include <gtest/gtest.h>
+
 #include "art.hpp"
 #include "art_common.hpp"
-#include "db_test_utils.hpp"
-#include "gtest_utils.hpp"
+#include "art_internal.hpp"
 #include "mutex_art.hpp"
 #include "olc_art.hpp"
+
+#include "db_test_utils.hpp"
+#include "gtest_utils.hpp"
 
 namespace {
 
 // Test suite for scan() API for the ART.
 //
-// FIXME variable length keys: unit tests for gsl::span<std::byte>
+// FIXME variable length keys: unit tests for std::span<std::byte>
 //
 template <class Db>
 class ARTScanTest : public ::testing::Test {
@@ -136,7 +143,7 @@ void do_scan_range_test(const unodb::key from_key, const unodb::key to_key,
       return true;  // halt early.
       // LCOV_EXCL_STOP
     }
-    EXPECT_TRUE(unodb::test::SAME_SPAN(aval, eval));
+    EXPECT_TRUE(std::ranges::equal(aval, eval));
     nactual++;     // count #of visited keys.
     eit++;         // advance iterator over the expected keys.
     return false;  // !halt (aka continue scan).
@@ -215,7 +222,8 @@ TYPED_TEST(ARTScanTest, scanForwardOneLeaf) {
   db.scan(fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(
+      std::ranges::equal(visited_val, unodb::test::test_values[0]));
 }
 
 TYPED_TEST(ARTScanTest, scanFromForwardOneLeaf) {
@@ -235,7 +243,8 @@ TYPED_TEST(ARTScanTest, scanFromForwardOneLeaf) {
   db.scan_from(0, fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(
+      std::ranges::equal(visited_val, unodb::test::test_values[0]));
 }
 
 TYPED_TEST(ARTScanTest, scanRangeForwardOneLeaf) {
@@ -255,7 +264,8 @@ TYPED_TEST(ARTScanTest, scanRangeForwardOneLeaf) {
   db.scan_range(0, 1, fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(
+      std::ranges::equal(visited_val, unodb::test::test_values[0]));
 }
 
 TYPED_TEST(ARTScanTest, scanForwardTwoLeaves) {
@@ -579,7 +589,8 @@ TYPED_TEST(ARTScanTest, scanReverseOneLeaf) {
   db.scan(fn, false /*fwd*/);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(
+      std::ranges::equal(visited_val, unodb::test::test_values[0]));
 }
 
 TYPED_TEST(ARTScanTest, scanFromReverseOneLeaf) {
@@ -599,7 +610,8 @@ TYPED_TEST(ARTScanTest, scanFromReverseOneLeaf) {
   db.scan_from(0, fn, false /*fwd*/);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(
+      std::ranges::equal(visited_val, unodb::test::test_values[0]));
 }
 
 TYPED_TEST(ARTScanTest, scanRangeReverseOneLeaf) {
@@ -619,7 +631,8 @@ TYPED_TEST(ARTScanTest, scanRangeReverseOneLeaf) {
   db.scan_range(1, 0, fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 1);
-  UNODB_EXPECT_EQ(visited_val, unodb::test::test_values[0]);
+  UNODB_EXPECT_TRUE(
+      std::ranges::equal(visited_val, unodb::test::test_values[0]));
 }
 
 TYPED_TEST(ARTScanTest, scanReverseTwoLeaves) {


### PR DESCRIPTION
Replace gsl::span with std::span everywhere, including the public API, and
include <span> instead of <gsl/span>. Remove SAME_SPAN functions, and use
std::ranges::equal instead.

In the touched code update the copyright assignments, do include-what-you-use
fixing.

This will allow dropping the GSL dependency altogether.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Documentation**
	- Updated copyright notices from "2019-2024 Laurynas Biveinis" to "2019-2025 UnoDB contributors" across multiple files.
	- Simplified library dependency descriptions in README.

- **Dependency Changes**
	- Transitioned from GSL (Guideline Support Library) span to standard library's `std::span`.
	- Updated header inclusions to use more standard C++ library components.

- **Testing**
	- Updated test cases to use standard library range comparisons.
	- Modernized span and comparison methods in test utilities.

- **Code Quality**
	- Added IWYU (Include What You Use) pragmas for better header management.
	- Improved header organization and inclusion strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->