### PR TITLE
Convert optimistic_lock::read_critical_section docs to Doxygen

### DIFF
--- a/.ispell.dict
+++ b/.ispell.dict
@@ -12,3 +12,4 @@ endian
 radix
 qsbr
 rcs
+nullptr


### PR DESCRIPTION
At the same time reorder class methods to be closer in the lifetime order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for `optimistic_lock.hpp`, including:
		- Improved method parameter descriptions
		- Clarified class and method behaviors
		- Added more detailed explanations for `read_critical_section` class methods

- **Chores**
	- Added `nullptr` to dictionary file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->