### PR TITLE
Modernize micro_benchmark_node_utils.hpp to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,9 +156,10 @@ set(MSVC_CXX_WARNING_FLAGS "/Wall" "/wd4324" "/wd5030" "/wd5072"
 set(ANY_MSVC_CXX_FLAGS "/permissive-")
 
 # clang-cl warning flags that cl does not understand
-set(MSVC_CLANG_WARNING_FLAGS "-Wno-c++98-compat" "-Wno-c++98-compat-pedantic"
-  "-Wno-exit-time-destructors" "-Wno-ctad-maybe-unsupported"
-  "-Wno-global-constructors" "-Wno-unsafe-buffer-usage" "-Wno-switch-default")
+set(MSVC_CLANG_WARNING_FLAGS "-Wno-c++20-compat" "-Wno-c++98-compat"
+  "-Wno-c++98-compat-pedantic" "-Wno-exit-time-destructors"
+  "-Wno-ctad-maybe-unsupported" "-Wno-global-constructors"
+  "-Wno-unsafe-buffer-usage" "-Wno-switch-default")
 
 # cl flags that clang-cl does not understand
 set(MSVC_CXX_FLAGS "/external:anglebrackets" "/external:W0")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,8 @@ unavoidable. If a macro has to be introduced, its name must be prefixed with
 * The code follows the Almost Always Auto guideline.
 * `const` should be used everywhere it is possible to do so, with the exception
   of by-value function parameters and class fields that support moving from.
-* `constexpr` should be applied everywhere it is legal to do so. Perhaps one day
-  we will have compile-time Adaptive Radix Tree.
+* `constexpr` (and `consteval`) should be applied everywhere it is legal to do
+  so. Perhaps one day we will have a compile-time Adaptive Radix Tree.
 * All C++ standard library symbols must be namespace-qualified, and this
   includes symbols shared with C. For example `std::size_t`.
 * Automatic code formatting can be configured through git clean/fuzz filters. To

--- a/heap.hpp
+++ b/heap.hpp
@@ -29,7 +29,7 @@
 namespace unodb::detail {
 
 template <typename T>
-[[nodiscard]] constexpr auto alignment_for_new() noexcept {
+[[nodiscard]] consteval auto alignment_for_new() noexcept {
   return std::max(alignof(T),
                   static_cast<std::size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__));
 }


### PR DESCRIPTION
- Replace constexpr to consteval where applicable
- Replace std::generate with iterator pairs with std::ranges::generate
- Suppress clang-tidy warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal computation processes to ensure more robust compile-time evaluations.
	- Modernized the random key generation mechanism using updated library features.
- **Documentation**
	- Updated code style guidelines to include `consteval` alongside `constexpr` for better optimization practices.
- **Style**
	- Applied formatting adjustments and added comments to improve code clarity and readability.
- **Chores**
	- Updated compiler warning flags to focus on C++20 compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->