### PR TITLE
Continue C++20 modernization

### DIFF
--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1239,10 +1239,9 @@ class [[nodiscard]] qsbr_thread : public std::thread {
  public:
   using thread::thread;
 
-  template <typename Function, typename... Args,
-            class = std::enable_if_t<
-                !std::is_same_v<remove_cvref_t<Function>, qsbr_thread>>>
+  template <typename Function, typename... Args>
   explicit qsbr_thread(Function &&f, Args &&...args)
+      requires(!std::is_same_v<remove_cvref_t<Function>, qsbr_thread>)
       : std::thread{make_qsbr_thread(std::forward<Function>(f),
                                      std::forward<Args>(args)...)} {}
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -12,12 +12,9 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <__fwd/sstream.h>
 // IWYU pragma: no_include <__ostream/basic_ostream.h>
-// IWYU pragma: no_include <iterator>
+// IWYU pragma: no_include <iomanip>
 // IWYU pragma: no_include <string>
-// IWYU pragma: no_include "gmock/gmock.h"
-// IWYU pragma: no_include "gtest/gtest.h"
 
 #include <algorithm>
 #include <array>
@@ -31,13 +28,14 @@
 #include <tuple>
 #include <type_traits>
 
-#include <gmock/gmock.h>  // IWYU pragma: keep
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "gtest_utils.hpp"
 
 #include "art.hpp"
 #include "art_common.hpp"
+#include "art_internal.hpp"
 #include "assert.hpp"
 #include "mutex_art.hpp"
 #include "node_type.hpp"
@@ -90,13 +88,10 @@ void assert_value_eq(const typename Db::get_result &result,
   if constexpr (std::is_same_v<Db, unodb::mutex_db<typename Db::key_type>>) {
     UNODB_DETAIL_ASSERT(result.second.owns_lock());
     UNODB_DETAIL_ASSERT(result.first.has_value());
-    UNODB_ASSERT_TRUE(std::equal(std::cbegin(*result.first),
-                                 std::cend(*result.first),
-                                 std::cbegin(expected), std::cend(expected)));
+    UNODB_ASSERT_TRUE(std::ranges::equal(*result.first, expected));
   } else {
     UNODB_DETAIL_ASSERT(result.has_value());
-    UNODB_ASSERT_TRUE(std::equal(std::cbegin(*result), std::cend(*result),
-                                 std::cbegin(expected), std::cend(expected)));
+    UNODB_ASSERT_TRUE(std::ranges::equal(*result, expected));
   }
 }
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
@@ -148,6 +143,11 @@ class [[nodiscard]] tree_verifier final {
   UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
+  // Replace std::enable_if_t in the next two methods with
+  // requires(std::is_same_v) when LLVM 15 is the oldest supported LLVM version.
+  // Earlier versions give errors of different declarations having identical
+  // mangled names.
+  // NOLINTBEGIN(modernize-use-constraints)
   template <class Db2 = Db>
   std::enable_if_t<!std::is_same_v<Db2, unodb::olc_db<key_type>>, void>
   do_insert(key_type k, unodb::value_view v) {
@@ -160,6 +160,7 @@ class [[nodiscard]] tree_verifier final {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     UNODB_ASSERT_TRUE(test_db.insert(k, v));
   }
+  // NOLINTEND(modernize-use-constraints)
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   void do_remove(key_type k, bool bypass_verifier) {
@@ -219,6 +220,11 @@ class [[nodiscard]] tree_verifier final {
   }
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
+  // Replace std::enable_if_t in the next two methods with
+  // requires(std::is_same_v) when LLVM 15 is the oldest supported LLVM version.
+  // Earlier versions give errors of different declarations having identical
+  // mangled names.
+  // NOLINTBEGIN(modernize-use-constraints)
   template <class Db2 = Db>
   std::enable_if_t<!std::is_same_v<Db2, unodb::olc_db<key_type>>, void>
   do_try_remove_missing_key(key_type absent_key) {
@@ -231,6 +237,7 @@ class [[nodiscard]] tree_verifier final {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     UNODB_ASSERT_FALSE(test_db.remove(absent_key));
   }
+  // NOLINTEND(modernize-use-constraints)
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
@@ -338,6 +345,11 @@ class [[nodiscard]] tree_verifier final {
     }
   }
 
+  // Replace std::enable_if_t in the next four methods with
+  // requires(std::is_same_v) when LLVM 15 is the oldest supported LLVM version.
+  // Earlier versions give errors of different declarations having identical
+  // mangled names.
+  // NOLINTBEGIN(modernize-use-constraints)
   template <class Db2 = Db>
   std::enable_if_t<!std::is_same_v<Db2, unodb::olc_db<key_type>>, void> remove(
       key_type k, bool bypass_verifier = false) {
@@ -363,6 +375,7 @@ class [[nodiscard]] tree_verifier final {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     std::ignore = test_db.remove(k);
   }
+  // NOLINTEND(modernize-use-constraints)
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
   void attempt_remove_missing_keys(
@@ -385,6 +398,11 @@ class [[nodiscard]] tree_verifier final {
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
+  // Replace std::enable_if_t in the next two methods with
+  // requires(std::is_same_v) when LLVM 15 is the oldest supported LLVM version.
+  // Earlier versions give errors of different declarations having identical
+  // mangled names.
+  // NOLINTBEGIN(modernize-use-constraints)
   template <class Db2 = Db>
   std::enable_if_t<!std::is_same_v<Db2, unodb::olc_db<key_type>>, void> try_get(
       key_type k) const noexcept(noexcept(this->test_db.get(k))) {
@@ -397,6 +415,7 @@ class [[nodiscard]] tree_verifier final {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     std::ignore = test_db.get(k);
   }
+  // NOLINTEND(modernize-use-constraints)
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26445)
   void check_present_values() const {
@@ -477,6 +496,9 @@ class [[nodiscard]] tree_verifier final {
   }
 
   [[nodiscard, gnu::pure]] constexpr Db &get_db() noexcept { return test_db; }
+
+  tree_verifier(const tree_verifier &) = delete;
+  tree_verifier &operator=(const tree_verifier &) = delete;
 
  private:
   // Custom comparator is required for key_view.


### PR DESCRIPTION
- qsbr.hpp: replace std::enable_if_t with requires
- db_test_utils.hpp: replace std::enable_if_t with requires, iterator pairs
  with ranges, update includes, fix clang-tidy warning on const field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**  
  - Modernized the thread initialization interface by removing certain restrictions, offering greater flexibility when launching operations.
  - Improved the structure and readability of test utilities by updating method signatures and leveraging modern language constructs.

- **Tests**  
  - Enhanced test utilities by updating dependency inclusions and streamlining method signatures with modern language constructs, resulting in clearer and more maintainable verification routines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->