### PR TITLE
Convert iterator pairs to C++20 ranges

### DIFF
--- a/benchmark/micro_benchmark_key_prefix.cpp
+++ b/benchmark/micro_benchmark_key_prefix.cpp
@@ -18,12 +18,9 @@
 
 #include <benchmark/benchmark.h>
 
-#include "art.hpp"
 #include "art_common.hpp"
 #include "assert.hpp"
 #include "micro_benchmark_utils.hpp"
-#include "mutex_art.hpp"
-#include "olc_art.hpp"
 
 namespace {
 
@@ -73,6 +70,7 @@ Keys to be inserted:    Additional key prefix mismatch keys:
 template <class Db>
 void unpredictable_get_shared_length(benchmark::State &state) {
   std::vector<std::uint64_t> search_keys{};
+  // NOLINTNEXTLINE(readability-math-missing-parentheses)
   search_keys.reserve(7 * 2 + 7 * 2 - 3);
   Db test_db;
   for (std::uint8_t top_byte = 0x00; top_byte <= 0x05; ++top_byte) {
@@ -96,8 +94,7 @@ void unpredictable_get_shared_length(benchmark::State &state) {
 
   for (const auto _ : state) {
     state.PauseTiming();
-    std::shuffle(search_keys.begin(), search_keys.end(),
-                 unodb::benchmark::get_prng());
+    std::ranges::shuffle(search_keys, unodb::benchmark::get_prng());
     state.ResumeTiming();
     for (const auto k : search_keys) unodb::benchmark::get_key(test_db, k);
   }
@@ -182,8 +179,7 @@ void do_insert_benchmark(benchmark::State &state,
     state.PauseTiming();
     Db test_db;
     insert_keys(test_db, prepare_keys);
-    std::shuffle(benchmark_keys.begin(), benchmark_keys.end(),
-                 unodb::benchmark::get_prng());
+    std::ranges::shuffle(benchmark_keys, unodb::benchmark::get_prng());
     state.ResumeTiming();
 
     insert_keys(test_db, benchmark_keys);
@@ -211,20 +207,18 @@ void unpredictable_leaf_key_prefix_split(benchmark::State &state) {
     const auto first_key = static_cast<std::uint64_t>(top_byte) << 56U;
 
     // Quadratic but debug build only
-    UNODB_DETAIL_ASSERT(std::find(prepare_keys.cbegin(), prepare_keys.cend(),
-                                  first_key) == prepare_keys.cend());
-    UNODB_DETAIL_ASSERT(std::find(benchmark_keys.cbegin(),
-                                  benchmark_keys.cend(),
-                                  first_key) == benchmark_keys.cend());
+    UNODB_DETAIL_ASSERT(std::ranges::find(prepare_keys, first_key) ==
+                        prepare_keys.cend());
+    UNODB_DETAIL_ASSERT(std::ranges::find(benchmark_keys, first_key) ==
+                        benchmark_keys.cend());
     prepare_keys.push_back(first_key);
 
     const auto second_key = first_key | (1ULL << (top_byte % stride_len * 8U));
     // Quadratic but debug build only
-    UNODB_DETAIL_ASSERT(std::find(prepare_keys.cbegin(), prepare_keys.cend(),
-                                  second_key) == prepare_keys.cend());
-    UNODB_DETAIL_ASSERT(std::find(benchmark_keys.cbegin(),
-                                  benchmark_keys.cend(),
-                                  second_key) == benchmark_keys.cend());
+    UNODB_DETAIL_ASSERT(std::ranges::find(prepare_keys, second_key) ==
+                        prepare_keys.cend());
+    UNODB_DETAIL_ASSERT(std::ranges::find(benchmark_keys, second_key) ==
+                        benchmark_keys.cend());
     benchmark_keys.push_back(second_key);
   }
 
@@ -422,8 +416,7 @@ void unpredictable_prepend_key_prefix(benchmark::State &state) {
     state.PauseTiming();
     Db test_db;
     insert_keys(test_db, prepare_keys);
-    std::shuffle(benchmark_keys.begin(), benchmark_keys.end(),
-                 unodb::benchmark::get_prng());
+    std::ranges::shuffle(benchmark_keys, unodb::benchmark::get_prng());
     state.ResumeTiming();
 
     for (const auto k : benchmark_keys) {

--- a/benchmark/micro_benchmark_n4.cpp
+++ b/benchmark/micro_benchmark_n4.cpp
@@ -19,13 +19,9 @@
 
 #include <benchmark/benchmark.h>
 
-#include "art.hpp"
-#include "art_common.hpp"
 #include "micro_benchmark_node_utils.hpp"
 #include "micro_benchmark_utils.hpp"
-#include "mutex_art.hpp"
 #include "node_type.hpp"
-#include "olc_art.hpp"
 
 namespace {
 
@@ -106,7 +102,7 @@ void node4_random_insert(benchmark::State &state) {
 
   for (const auto _ : state) {
     state.PauseTiming();
-    std::shuffle(keys.begin(), keys.end(), unodb::benchmark::get_prng());
+    std::ranges::shuffle(keys, unodb::benchmark::get_prng());
     Db test_db;
     benchmark::ClobberMemory();
     state.ResumeTiming();
@@ -202,7 +198,7 @@ void node4_random_delete_benchmark(benchmark::State &state,
 #endif  // UNODB_DETAIL_WITH_STATS
 
     auto keys = make_limited_key_sequence(key_limit, delete_key_zero_bits);
-    std::shuffle(keys.begin(), keys.end(), unodb::benchmark::get_prng());
+    std::ranges::shuffle(keys, unodb::benchmark::get_prng());
     state.ResumeTiming();
 
     unodb::benchmark::delete_keys(test_db, keys);

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -289,8 +289,7 @@ generate_random_keys_over_full_smaller_tree(std::uint64_t key_limit) {
                 const std::uint64_t k = constructed_key.as_int;
                 if (k > key_limit) {
                   result.shrink_to_fit();
-                  std::shuffle(result.begin(), result.end(),
-                               unodb::benchmark::get_prng());
+                  std::ranges::shuffle(result, unodb::benchmark::get_prng());
                   return result;
                 }
                 result.push_back(k);
@@ -1034,7 +1033,7 @@ void random_add_benchmark(::benchmark::State &state) {
         detail::make_base_tree_for_add<Db, NodeSize>(test_db, node_count);
     auto benchmark_keys = detail::generate_keys_to_limit(
         key_limit, detail::number_to_full_leaf_over_minimal_tree_key<NodeSize>);
-    std::shuffle(benchmark_keys.begin(), benchmark_keys.end(), get_prng());
+    std::ranges::shuffle(benchmark_keys, get_prng());
     state.ResumeTiming();
 
     insert_keys(test_db, benchmark_keys);
@@ -1175,7 +1174,7 @@ void random_delete_benchmark(::benchmark::State &state) {
     auto remove_keys = detail::generate_keys_to_limit(
         key_limit, detail::number_to_full_leaf_over_minimal_tree_key<NodeSize>);
     remove_key_count = remove_keys.size();
-    std::shuffle(remove_keys.begin(), remove_keys.end(), get_prng());
+    std::ranges::shuffle(remove_keys, get_prng());
     state.ResumeTiming();
 
     delete_keys(test_db, remove_keys);

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #ifndef NDEBUG
 #include <iostream>
 #endif
@@ -23,10 +24,12 @@
 
 #include <benchmark/benchmark.h>
 
+#include "art.hpp"
 #include "art_common.hpp"
 #ifndef NDEBUG
 #include "assert.hpp"
 #endif
+#include "mutex_art.hpp"
 #include "olc_art.hpp"
 #include "qsbr.hpp"
 
@@ -42,14 +45,6 @@
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26485) \
   BENCHMARK_MAIN()                         \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
-
-namespace unodb {
-template <typename>
-class db;  // IWYU pragma: keep
-
-template <typename>
-class mutex_db;  // IWYU pragma: keep
-}  // namespace unodb
 
 namespace unodb::benchmark {
 

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Laurynas Biveinis
+// Copyright 2021-2025 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -681,8 +681,9 @@ TEST(QSBR, DeepStateFuzz) {
           reset_stats();
         });
     const auto unpaused_threads = static_cast<unodb::qsbr_thread_count_type>(
-        std::count_if(threads.cbegin(), threads.cend(),
-                      [](const thread_info &info) { return !info.is_paused; }));
+        std::ranges::count_if(threads, [](const thread_info &info) noexcept {
+          return !info.is_paused;
+        }));
     const auto current_qsbr_state = unodb::qsbr::instance().get_state();
     ASSERT(unodb::qsbr_state::single_thread_mode(current_qsbr_state) ==
            (unpaused_threads < 2));

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -14,8 +14,6 @@
 // IWYU pragma: no_include <array>
 // IWYU pragma: no_include <span>
 // IWYU pragma: no_include <string>
-// IWYU pragma: no_include <iterator>
-// IWYU pragma: no_forward_declare unodb::visitor
 
 #include <algorithm>
 #include <cstdint>
@@ -25,9 +23,7 @@
 
 #include <gtest/gtest.h>
 
-#include "art.hpp"
 #include "art_common.hpp"
-#include "olc_art.hpp"
 
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
@@ -58,10 +54,8 @@ inline std::uint64_t decode(unodb::key_view akey) {
 [[maybe_unused]] void dump(
     const std::vector<std::pair<std::uint64_t, unodb::value_view>>& x) {
   std::cerr << "[";
-  auto it = x.begin();
-  while (it != x.end()) {
-    std::cerr << "(" << (*it).first << ") ";
-    it++;
+  for (const auto& key_and_val : x) {
+    std::cerr << "(" << key_and_val.first << ") ";
   }
   std::cerr << "]\n";
 }

--- a/test/test_key_encode_decode.cpp
+++ b/test/test_key_encode_decode.cpp
@@ -10,6 +10,8 @@
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
 
+// IWYU pragma: no_include <string>
+
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -145,8 +147,8 @@ void do_encode_decode_test(const T ekey,
   EXPECT_EQ(kv.size_bytes(), sizeof(ekey));       // check size
   // check order.
   size_t i = 0;
-  for (auto it = ikey.begin(); it != ikey.end(); it++) {
-    EXPECT_EQ(*it, kv[i++]);
+  for (const auto byte : ikey) {
+    EXPECT_EQ(byte, kv[i++]);
   }
   // decode check
   unodb::key_decoder dec{kv};


### PR DESCRIPTION
Do the conversion everywhere except for directly ART-related classes, to be done
separately.

At the same time fixup clang-tidy and IWYU warnings in the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Modernized internal operations by adopting contemporary C++ ranges for randomization and iteration, enhancing readability and maintainability.
	- Refactored functions to utilize range-based loops for improved clarity.
- **Chores**
	- Streamlined code by removing obsolete headers and redundant template declarations.
	- Optimized header inclusion management.
- **Tests**
	- Updated test implementations for improved clarity and consistency, ensuring robust benchmarking and validation without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->