### PR TITLE
Doxygen: introduce internals section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ unavoidable. If a macro has to be introduced, its name must be prefixed with
   in parentheses, i.e. `TODO(alice)`, `FIXME(bob)`. It indicates the comment
   author, not necessarily who should address it.
 * Doxygen is used to produce source code documentation.
+* Doxygen commands should use `\foo` (and not `@foo`) syntax.
 * The preferred location of the comments is next to the declarations. An
   exception is macros with multiple conditionally compiled declarations, in
   which case a Doxygen comment with a `\def` for the macro should appear at the

--- a/Doxyfile
+++ b/Doxyfile
@@ -540,7 +540,7 @@ EXTRACT_ALL            = NO
 # be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 
 # If the EXTRACT_PRIV_VIRTUAL tag is set to YES, documented private virtual
 # methods of a class will be included in the documentation.
@@ -552,13 +552,13 @@ EXTRACT_PRIV_VIRTUAL   = NO
 # scope will be included in the documentation.
 # The default value is: NO.
 
-EXTRACT_PACKAGE        = NO
+EXTRACT_PACKAGE        = YES
 
 # If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,
@@ -2442,7 +2442,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2450,7 +2450,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2489,6 +2489,8 @@ PREDEFINED            += __has_feature
 PREDEFINED            += _MSC_VER
 PREDEFINED            += _M_X64
 PREDEFINED            += __clang__
+PREDEFINED            += UNODB_DETAIL_HEADER_NOINLINE=
+PREDEFINED            += UNODB_DETAIL_C_STRING_ARG(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/global.hpp
+++ b/global.hpp
@@ -5,6 +5,10 @@
 /// \file global.hpp
 /// Global defines that must precede every other include directive in all the
 /// source files.
+/// \ingroup internal
+
+/// \addtogroup internal
+///@{
 
 // Macros that have multiple definitions are documented once.
 
@@ -198,7 +202,7 @@
 #endif
 #endif
 
-/// \name Architecture
+/// \name Architecture macros
 /// Macros for the CPU architecture, instruction set level, endianness.
 ///@{
 
@@ -230,7 +234,7 @@
 
 ///@}
 
-/// \name Compiler
+/// \name Compiler macros
 /// Macros to hide compiler specifics
 ///@{
 
@@ -311,7 +315,7 @@
 /// declared in headers.
 #define UNODB_DETAIL_HEADER_NOINLINE UNODB_DETAIL_NOINLINE inline
 
-/// \name Sanitizers
+/// \name Sanitizer macros
 ///@{
 
 #if defined(__has_feature)
@@ -334,7 +338,7 @@
 
 #define UNODB_DETAIL_DO_PRAGMA(x) _Pragma(#x)
 
-/// \name Warnings
+/// \name Warning macros
 ///@{
 
 #ifndef UNODB_DETAIL_MSVC
@@ -393,7 +397,7 @@
 
 ///@}
 
-/// \name Debug or release build
+/// \name Debug or release build macros
 /// Definitions conditional on the build type
 ///@{
 
@@ -411,7 +415,7 @@
 
 ///@}
 
-/// \name Features
+/// \name Feature macros
 /// Compile-time feature selection macros
 ///@{
 
@@ -421,6 +425,8 @@
 
 /// Spin lock loop wait loops are empty, causing aggressive spinning.
 #define UNODB_DETAIL_SPINLOCK_LOOP_EMPTY 2
+
+///@}
 
 ///@}
 

--- a/modules.dox
+++ b/modules.dox
@@ -1,0 +1,12 @@
+/// \defgroup internal Internals
+/// Internals documentation for UnoDB developers.
+///
+/// See also CONTRIBUTING.md.
+
+/// \namespace unodb
+/// The namespace for the public UnoDB API.
+
+/// \namespace unodb::detail
+/// The namespace for the UnoDB internal implementation details.
+/// \ingroup internal
+/// It is not part of the public API, and it may change at any time.


### PR DESCRIPTION
- Tweak Doxygen configuration to extract more info, and to parse function
  declarations correctly
- Introduce modules.dox to document internals and the namespaces
- Clean up assert.hpp
- Update global.hpp for the internals section
- Update assert.hpp includes
- Add one more Doxygen note to CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation style guide to use `\foo` syntax for Doxygen commands.
	- Enhanced Doxygen configuration to include private, package, and static members.
	- Improved documentation organization for internal code groups and namespaces.
	- Added clarity to assertion and assumption macro documentation.
	- Introduced new documentation sections and groups for better structure and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->