### PR TITLE
Make DeepState tests honor the timeouts passed on command line

### DIFF
--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -1,10 +1,11 @@
-// Copyright 2021 Laurynas Biveinis
+// Copyright 2021-2025 Laurynas Biveinis
 #ifndef UNODB_DETAIL_DEEPSTATE_UTILS_HPP
 #define UNODB_DETAIL_DEEPSTATE_UTILS_HPP
 
 #include "global.hpp"
 
 #include <cstddef>
+#include <ctime>
 
 #include <deepstate/DeepState.hpp>
 
@@ -23,5 +24,27 @@ template <class T>
   ASSERT(!container.empty());
   return DeepState_SizeTInRange(0, std::size(container) - 1);
 }
+
+/// The DeepState command line-specified timeout in seconds. We need it, but
+/// it is not exposed through the public DeepState API, hence take the risk
+/// and declare it ourselves.
+extern "C" int FLAGS_timeout;
+
+namespace unodb::test {
+
+/// Check whether the DeepState test timeout has been reached.
+/// \param[in] start_tm Test start timestamp in seconds since epoch
+/// \return true if current time exceeds \a start_tm by more than the timeout
+/// value.
+///
+/// The timeout value is specified via DeepState command line. Since the test
+/// harness only checks it between the tests, we need additional checks for
+/// long-running tests.
+[[nodiscard]] bool inline timeout_reached(std::time_t start_tm) {
+  const auto current_tm = std::time(nullptr);
+  return current_tm - start_tm > FLAGS_timeout;
+}
+
+}  // namespace unodb::test
 
 #endif  // UNODB_DETAIL_DEEPSTATE_UTILS_HPP

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>  // IWYU pragma: keep
 #include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <limits>
 #include <new>
 #include <optional>  // IWYU pragma: keep
@@ -226,6 +227,8 @@ TEST(ART, DeepStateFuzz) {
   values_type values;
   oracle_type oracle;
 
+  const auto start_tm = std::time(nullptr);
+
   for (auto i = 0; i < test_length; i++) {
     LOG(TRACE) << "Iteration " << i;
     deepstate::OneOf(
@@ -278,6 +281,7 @@ TEST(ART, DeepStateFuzz) {
           LOG(TRACE) << "Deleting key " << key;
           op_with_oom_test(oracle, keys, test_db, key, {});
         });
+    if (unodb::test::timeout_reached(start_tm)) break;
   }
 
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Laurynas Biveinis
+// Copyright 2021-2025 Laurynas Biveinis
 
 #include "global.hpp"
 
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <iterator>
 #include <new>
 #include <sstream>
@@ -616,6 +617,8 @@ TEST(QSBR, DeepStateFuzz) {
 
   threads.emplace_back(main_thread_i);
 
+  const auto start_tm = time(nullptr);
+
   for (auto i = 0; i < test_length; ++i) {
     LOG(TRACE) << "Iteration " << i;
     deepstate::OneOf(
@@ -715,6 +718,8 @@ TEST(QSBR, DeepStateFuzz) {
     dump_sink << unodb::qsbr::instance().get_max_backlog_bytes();
     dump_sink << unodb::qsbr::instance().get_mean_backlog_bytes();
 #endif  // UNODB_DETAIL_WITH_STATS
+
+    if (unodb::test::timeout_reached(start_tm)) break;
   }
 
   for (std::size_t i = 0; i < threads.size(); ++i) {


### PR DESCRIPTION
The DeepState harness checks for timeouts between the test runs, which are very
long in our tests. Before the fix, the timeouts were effectively ignored for the
ART fuzzer, resulting in Valgrind timeouts in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a timeout mechanism that monitors execution duration during tests and interrupts them if they run too long.
- **Chores**
	- Updated copyright notices to reflect the current licensing timeframe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->