### PR TITLE
Doxygen: start converting qsbr_ptr.hpp

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2494,6 +2494,7 @@ PREDEFINED            += UNODB_DETAIL_C_STRING_ARG(x)=
 PREDEFINED            += UNODB_DETAIL_CONSTEXPR_NOT_MSVC
 PREDEFINED            += UNODB_DETAIL_NOINLINE=
 PREDEFINED            += UNODB_DETAIL_FORCE_INLINE=
+PREDEFINED            += UNODB_DETAIL_RELEASE_CONSTEXPR=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -191,7 +191,7 @@ struct [[nodiscard]] basic_art_key final {
   /// Thus, for a fixed width type, this causes the key to be
   /// logically zero filled as it becomes shorter.  E.g.
   ///
-  /// ```0x0011223344556677 shift_right(2) => 0x2233445566770000```
+  /// `0x0011223344556677 shift_right(2) => 0x2233445566770000`
   constexpr void shift_right(const std::size_t num_bytes) noexcept {
     if constexpr (std::is_same_v<KeyType, key_view>) {
       UNODB_DETAIL_ASSERT(num_bytes <= key.size_bytes());

--- a/assert.hpp
+++ b/assert.hpp
@@ -11,12 +11,12 @@
 /// \ingroup internal
 
 /// \addtogroup internal
-///@{
+/// @{
 
 // Macros that have multiple definitions are documented once.
 
 /// \name Assertion & assumption macros
-///@{
+/// @{
 
 /// \def UNODB_DETAIL_ASSERT(condition)
 /// \hideinitializer
@@ -207,8 +207,8 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 // LCOV_EXCL_STOP
 
-///@}
+/// @}
 
-///@}
+/// @}
 
 #endif

--- a/global.hpp
+++ b/global.hpp
@@ -8,7 +8,7 @@
 /// \ingroup internal
 
 /// \addtogroup internal
-///@{
+/// @{
 
 // Macros that have multiple definitions are documented once.
 
@@ -130,7 +130,7 @@
 
 /// \name CMake macros
 /// Macros set by CMake.
-///@{
+/// @{
 // This section is never compiled in, only processed by Doxygen
 #ifdef UNODB_DETAIL_DOXYGEN
 
@@ -155,14 +155,14 @@
 
 #endif  // UNODB_DETAIL_DOXYGEN
 
-///@}
+/// @}
 
 #ifdef UNODB_DETAIL_STANDALONE
 
 /// \name libstdc++ debug mode
 /// Defines to enable libstdc++ debug mode.
 /// Only defined in the standalone debug configuration with GCC.
-///@{
+/// @{
 #if !defined(NDEBUG) && !defined(__clang__)
 
 #ifndef _GLIBCXX_DEBUG
@@ -189,7 +189,7 @@
 
 #endif  // UNODB_DETAIL_STANDALONE
 
-///@}
+/// @}
 
 #ifdef _MSC_VER
 /// Defined under MSVC to stop redefining `min` and `max` if windows.h is
@@ -205,7 +205,7 @@
 
 /// \name Architecture macros
 /// Macros for the CPU architecture, instruction set level, endianness.
-///@{
+/// @{
 
 #if defined(_MSC_VER) && defined(_M_X64)
 /// Defined when compiling with MSVC on x86-64
@@ -233,11 +233,11 @@
 #define UNODB_DETAIL_LITTLE_ENDIAN
 #endif
 
-///@}
+/// @}
 
 /// \name Compiler macros
 /// Macros to hide compiler specifics
-///@{
+/// @{
 
 #if defined(_MSC_VER)
 #if !defined(__clang__)
@@ -305,7 +305,7 @@
 
 #endif  // #ifndef UNODB_DETAIL_MSVC
 
-///@}
+/// @}
 
 /// A declaration specifier for a function in a header file that should not be
 /// inlined.
@@ -317,7 +317,7 @@
 #define UNODB_DETAIL_HEADER_NOINLINE UNODB_DETAIL_NOINLINE inline
 
 /// \name Sanitizer macros
-///@{
+/// @{
 
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
@@ -335,12 +335,12 @@
 #endif
 #endif
 
-///@}
+/// @}
 
 #define UNODB_DETAIL_DO_PRAGMA(x) _Pragma(#x)
 
 /// \name Warning macros
-///@{
+/// @{
 
 #ifndef UNODB_DETAIL_MSVC
 
@@ -396,11 +396,11 @@
 #define UNODB_DETAIL_RESTORE_GCC_11_WARNINGS()
 #endif  // defined(__GNUG__) && !defined(__clang__)
 
-///@}
+/// @}
 
 /// \name Debug or release build macros
 /// Definitions conditional on the build type
-///@{
+/// @{
 
 #ifdef NDEBUG
 #define UNODB_DETAIL_RELEASE_CONSTEXPR constexpr
@@ -414,11 +414,11 @@
 #define UNODB_DETAIL_USED_IN_DEBUG
 #endif
 
-///@}
+/// @}
 
 /// \name Feature macros
 /// Compile-time feature selection macros
-///@{
+/// @{
 
 /// Spin lock wait loops use x86_64 PAUSE instruction or its closest equivalent
 /// on other architectures.
@@ -427,8 +427,8 @@
 /// Spin lock loop wait loops are empty, causing aggressive spinning.
 #define UNODB_DETAIL_SPINLOCK_LOOP_EMPTY 2
 
-///@}
+/// @}
 
-///@}
+/// @}
 
 #endif  // UNODB_DETAIL_GLOBAL_HPP

--- a/modules.dox
+++ b/modules.dox
@@ -1,3 +1,6 @@
+/// \defgroup qsbr Quiescent State-Based Reclamation
+/// Deferred memory reclamation method, compatible with \ref optimistic-lock.
+
 /// \defgroup internal Internals
 /// Internals documentation for UnoDB developers.
 ///

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -2,8 +2,6 @@
 #ifndef UNODB_DETAIL_QSBR_HPP
 #define UNODB_DETAIL_QSBR_HPP
 
-/// \defgroup qsbr Quiescent State-Based Reclamation
-
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
 // HEADER FILES !!!


### PR DESCRIPTION
- Add file-level docs to qsbr_ptr.hpp, qsbr_ptr_base class, and start
 documenting qsbr_ptr class template.
- Move the QSBR topic declaration from qsbr.hpp to modules.dox
- Fix some markup warning in art_internal.hpp, a recent regression
- Add UNODB_DETAIL_RELEASE_CONSTEXPR to Doxygen-expanded macros
- Add a space to all existing ///@{ and ///@} comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section on deferred memory reclamation (QSBR) to enrich the project documentation.
  - Improved inline examples and explanatory notes for better clarity.

- **Style**
  - Refined comment formatting to ensure more consistent and readable documentation.

- **New Features**
  - Introduced a configuration macro to support enhanced documentation processing.
  - Enhanced the debug pointer management system with active pointer registration and unregistration.
  - Updated documentation for `qsbr_ptr` and `qsbr_ptr_span` classes to clarify their roles and functionalities.
  - Removed outdated documentation group for QSBR in the header file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->