### PR TITLE
Convert node_type.hpp to Doxygen docs

### DIFF
--- a/.ispell.dict
+++ b/.ispell.dict
@@ -9,3 +9,4 @@ intrinsics
 Radix
 Doxygen
 endian
+radix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,10 +118,10 @@ unavoidable. If a macro has to be introduced, its name must be prefixed with
 * Doxygen is used to produce source code documentation.
 * Doxygen commands should use `\foo` (and not `@foo`) syntax.
 * The preferred location of the comments is next to the declarations. An
-  exception is macros with multiple conditionally compiled declarations, in
-  which case a Doxygen comment with a `\def` for the macro should appear at the
-  top of its section or source file, and it should also have a
-  `\hideinitializer` tag.
+  exception is declarations with multiple conditionally compiled declarations,
+  in which case a Doxygen comment with a `\def`, `\var`, or another suitable tag
+  for the declaration should appear at the top of its section or source file,
+  and it should also have a `\hideinitializer` tag.
 * Doxygen automatic brief description detection is enabled, thus explicit
   `\brief` tags are not required, rather the first sentence in the Doxygen
   comment block will be interpreted as the brief description.

--- a/Doxyfile
+++ b/Doxyfile
@@ -1207,7 +1207,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # If the IMPLICIT_DIR_DOCS tag is set to YES, any README.md file found in sub-
 # directories of the project's root, is used as the documentation for that sub-

--- a/assert.hpp
+++ b/assert.hpp
@@ -2,7 +2,7 @@
 #ifndef UNODB_DETAIL_ASSERT_HPP
 #define UNODB_DETAIL_ASSERT_HPP
 
-/// \file assert.hpp
+/// \file
 /// Internal macros for assertions, assumptions & intentional crashing.
 ///
 /// If compiling as a part of another project, they will expand to C++ standard

--- a/global.hpp
+++ b/global.hpp
@@ -2,7 +2,7 @@
 #ifndef UNODB_DETAIL_GLOBAL_HPP
 #define UNODB_DETAIL_GLOBAL_HPP
 
-/// \file global.hpp
+/// \file
 /// Global defines that must precede every other include directive in all the
 /// source files.
 /// \ingroup internal

--- a/modules.dox
+++ b/modules.dox
@@ -1,7 +1,7 @@
 /// \defgroup internal Internals
 /// Internals documentation for UnoDB developers.
 ///
-/// See also CONTRIBUTING.md.
+/// See also [CONTRIBUTING.md](CONTRIBUTING.md).
 
 /// \namespace unodb
 /// The namespace for the public UnoDB API.

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -1,6 +1,11 @@
-// Copyright 2021-2022 Laurynas Biveinis
+// Copyright 2021-2025 Laurynas Biveinis
 #ifndef UNODB_DETAIL_NODE_TYPE_HPP
 #define UNODB_DETAIL_NODE_TYPE_HPP
+
+/// \file
+/// Adaptive Radix Tree node types.
+/// Defines the node types and, if compiling with stats, counter arrays indexed
+/// by the types.
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -12,45 +17,79 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 
+#ifdef UNODB_DETAIL_WITH_STATS
+
+#include <array>
+
 #include "assert.hpp"
+
+#endif
 
 namespace unodb {
 
-enum class [[nodiscard]] node_type : std::uint8_t { LEAF, I4, I16, I48, I256 };
+/// Node type in the Adaptive Radix Tree.
+/// The type of an internal node depends on its number of children.
+enum class [[nodiscard]] node_type : std::uint8_t {
+  LEAF,  ///< Leaf node for a single value
+  I4,    ///< Internal node for 2-4 children
+  I16,   ///< Internal node for 5-16 children
+  I48,   ///< Internal node for 17-48 children
+  I256   ///< Internal node for 49-256 children
+};
 
 namespace detail {
 
-// C++ has five value categories and IIRC thousands of ways to initialize but no
-// way to count the number of enum elements.
+// C++ has five value categories and IIRC thousands of ways to initialize
+// but no way to count the number of enum elements.
+
+/// The number of different node types.
 constexpr std::size_t node_type_count{5};
+
+}  // namespace detail
+
+// The rest are used only if stats are compiled in
+#ifdef UNODB_DETAIL_WITH_STATS
+
+namespace detail {
+
+/// The number of different internal node types.
 constexpr std::size_t inode_type_count{4};
 
+/// Statically assert that \a NodeType is one of the internal node types.
+/// This function may not be executed, and only holds the static assert, because
+/// it is not an expression and thus cannot appear in expression contexts by
+/// itself.
 template <node_type NodeType>
 void is_internal_static_assert() noexcept {
   static_assert(NodeType != node_type::LEAF);
-  // This function is not for execution, but to wrap the static_assert, which is
-  // not an expression for some reason.
   UNODB_DETAIL_CANNOT_HAPPEN();
 }
 
 }  // namespace detail
 
+/// An `std::array` of `std::uint64_t` values for each node type.
+/// Use as_i() for indexing.
 using node_type_counter_array =
     std::array<std::uint64_t, detail::node_type_count>;
 
+/// Convert \a NodeType to a value suitable for use as an index.
+/// Meant for using together with node_type_counter_array.
 template <node_type NodeType>
 inline constexpr auto as_i{static_cast<std::size_t>(NodeType)};
 
+/// An `std::array` of `std::uint64_t` values for each internal node type.
+/// Use internal_as_i() for indexing.
 using inode_type_counter_array =
     std::array<std::uint64_t, detail::inode_type_count>;
 
 // function call before comma missing argument list
 UNODB_DETAIL_DISABLE_MSVC_WARNING(4546)
 
+/// Convert internal \a NodeType to a value suitable for use as an index.
+/// Meant for using together with inode_type_counter_array.
 template <node_type NodeType>
 inline constexpr auto internal_as_i{
     static_cast<std::size_t>(
@@ -59,6 +98,8 @@ inline constexpr auto internal_as_i{
     1};
 
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+#endif  // UNODB_DETAIL_WITH_STATS
 
 }  // namespace unodb
 

--- a/portability_arch.hpp
+++ b/portability_arch.hpp
@@ -2,7 +2,7 @@
 #ifndef UNODB_DETAIL_PORTABILITY_ARCH_HPP
 #define UNODB_DETAIL_PORTABILITY_ARCH_HPP
 
-/// \file portability_arch.hpp
+/// \file
 /// Definitions to abstract differences between architectures.
 /// \ingroup internal
 

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -2,8 +2,8 @@
 #ifndef UNODB_DETAIL_PORTABILITY_BUILTINS_HPP
 #define UNODB_DETAIL_PORTABILITY_BUILTINS_HPP
 
-/// \file portability_builtins.hpp
-/// Definitions to abstact differences between different compiler builtins and
+/// \file
+/// Definitions to abstract differences between different compiler builtins and
 /// intrinsics.
 /// \ingroup internal
 


### PR DESCRIPTION
At the same time:
- Tweak conditional compilation for node_type.hpp to guard things with stats
  compilation better
- Update Doxygen guidelines in CONTRIBUTING.md
- Set README.md as a start page in Doxygen
- Remove redundant names from \file directives
- Fix link to CONTRIBUTING.md from internals topic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Documentation**
  - Updated documentation in `CONTRIBUTING.md` to clarify Doxygen comment requirements for conditionally compiled declarations
  - Modified Doxyfile to use `README.md` as the main documentation page
  - Enhanced documentation in various header files with improved comments and formatting

- **New Features**
  - Expanded node type definitions with additional type aliases and constants
  - Improved assertion mechanism with more detailed error reporting

- **Chores**
  - Minor documentation and comment updates across multiple files
  - Updated copyright notices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->