### PR TITLE
Replace std::string with std::string_view in assert.hpp

### DIFF
--- a/assert.hpp
+++ b/assert.hpp
@@ -21,7 +21,7 @@
 
 #include <iostream>
 #include <sstream>
-#include <string>
+#include <string_view>
 #include <thread>
 
 #ifdef UNODB_DETAIL_BOOST_STACKTRACE
@@ -43,14 +43,14 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 /// Print a message and a stacktrace to std::cerr, then abort.
 [[noreturn, gnu::cold]] UNODB_DETAIL_HEADER_NOINLINE void msg_stacktrace_abort(
-    const std::string &msg) noexcept {
+    std::string_view msg) noexcept {
   UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
   buf << msg;
 #ifdef UNODB_DETAIL_BOOST_STACKTRACE
   buf << boost::stacktrace::stacktrace();
 #else
-  std::cerr << "(stacktrace not available, not compiled with Boost.Stacktrace)";
+  buf << "(stacktrace not available, not compiled with Boost.Stacktrace)\n";
 #endif
   std::cerr << buf.str();
   std::abort();


### PR DESCRIPTION
Tweak output format in the case of Boost.Stacktrace not available too at the
same time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Updated string handling to use `std::string_view` for more efficient message passing in assertion mechanisms
  - Optimized message construction in error reporting functions

- **Technical Refinements**
  - Standardized internal message handling approach for assertion and error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->