### PR TITLE
Pass -march=armv8.2-a to compilers under ARM Linux [actions skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
             cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSTANDALONE=ON \
               -DMAINTAINER_MODE=ON -DSANITIZE_ADDRESS=$ASAN \
               -DSANITIZE_THREAD=$TSAN -DSANITIZE_UB=$UBSAN \
-              "${EXTRA_CMAKE_ARGS[@]}"
+              -DCMAKE_CXX_FLAGS=-march=armv8.2-a "${EXTRA_CMAKE_ARGS[@]}"
       - run:
           name: Build
           working_directory: build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the Linux build process to optimize performance on ARM-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->