### PR TITLE
Convert the rest of qsbr_ptr.hpp and qsbr_ptr.cpp to Doxygen comments

### DIFF
--- a/qsbr_ptr.cpp
+++ b/qsbr_ptr.cpp
@@ -1,5 +1,9 @@
 // Copyright (C) 2021-2025 UnoDB contributors
 
+/// \file
+/// Implementation of active pointer registration for QSBR-managed data in debug
+/// builds.
+
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 


### PR DESCRIPTION
At the same time replace some "class" uses with "typename" and remove redundant
template args.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced inline comments and documentation for improved clarity in debugging and data span management.
  
- **New Features**
  - Introduced a method to retrieve the number of elements from managed spans.

- **Style**
  - Refined type annotations and interface declarations for better consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->