### PR TITLE
Consolidate and reduce Valgrind testing in GitHub Actions [circle skip]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -458,18 +458,6 @@ jobs:
           && env.COMPILER == 'clang' && env.BUILD_TYPE != 'Release'
           && env.SANITIZE_THREAD != 'ON'
 
-      - name: Valgrind test
-        working-directory: ${{github.workspace}}/build
-        run: |
-          sudo apt-get install -y libc6-dbg
-          sudo snap install --classic valgrind
-          make -k valgrind
-        if: >
-          env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
-          && env.SANITIZE_UB != 'ON' && env.STATIC_ANALYSIS != 'ON'
-          && runner.os == 'Linux' && env.COVERAGE != 'ON'
-        timeout-minutes: 180
-
       - name: Gather coverage data
         working-directory: ${{github.workspace}}/build
         run: |

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -537,14 +537,3 @@ jobs:
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
         run: make -k quick_benchmarks
-
-      - name: Valgrind test
-        working-directory: ${{github.workspace}}/build
-        run: |
-          sudo apt-get install -y libc6-dbg
-          sudo snap install --classic valgrind
-          make -k valgrind
-        if: >
-          env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
-          && env.SANITIZE_UB != 'ON'
-        timeout-minutes: 180

--- a/.github/workflows/ubuntu-20.04.yml
+++ b/.github/workflows/ubuntu-20.04.yml
@@ -243,14 +243,3 @@ jobs:
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
         run: make -k quick_benchmarks
-
-      - name: Valgrind test
-        working-directory: ${{github.workspace}}/build
-        run: |
-          sudo apt-get install -y libc6-dbg
-          sudo snap install --classic valgrind
-          make -k valgrind
-        if: >
-          env.SANITIZE_ADDRESS != 'ON' && env.SANITIZE_THREAD != 'ON'
-          && env.SANITIZE_UB != 'ON'
-        timeout-minutes: 180

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,57 @@
+---
+name: valgrind
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    env:
+      BUILD_TYPE: ${{matrix.BUILD_TYPE}}
+      AVX2: ${{matrix.AVX2}}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        BUILD_TYPE: [Release, Debug]
+        AVX2: [ON, OFF]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-dev libc6-dev-i386 libc6-dbg
+          sudo snap install --classic valgrind
+
+      - name: Create build environment
+        run: mkdir ${{github.workspace}}/build
+
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment
+        # variable access regardless of the host operating system
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: |
+          cmake "$GITHUB_WORKSPACE" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
+              "-DSTANDALONE=ON" "-DAVX2=$AVX2"
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: make -j3 -k
+
+      - name: Valgrind test
+        working-directory: ${{github.workspace}}/build
+        run: make -k valgrind
+        timeout-minutes: 180


### PR DESCRIPTION
No longer test Valgrind for every compiler, but have on dedicated job with the
default compiler that tests debug-release and AVX2-no AVX2 matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated testing workflow that validates builds under varied configurations for enhanced quality control.
  
- **Chores**
  - Streamlined the automated build process by removing redundant Valgrind testing steps, ensuring a more efficient integration pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->