### PR TITLE
Make qsbr_ptr_range a std::ranges::sized_range

### DIFF
--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -270,6 +270,10 @@ class qsbr_ptr_span : public std::ranges::view_base {
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
+  [[nodiscard, gnu::pure]] constexpr std::size_t size() const noexcept {
+    return length;
+  }
+
  private:
   qsbr_ptr<T> start;
   std::size_t length;
@@ -289,6 +293,7 @@ static_assert(
 static_assert(std::ranges::borrowed_range<unodb::qsbr_ptr_span<std::byte>>);
 static_assert(std::ranges::contiguous_range<unodb::qsbr_ptr_span<std::byte>>);
 static_assert(std::ranges::common_range<unodb::qsbr_ptr_span<std::byte>>);
+static_assert(std::ranges::sized_range<unodb::qsbr_ptr_span<std::byte>>);
 static_assert(std::ranges::view<unodb::qsbr_ptr_span<std::byte>>);
 
 #endif  // UNODB_DETAIL_QSBR_PTR_HPP

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -265,6 +265,12 @@ TEST(QSBRPtr, Get) {
   UNODB_ASSERT_EQ(ptr.get(), &x);
 }
 
+TEST(QSBRPtrSpan, DefaultCtor) {
+  const unodb::qsbr_ptr_span<const char> span{};
+  UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
+  UNODB_ASSERT_EQ(span.size(), 0);
+}
+
 TEST(QSBRPtrSpan, CopyStdSpanCtor) {
   const unodb::qsbr_ptr_span span{std_span};
 
@@ -283,7 +289,6 @@ TEST(QSBRPtrSpan, MoveCtor) {
   const unodb::qsbr_ptr_span span2{std::move(span)};
 
   UNODB_ASSERT_TRUE(std::ranges::equal(span2, std_span));
-  UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
 }
 
 UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
@@ -307,7 +312,6 @@ TEST(QSBRPtrSpan, MoveAssignment) {
   UNODB_ASSERT_TRUE(std::ranges::equal(span2, std_span2));
   span2 = std::move(span);
   UNODB_ASSERT_TRUE(std::ranges::equal(span2, std_span));
-  UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
 }
 
 TEST(QSBRPtrSpan, Cbegin) {
@@ -323,6 +327,13 @@ TEST(QSBRPtrSpan, Cend) {
 }
 
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+TEST(QSBRPtrSpan, Size) {
+  const unodb::qsbr_ptr_span span{std_span};
+  UNODB_ASSERT_EQ(span.size(), std_span.size());
+  const unodb::qsbr_ptr_span span2{std_span2};
+  UNODB_ASSERT_EQ(span2.size(), std_span2.size());
+}
 
 TEST(QSBRPtr, GreaterThan) {
   // NOLINTNEXTLINE(readability-container-data-pointer)


### PR DESCRIPTION
- Implement qsbr_ptr_range::size method
- Add a static_assert for the sized_range concept
- Add unit tests for the default constructor and the size method
- Remove checks for moved-from objects in the unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `size()` method to `qsbr_ptr_span` class to retrieve span length
	- Enhanced test coverage for `qsbr_ptr_span` class with new test cases

- **Tests**
	- Added tests to verify default constructor and size functionality
	- Simplified existing move-related tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->