### PR TITLE
Make UNODB_DETAIL_ABORT and UNODB_DETAIL_CRASH expand to assert and abort on non-standalone

### DIFF
--- a/assert.hpp
+++ b/assert.hpp
@@ -1,6 +1,13 @@
-// Copyright 2022-2024 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_ASSERT_HPP
 #define UNODB_DETAIL_ASSERT_HPP
+
+/// \file assert.hpp
+/// \brief Internal macros for assertions, assumptions & intentional crashing
+///
+/// If compiling as a part of another project, they will expand to C++ standard
+/// symbols (assert & std::abort). Otherwise, custom implementations are
+/// used that will show stacktraces if Boost.Stacktrace is available.
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -34,7 +41,8 @@ namespace unodb::detail {
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
-[[noreturn, gnu::cold]] UNODB_DETAIL_NOINLINE inline void msg_stacktrace_abort(
+/// Print a message and a stacktrace to std::cerr, then abort.
+[[noreturn, gnu::cold]] UNODB_DETAIL_HEADER_NOINLINE void msg_stacktrace_abort(
     const std::string &msg) noexcept {
   UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
@@ -48,10 +56,10 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
   std::abort();
 }
 
+/// Intentionally crash from a given source location.
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-    UNODB_DETAIL_C_STRING_ARG(3)
-        UNODB_DETAIL_NOINLINE inline void crash(const char *file, int line,
-                                                const char *func) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_HEADER_NOINLINE
+    void crash(const char *file, int line, const char *func) noexcept {
   UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
   buf << "Crash requested at " << file << ':' << line << ", function \"" << func
@@ -61,23 +69,13 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
+// Definitions that only depend on Debug vs Release
 #ifndef NDEBUG
 
-UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
+/// Crash with a stacktrace on debug build, do nothing on release build.
+#define UNODB_DETAIL_DEBUG_CRASH() UNODB_DETAIL_CRASH()
 
-[[noreturn, gnu::cold]] UNODB_DETAIL_NOINLINE UNODB_DETAIL_C_STRING_ARG(1)
-    UNODB_DETAIL_C_STRING_ARG(3)
-        UNODB_DETAIL_C_STRING_ARG(4) inline void assert_failure(
-            const char *file, int line, const char *func,
-            const char *condition) noexcept {
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
-  std::ostringstream buf;
-  buf << "Assertion \"" << condition << "\" failed at " << file << ':' << line
-      << ", function \"" << func << "\", thread " << std::this_thread::get_id()
-      << '\n';
-  msg_stacktrace_abort(buf.str());
-}
-
+/// Implementation for marking a source code location as unreachable.
 [[noreturn]] UNODB_DETAIL_C_STRING_ARG(1)
     UNODB_DETAIL_C_STRING_ARG(3) inline void cannot_happen(
         const char *file, int line, const char *func) noexcept {
@@ -89,40 +87,94 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
   msg_stacktrace_abort(buf.str());
 }
 
-UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+#else  // !NDEBUG
 
-#define UNODB_DETAIL_ASSERT(condition)                                      \
-  UNODB_DETAIL_UNLIKELY(!(condition))                                       \
-  ? unodb::detail::assert_failure(__FILE__, __LINE__, __func__, #condition) \
-  : ((void)0)
-
-#define UNODB_DETAIL_DEBUG_CRASH() UNODB_DETAIL_CRASH()
-
-#else  // #ifndef NDEBUG
+#define UNODB_DETAIL_DEBUG_CRASH()
 
 [[noreturn]] UNODB_DETAIL_C_STRING_ARG(1) UNODB_DETAIL_C_STRING_ARG(
     3) inline void cannot_happen(const char *, int, const char *) noexcept {
   UNODB_DETAIL_UNREACHABLE();
 }
 
+#endif  // !NDEBUG
+
+// Definitions that only depend on standalone vs part of another project
+#ifdef UNODB_DETAIL_STANDALONE
+
+/// Intentionally crash.
+#define UNODB_DETAIL_CRASH() unodb::detail::crash(__FILE__, __LINE__, __func__)
+
+#else  // UNODB_DETAIL_STANDALONE
+
+#define UNODB_DETAIL_CRASH() std::abort()
+
+#endif  // UNODB_DETAIL_STANDALONE
+
+// Definitions that depend on both Debug vs Release and standalone vs part of
+// another project
+#ifndef UNODB_DETAIL_STANDALONE
+
+#define UNODB_DETAIL_ASSERT(condition) assert(condition)
+
+#elif !defined(NDEBUG)
+
+UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
+
+/// Assert failure implementation for standalone debug build.
+[[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
+    UNODB_DETAIL_C_STRING_ARG(3)
+        UNODB_DETAIL_C_STRING_ARG(4) UNODB_DETAIL_HEADER_NOINLINE
+    void assert_failure(const char *file, int line, const char *func,
+                        const char *condition) noexcept {
+  unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
+  std::ostringstream buf;
+  buf << "Assertion \"" << condition << "\" failed at " << file << ':' << line
+      << ", function \"" << func << "\", thread " << std::this_thread::get_id()
+      << '\n';
+  msg_stacktrace_abort(buf.str());
+}
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+/// Assert a condition.
+///
+/// Should be used everywhere instead of the standard assert macro and will
+/// expand to it if building as a part of another project, thus using its
+/// replaced declaration, if any. If building standalone, will print a
+/// stacktrace on failures if Boost.Stacktrace is available.
+#define UNODB_DETAIL_ASSERT(condition)                                      \
+  UNODB_DETAIL_UNLIKELY(!(condition))                                       \
+  ? unodb::detail::assert_failure(__FILE__, __LINE__, __func__, #condition) \
+  : ((void)0)
+
+#else  // !defined(NDEBUG)
+
 #define UNODB_DETAIL_ASSERT(condition) ((void)0)
 
-#define UNODB_DETAIL_DEBUG_CRASH()
-
-#endif  // #ifndef NDEBUG
+#endif  // !defined(NDEBUG)
 
 }  // namespace unodb::detail
 
+/// Provide an assumption for the compiler.
+///
+/// The assumption is expressed as a condition that always holds, i.e. an
+/// allowed value range for a variable, which may allow the compiler to e.g.
+/// optimize a redundant check away or silence a warning. Plain assertions
+/// should be used almost always instead, and replaced with assumptions only
+/// with provable effect on the diagnostics or generated code.
 #define UNODB_DETAIL_ASSUME(x)      \
   do {                              \
     UNODB_DETAIL_ASSERT(x);         \
     UNODB_DETAIL_BUILTIN_ASSUME(x); \
   } while (0)
 
+/// Mark this source code location as unreachable.
+///
+/// Under release build the location is annotated for the compiler as
+/// unreachable, potentially enabling more optimizations. Under debug build, if
+/// execution comes here, it will crash with a stacktrace.
 #define UNODB_DETAIL_CANNOT_HAPPEN() \
   unodb::detail::cannot_happen(__FILE__, __LINE__, __func__)
-
-#define UNODB_DETAIL_CRASH() unodb::detail::crash(__FILE__, __LINE__, __func__)
 
 // LCOV_EXCL_STOP
 

--- a/global.hpp
+++ b/global.hpp
@@ -2,7 +2,11 @@
 #ifndef UNODB_DETAIL_GLOBAL_HPP
 #define UNODB_DETAIL_GLOBAL_HPP
 
-// Defines that must precede includes
+/// \file global.hpp
+/// \brief Global defines
+///
+/// Defines that must precede every other include directive in all the source
+/// files.
 
 #ifdef UNODB_DETAIL_STANDALONE
 
@@ -131,6 +135,14 @@
 #define UNODB_DETAIL_C_STRING_ARG(x)
 
 #endif  // #ifndef UNODB_DETAIL_MSVC
+
+/// Define in a header a function that should not be inlined.
+///
+/// This is a pair of two seemingly conflicting intentions: "noinline" and
+/// "inline". However, only the "noinline" has anything to do with inlining. The
+/// "inline" has nothing to do with inlining and is required for functions
+/// declared in headers.
+#define UNODB_DETAIL_HEADER_NOINLINE UNODB_DETAIL_NOINLINE inline
 
 // Sanitizers
 


### PR DESCRIPTION
This enables better integration with parent projects. At the same type add
Doxygen comments on assert.hpp declarations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated copyright information for the year 2025
	- Enhanced documentation for assertion-related macros and functions
	- Added detailed comments for file purpose and include directives

- **New Features**
	- Added a stack trace printing function before program abort
	- Introduced a new function to mark unreachable code
	- Defined a new utility macro for header files regarding inlining

- **Improvements**
	- Refined assertion mechanisms
	- Updated crash and assertion failure handling
	- Improved debugging support with new macros
<!-- end of auto-generated comment: release notes by coderabbit.ai -->