### PR TITLE
Handle the global preprocessor defines completely in CMake and be consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,9 +394,10 @@ set(with_stats "$<BOOL:${STATS}>")
 set(fatal_warnings_on "$<BOOL:${MAINTAINER_MODE}>")
 set(coverage_on "$<BOOL:${COVERAGE}>")
 set(is_standalone "$<BOOL:${STANDALONE}>")
+set(asan_on "$<BOOL:${SANITIZE_ADDRESS}>")
 # Checks across multiple categories
-set(is_gxx_not_release_standalone
-  $<AND:${is_gxx_genex},${is_not_release_genex},${is_standalone}>)
+set(is_standalone_not_release "$<AND:${is_standalone},${is_not_release_genex}>")
+set(is_standalone_asan "$<AND:${is_standalone},${asan_on}>")
 
 option(TESTS "Build tests, including fuzz ones if DeepState is available" ON)
 
@@ -438,6 +439,15 @@ if(TESTS OR BENCHMARKS)
   endmacro()
 endif()
 
+# C++-related properties that must be set on every compiled target. Applies to
+# dependencies too in the case of standalone build.
+function(GLOBAL_CXX_TARGET_PROPERTIES TARGET)
+  target_compile_definitions(${TARGET} PUBLIC
+    "$<${is_standalone_not_release}:_GLIBCXX_DEBUG>"
+    "$<${is_standalone_not_release}:_GLIBCXX_DEBUG_PEDANTIC>"
+    "$<${is_standalone_asan}:_GLIBCXX_SANITIZE_VECTOR>")
+endfunction()
+
 if(TESTS)
   # For Windows: Prevent overriding the parent project's compiler/linker settings
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
@@ -445,6 +455,9 @@ if(TESTS)
   ADD_CXX_FLAGS_FOR_SUBDIR()
   add_subdirectory(3rd_party/googletest)
   RESTORE_CXX_FLAGS_FOR_SUBDIR()
+
+  global_cxx_target_properties(gtest)
+  global_cxx_target_properties(gtest_main)
 
   # Do not build DeepState:
   # - under Windows as it's not supported
@@ -529,8 +542,8 @@ if(BENCHMARKS)
   add_subdirectory(3rd_party/benchmark)
   RESTORE_CXX_FLAGS_FOR_SUBDIR()
 
-  target_compile_definitions(benchmark PUBLIC
-    "$<${is_gxx_not_release_standalone}:_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC>")
+  global_cxx_target_properties(benchmark)
+  global_cxx_target_properties(benchmark_main)
 
   # Add benchmark_include_dirs by target_include_directories(... SYSTEM ...)
   # before target_link_libraries so that benchmark headers are included through
@@ -628,6 +641,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
   cmake_parse_arguments(PARSE_ARGV 1 CTP "SKIP_CHECKS" "" "")
   target_compile_features(${TARGET} PUBLIC cxx_std_20)
   set_target_properties(${TARGET} PROPERTIES CXX_EXTENSIONS OFF)
+  global_cxx_target_properties(${TARGET})
   target_compile_definitions(${TARGET} PUBLIC
     "$<${is_standalone}:UNODB_DETAIL_STANDALONE>"
     "$<${use_boost_stacktrace}:UNODB_DETAIL_BOOST_STACKTRACE>"

--- a/art.hpp
+++ b/art.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_ART_HPP
 #define UNODB_DETAIL_ART_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_ART_COMMON_HPP
 #define UNODB_DETAIL_ART_COMMON_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>

--- a/art_internal.cpp
+++ b/art_internal.cpp
@@ -1,13 +1,6 @@
 // Copyright 2021-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_ART_INTERNAL_HPP
 #define UNODB_DETAIL_ART_INTERNAL_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <_string.h>

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_ART_INTERNAL_IMPL_HPP
 #define UNODB_DETAIL_ART_INTERNAL_IMPL_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <algorithm>

--- a/assert.hpp
+++ b/assert.hpp
@@ -35,15 +35,7 @@
 /// \hideinitializer
 /// Crash with a stacktrace on debug build, do nothing on release build.
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
-#include "global.hpp"  // IWYU pragma: keep
+// Copyright 2022-2025 UnoDB contributors
 
 #include <cstdlib>
 #include <iostream>

--- a/benchmark/micro_benchmark.cpp
+++ b/benchmark/micro_benchmark.cpp
@@ -1,13 +1,6 @@
 // Copyright 2019-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_CONCURRENCY_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <memory>

--- a/benchmark/micro_benchmark_key_prefix.cpp
+++ b/benchmark/micro_benchmark_key_prefix.cpp
@@ -1,13 +1,6 @@
 // Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_mutex.cpp
+++ b/benchmark/micro_benchmark_mutex.cpp
@@ -1,13 +1,6 @@
 // Copyright 2019-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n16.cpp
+++ b/benchmark/micro_benchmark_n16.cpp
@@ -1,13 +1,6 @@
 // Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n256.cpp
+++ b/benchmark/micro_benchmark_n256.cpp
@@ -1,13 +1,6 @@
 // Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n4.cpp
+++ b/benchmark/micro_benchmark_n4.cpp
@@ -1,13 +1,6 @@
-// Copyright 2020-2025 Laurynas Biveinis
+// Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_n48.cpp
+++ b/benchmark/micro_benchmark_n48.cpp
@@ -1,13 +1,6 @@
 // Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_NODE_UTILS_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <algorithm>

--- a/benchmark/micro_benchmark_olc.cpp
+++ b/benchmark/micro_benchmark_olc.cpp
@@ -1,13 +1,6 @@
 // Copyright 2019-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -1,13 +1,6 @@
 // Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "micro_benchmark_utils.hpp"

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 #define UNODB_DETAIL_MICRO_BENCHMARK_UTILS_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -2,6 +2,7 @@
 #ifndef UNODB_DETAIL_DEEPSTATE_UTILS_HPP
 #define UNODB_DETAIL_DEEPSTATE_UTILS_HPP
 
+// Should be the first include
 #include "global.hpp"
 
 #include <cstddef>

--- a/global.hpp
+++ b/global.hpp
@@ -138,11 +138,9 @@
 /// another project.
 #define UNODB_DETAIL_STANDALONE
 
-/// \def UNODB_DETAIL_WITH_STATS
 /// Defined when UnoDB is compiled with the statistics counters.
 #define UNODB_DETAIL_WITH_STATS
 
-/// \def UNODB_DETAIL_BOOST_STACKTRACE
 /// Defined when UnoDB is compiled with Boost.Stacktrace.
 #define UNODB_DETAIL_BOOST_STACKTRACE
 
@@ -153,42 +151,19 @@
 /// #UNODB_DETAIL_SPINLOCK_LOOP_EMPTY.
 #define UNODB_DETAIL_SPINLOCK_LOOP_VALUE
 
-#endif  // UNODB_DETAIL_DOXYGEN
-
-/// @}
-
-#ifdef UNODB_DETAIL_STANDALONE
-
-/// \name libstdc++ debug mode
-/// Defines to enable libstdc++ debug mode.
-/// Only defined in the standalone debug configuration with GCC.
-/// @{
-#if !defined(NDEBUG) && !defined(__clang__)
-
-#ifndef _GLIBCXX_DEBUG
-/// Enables the libstdc++ debug mode.
+/// Enables the libstdc++ debug mode when compiling in the standalone debug
+/// configuration.
 #define _GLIBCXX_DEBUG
-#endif
 
-#ifndef _GLIBCXX_DEBUG_PEDANTIC
-/// Enables erroring on the use of libstdc++-specific behaviors and extensions.
+/// Enables erroring on the use of libstdc++-specific behaviors and extensions
+/// when compiling in the standalone debug configuration.
 #define _GLIBCXX_DEBUG_PEDANTIC
-#endif
 
-#endif  // !defined(NDEBUG) && !defined(__clang__)
+/// Annotates `std::vector` in libstdc++ for AddressSanitizer when compiling
+/// with AddressSanitizer.
+#define _GLIBCXX_SANITIZE_VECTOR
 
-#if defined(__has_feature) && !defined(__clang__)
-#if __has_feature(address_sanitizer)
-/// Annotate `std::vector` for AddressSanitizer.
-/// Only defined if building with AddressSanitizer.
-#define _GLIBCXX_SANITIZE_VECTOR 1
-#endif
-#elif defined(__SANITIZE_ADDRESS__)
-#define _GLIBCXX_SANITIZE_VECTOR 1
-#endif
-
-#endif  // UNODB_DETAIL_STANDALONE
-
+#endif  // UNODB_DETAIL_DOXYGEN
 /// @}
 
 #ifdef _MSC_VER

--- a/heap.hpp
+++ b/heap.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_HEAP_HPP
 #define UNODB_DETAIL_HEAP_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <algorithm>

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -16,14 +16,7 @@
 /// parameters, resulting in code that can be compiled for both single-threaded
 /// and concurrent use cases.
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -1,15 +1,8 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_MUTEX_ART_HPP
 #define UNODB_DETAIL_MUTEX_ART_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cassert>

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Laurynas Biveinis
+// Copyright 2021-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_NODE_TYPE_HPP
 #define UNODB_DETAIL_NODE_TYPE_HPP
 
@@ -7,14 +7,7 @@
 /// Defines the node types and, if compiling with stats, counter arrays indexed
 /// by the types.
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_OLC_ART_HPP
 #define UNODB_DETAIL_OLC_ART_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -209,14 +209,7 @@
 /// the addition of an obsolete state for data marked for reclamation.
 /// \}
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <atomic>

--- a/portability_arch.hpp
+++ b/portability_arch.hpp
@@ -6,14 +6,7 @@
 /// Definitions to abstract differences between architectures.
 /// \ingroup internal
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -7,14 +7,7 @@
 /// intrinsics.
 /// \ingroup internal
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstdint>

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -1,13 +1,6 @@
-// Copyright (C) 2019-2024 Laurynas Biveinis
+// Copyright (C) 2019-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__hash_table>

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_QSBR_HPP
 #define UNODB_DETAIL_QSBR_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>

--- a/qsbr_ptr.cpp
+++ b/qsbr_ptr.cpp
@@ -1,13 +1,6 @@
-// Copyright (C) 2021-2023 Laurynas Biveinis
+// Copyright (C) 2021-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "qsbr_ptr.hpp"  // IWYU pragma: keep

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -10,14 +10,7 @@
 /// They are debugging helpers to catch the QSBR contract violation of declaring
 /// a quiescent state while having an active pointer to the shared data.
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>

--- a/test/db_test_utils.cpp
+++ b/test/db_test_utils.cpp
@@ -1,13 +1,6 @@
 // Copyright 2019-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstdint>

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -2,14 +2,7 @@
 #ifndef UNODB_DETAIL_DB_TEST_UTILS_HPP
 #define UNODB_DETAIL_DB_TEST_UTILS_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/sstream.h>

--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -1,15 +1,8 @@
-// Copyright 2021-2024 Laurynas Biveinis
+// Copyright 2021-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_GTEST_UTILS_HPP
 #define UNODB_DETAIL_GTEST_UTILS_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <gtest/gtest.h>

--- a/test/qsbr_gtest_utils.cpp
+++ b/test/qsbr_gtest_utils.cpp
@@ -1,13 +1,6 @@
-// Copyright 2022-2024 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "qsbr_gtest_utils.hpp"

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -1,19 +1,12 @@
-// Copyright 2022-2024 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_QSBR_GTEST_UTILS_HPP
 #define UNODB_DETAIL_QSBR_GTEST_UTILS_HPP
 
+// Should be the first include
+#include "global.hpp"  // IWYU pragma: keep
+
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
-
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
-#include "global.hpp"  // IWYU pragma: keep
 
 #include <gtest/gtest.h>
 

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -1,13 +1,6 @@
 // Copyright 2021-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/test/qsbr_test_utils.hpp
+++ b/test/qsbr_test_utils.hpp
@@ -1,15 +1,8 @@
-// Copyright 2021-2024 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_QSBR_TEST_UTILS_HPP
 #define UNODB_DETAIL_QSBR_TEST_UTILS_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 namespace unodb::test {

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -1,17 +1,10 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2019-2025 UnoDB contributors
 
 // IWYU pragma: no_include <array>
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <cstddef>

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -1,13 +1,6 @@
 // Copyright 2021-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/test/test_art_iter.cpp
+++ b/test/test_art_iter.cpp
@@ -1,13 +1,6 @@
 // Copyright 2024-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -2,14 +2,7 @@
 
 #ifndef NDEBUG
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <array>

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -1,13 +1,6 @@
-// Copyright 2019-2025 UnoDB contributors
+// Copyright 2024-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>

--- a/test/test_art_span.cpp
+++ b/test/test_art_span.cpp
@@ -1,13 +1,6 @@
 // Copyright 2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <array>

--- a/test/test_key_encode_decode.cpp
+++ b/test/test_key_encode_decode.cpp
@@ -1,13 +1,6 @@
-// Copyright 2019-2024 Laurynas Biveinis
+// Copyright 2024-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <array>

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -1,13 +1,6 @@
-// Copyright 2020-2024 Laurynas Biveinis
+// Copyright 2020-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/sstream.h>

--- a/test/test_qsbr_oom.cpp
+++ b/test/test_qsbr_oom.cpp
@@ -1,15 +1,8 @@
-// Copyright 2022-2024 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 
 #ifndef NDEBUG
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <array>

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -1,13 +1,6 @@
 // Copyright 2022-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -1,15 +1,8 @@
-// Copyright 2022-2023 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_TEST_UTILS_HPP
 #define UNODB_DETAIL_TEST_UTILS_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "test_heap.hpp"

--- a/test_heap.cpp
+++ b/test_heap.cpp
@@ -1,13 +1,6 @@
-// Copyright 2022-2023 Laurynas Biveinis
+// Copyright 2022-2025 UnoDB contributors
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include "test_heap.hpp"  // IWYU pragma: keep

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -1,15 +1,8 @@
-// Copyright 2023 Laurynas Biveinis
+// Copyright 2023-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_TEST_HEAP_HPP
 #define UNODB_DETAIL_TEST_HEAP_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #ifndef NDEBUG

--- a/thread_sync.hpp
+++ b/thread_sync.hpp
@@ -1,15 +1,8 @@
-// Copyright 2020-2024 Laurynas Biveinis
+// Copyright 2020-2025 UnoDB contributors
 #ifndef UNODB_DETAIL_THREAD_SYNC_HPP
 #define UNODB_DETAIL_THREAD_SYNC_HPP
 
-//
-// CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
-// HEADER FILES !!!
-//
-// This header defines _GLIBCXX_DEBUG and _GLIBCXX_DEBUG_PEDANTIC for
-// DEBUG builds.  If some standard headers are included before and
-// after those symbols are defined, then that results in different
-// container internal structure layouts and that is Not Good.
+// Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
 #include <array>


### PR DESCRIPTION
Previously _GLIBCXX_SANITIZE_VECTOR was not used consistently for all build
targets, specifically, Google Test and Google Benchmark in the standalone
configuration were built without it. Also, _GLIBCXX_DEBUG and
_GLIBCXX_DEBUG_PEDANTIC were defined only in GCC builds, even though clang
builds might be using libstdc++ too.

Reimplement the handling of these three defines:
- New CMake function global_cxx_target_properties that conditionally sets all
  three by generator expressions.
- Call it for gtest and gbenchmark targets, as well as from
  common_target_properties which covers all of our code.
- No longer define these macros in global.hpp, but make their Doxygen-only
  declarations for documentation.
- Downgrade the warning severity for failing to include global.hpp before any
  other includes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the build configuration for enhanced sanitization support and consistent target property management.
  
- **Documentation**
  - Streamlined internal comments and standardized header inclusion notes.
  - Updated copyright notices for clarity.

These refinements enhance code maintainability and build consistency while keeping functionality unchanged for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->