### PR TITLE
Start converting qsbr.hpp to Doxygen style

### DIFF
--- a/.ispell.dict
+++ b/.ispell.dict
@@ -14,3 +14,4 @@ qsbr
 rcs
 nullptr
 benchmarking
+invariants

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,8 @@ unavoidable. If a macro has to be introduced, its name must be prefixed with
   and it should also have a `\hideinitializer` tag.
 * Doxygen automatic brief description detection is enabled, thus explicit
   `\brief` tags are not required, rather the first sentence in the Doxygen
-  comment block will be interpreted as the brief description.
+  comment block will be interpreted as the brief description. It should use a
+  headline-like style without articles.
 * Markdown markup is preferred, i.e. ```foo`` instead of `\c foo`.
 
 ## Linting and static analysis

--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -26,9 +26,9 @@ template <class T>
   return DeepState_SizeTInRange(0, std::size(container) - 1);
 }
 
-/// The DeepState command line-specified timeout in seconds. We need it, but
-/// it is not exposed through the public DeepState API, hence take the risk
-/// and declare it ourselves.
+/// DeepState command line-specified timeout in seconds. We need it, but it is
+/// not exposed through the public DeepState API, hence take the risk and
+/// declare it ourselves.
 extern "C" int FLAGS_timeout;
 
 namespace unodb::test {

--- a/global.hpp
+++ b/global.hpp
@@ -282,7 +282,7 @@
 
 /// @}
 
-/// A declaration specifier for a function in a header file that should not be
+/// Declaration specifier for a function in a header file that should not be
 /// inlined.
 /// \hideinitializer
 /// This is a pair of two seemingly conflicting intentions: "noinline" and

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -144,7 +144,7 @@ class [[nodiscard]] in_fake_critical_section final {
   in_fake_critical_section &operator=(in_fake_critical_section &&) = delete;
 
  private:
-  /// The wrapped value.
+  /// Wrapped value.
   T value;
 };
 

--- a/modules.dox
+++ b/modules.dox
@@ -7,13 +7,13 @@
 /// See also [CONTRIBUTING.md](CONTRIBUTING.md).
 
 /// \defgroup optimistic-lock Optimistic Locking
-/// The optimistic lock primitive and associated internals.
+/// Optimistic lock primitive and associated internals.
 /// \ingroup internal
 
 /// \namespace unodb
-/// The namespace for the public UnoDB API.
+/// Namespace for the public UnoDB API.
 
 /// \namespace unodb::detail
-/// The namespace for the UnoDB internal implementation details.
+/// Namespace for the UnoDB internal implementation details.
 /// \ingroup internal
 /// It is not part of the public API, and it may change at any time.

--- a/node_type.hpp
+++ b/node_type.hpp
@@ -23,8 +23,8 @@
 
 namespace unodb {
 
-/// Node type in the Adaptive Radix Tree.
-/// The type of an internal node depends on its number of children.
+/// Node type in the Adaptive Radix Tree. The type of an internal node depends
+/// on its number of children.
 enum class [[nodiscard]] node_type : std::uint8_t {
   LEAF,  ///< Leaf node for a single value
   I4,    ///< Internal node for 2-4 children
@@ -38,7 +38,7 @@ namespace detail {
 // C++ has five value categories and IIRC thousands of ways to initialize
 // but no way to count the number of enum elements.
 
-/// The number of different node types.
+/// Number of different node types.
 constexpr std::size_t node_type_count{5};
 
 }  // namespace detail
@@ -48,7 +48,7 @@ constexpr std::size_t node_type_count{5};
 
 namespace detail {
 
-/// The number of different internal node types.
+/// Number of different internal node types.
 constexpr std::size_t inode_type_count{4};
 
 /// Statically assert that \a NodeType is one of the internal node types.
@@ -63,8 +63,8 @@ void is_internal_static_assert() noexcept {
 
 }  // namespace detail
 
-/// An `std::array` of `std::uint64_t` values for each node type.
-/// Use as_i() for indexing.
+/// `std::array` of `std::uint64_t` values for each node type. Use as_i() for
+/// indexing.
 using node_type_counter_array =
     std::array<std::uint64_t, detail::node_type_count>;
 
@@ -73,8 +73,8 @@ using node_type_counter_array =
 template <node_type NodeType>
 inline constexpr auto as_i{static_cast<std::size_t>(NodeType)};
 
-/// An `std::array` of `std::uint64_t` values for each internal node type.
-/// Use internal_as_i() for indexing.
+/// `std::array` of `std::uint64_t` values for each internal node type. Use
+/// internal_as_i() for indexing.
 using inode_type_counter_array =
     std::array<std::uint64_t, detail::inode_type_count>;
 

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -3,7 +3,7 @@
 #define UNODB_DETAIL_OPTIMISTIC_LOCK_HPP
 
 /// \file
-/// The optimistic lock.
+/// Optimistic lock.
 ///
 /// \ingroup optimistic-lock
 
@@ -231,9 +231,9 @@
 
 namespace unodb {
 
-/// The optimistic spinlock wait loop algorithm implementation.
-/// The implementation is selected by #UNODB_DETAIL_SPINLOCK_LOOP_VALUE, set by
-/// CMake, and can be either #UNODB_DETAIL_SPINLOCK_LOOP_PAUSE or
+/// Optimistic spinlock wait loop algorithm implementation. The implementation
+/// is selected by #UNODB_DETAIL_SPINLOCK_LOOP_VALUE, set by CMake, and can be
+/// either #UNODB_DETAIL_SPINLOCK_LOOP_PAUSE or
 /// #UNODB_DETAIL_SPINLOCK_LOOP_EMPTY
 // TODO(laurynas): move to unodb::detail namespace
 // LCOV_EXCL_START
@@ -260,13 +260,13 @@ inline void spin_wait_loop_body() noexcept {
 }
 // LCOV_EXCL_STOP
 
-/// The underlying integer type used to store optimistic lock word, including
-/// its version and lock state information.
+/// Underlying integer type used to store optimistic lock word, including its
+/// version and lock state information.
 //
 // TODO(laurynas) can we use optimistic_lock::version_type instead?
 using version_tag_type = std::uint64_t;
 
-/// A version-based optimistic lock that supports single-writer/multiple-readers
+/// Version-based optimistic lock that supports single-writer/multiple-readers
 /// concurrency without shared memory writes during read operations.
 ///
 /// Writers bump the version counter and readers detect concurrent writes by
@@ -289,7 +289,7 @@ class [[nodiscard]] optimistic_lock final {
   // TODO(laurynas): rename to lock_word
   class [[nodiscard]] version_type final {
    public:
-    /// A lock word value constant in the obsolete state.
+    /// Lock word value constant in the obsolete state.
     static constexpr version_tag_type obsolete_lock_word = 1U;
 
     /// Create a new lock word from a raw \a version_val value.
@@ -352,12 +352,12 @@ class [[nodiscard]] optimistic_lock final {
     }
 
    private:
-    /// The raw lock word value.
+    /// Raw lock word value.
     version_tag_type version{0};
   };  // class version_type
 
  private:
-  /// The atomic lock word and its operations.
+  /// Atomic lock word and its operations.
   class [[nodiscard]] atomic_version_type final {
    public:
     /// Atomically load the lock word with acquire memory ordering.
@@ -415,7 +415,7 @@ class [[nodiscard]] optimistic_lock final {
     }
 
    private:
-    /// The raw atomic lock word.
+    /// Raw atomic lock word.
     std::atomic<std::uint64_t> version;
 
     static_assert(decltype(version)::is_always_lock_free,
@@ -425,8 +425,8 @@ class [[nodiscard]] optimistic_lock final {
  public:
   class write_guard;
 
-  /// A read critical section (RCS) that stores the lock version at the read
-  /// lock time and checks it against the current version for consistent reads.
+  /// Read critical section (RCS) that stores the lock version at the read lock
+  /// time and checks it against the current version for consistent reads.
   /// Instances are non-copyable and only movable with the move constructor.
   ///
   /// There are three different states for an RCS:
@@ -562,20 +562,20 @@ class [[nodiscard]] optimistic_lock final {
     read_critical_section &operator=(const read_critical_section &) = delete;
 
    private:
-    /// The lock backing this RCS.
+    /// Lock backing this RCS.
 #ifndef NDEBUG
     mutable
 #endif
         optimistic_lock *lock{nullptr};
 
-    /// The lock version at the RCS creation time. Immutable throughout
-    /// the RCS lifetime.
+    /// Lock version at the RCS creation time. Immutable throughout the RCS
+    /// lifetime.
     version_type version{0};
 
     friend class write_guard;
   };  // class read_critical_section
 
-  /// A write guard (WG) for exclusive access protection. Functions as a scope
+  /// Write guard (WG) for exclusive access protection. Functions as a scope
   /// guard if needed. Can only be created by attempting to upgrade a
   /// optimistic_lock::read_critical_section. Instances are non-copyable and
   /// non-movable.
@@ -664,7 +664,7 @@ class [[nodiscard]] optimistic_lock final {
       return result;
     }
 
-    /// The underlying lock. If `nullptr`, this WG is inactive.
+    /// Underlying lock. If `nullptr`, this WG is inactive.
     optimistic_lock *lock{nullptr};
   };  // class write_guard
 
@@ -808,7 +808,7 @@ class [[nodiscard]] optimistic_lock final {
 #endif
   }
 
-  /// The atomic lock word.
+  /// Atomic lock word.
   atomic_version_type version{};
 
 #ifndef NDEBUG
@@ -856,7 +856,7 @@ static_assert(sizeof(optimistic_lock) == 8);
 static_assert(sizeof(optimistic_lock) == 24);
 #endif
 
-/// A gloss for the atomic semantics used to guard loads and stores. Wraps the
+/// Gloss for the atomic semantics used to guard loads and stores. Wraps the
 /// protected data fields. The loads and stores become relaxed atomic operations
 /// as required by the optimistic lock memory model. The instances are
 /// non-moveable and non-copy-constructable but the assignments both from the
@@ -941,7 +941,7 @@ class [[nodiscard]] in_critical_section final {
   void operator=(in_critical_section &&) = delete;
 
  private:
-  /// The wrapped value.
+  /// Wrapped value.
   std::atomic<T> value;
 
   static_assert(std::atomic<T>::is_always_lock_free,

--- a/portability_arch.hpp
+++ b/portability_arch.hpp
@@ -14,22 +14,20 @@
 namespace unodb::detail {
 
 /// \var hardware_constructive_interference_size
-/// The maximum size in bytes where multiple variables will be guaranteed to be
+/// Maximum size in bytes where multiple variables will be guaranteed to be
 /// shared for the purposes of true sharing.
 /// \hideinitializer
-/// Use this instead of
-/// `std::hardware_constructive_interference_size` even if the latter is
-/// available, because it is used in public headers and its value may vary,
-/// for example, by GCC 12 or later `--param` or `-mtune` flag.
+/// Use this instead of `std::hardware_constructive_interference_size` even if
+/// the latter is available, because it is used in public headers and its value
+/// may vary, for example, by GCC 12 or later `--param` or `-mtune` flag.
 
 /// \var hardware_destructive_interference_size
-/// The minimum size in bytes where multiple variables will be guaranteed to be
+/// Minimum size in bytes where multiple variables will be guaranteed to be
 /// separated for the purposes of false sharing.
 /// \hideinitializer
-/// Use this instead of
-/// `std::hardware_destructive_interference_size` even if the latter is
-/// available, because it is used in public headers and its value may vary,
-/// for example, by GCC 12 or later `--param` or `-mtune` flag.
+/// Use this instead of `std::hardware_destructive_interference_size` even if
+/// the latter is available, because it is used in public headers and its value
+/// may vary, for example, by GCC 12 or later `--param` or `-mtune` flag.
 
 #ifdef UNODB_DETAIL_X86_64
 inline constexpr std::size_t hardware_constructive_interference_size = 64;

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -44,7 +44,7 @@ class qsbr_ptr_base {
 
 }  // namespace detail
 
-/// A raw pointer-like smart pointer to QSBR-managed shared data. Crashes debug
+/// Raw pointer-like smart pointer to QSBR-managed shared data. Crashes debug
 /// builds if a thread goes through a quiescent state while having an active
 /// pointer. Meets C++ contiguous iterator requirements.
 // Implemented the minimum necessary operations, extend as needed.
@@ -278,13 +278,13 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
   }
 
  private:
-  /// The raw pointer.
+  /// Raw pointer.
   pointer ptr{nullptr};
 };
 
 static_assert(std::contiguous_iterator<unodb::qsbr_ptr<std::byte>>);
 
-/// An std::span, but with unodb::qsbr_ptr instead of a raw pointer, that is, a
+/// `std::span`, but with unodb::qsbr_ptr instead of a raw pointer, that is, a
 /// span over QSBR-managed data. Crashes debug builds if a thread goes through a
 /// quiescent state while having an active span. Meets C++ contiguous range
 /// requirements.
@@ -337,9 +337,10 @@ class qsbr_ptr_span : public std::ranges::view_base {
   }
 
  private:
-  /// The QSBR pointer to the start of the span.
+  /// QSBR pointer to the start of the span.
   qsbr_ptr<T> start;
-  /// The number of elements.
+
+  /// Number of elements.
   std::size_t length;
 };
 


### PR DESCRIPTION
Also, use headline-style without articles in the Doxygen brief descriptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced spell-check capability with an expanded vocabulary that now recognizes the term "invariants."

- **Documentation**
  - Updated contributor guidelines to specify headline-style formatting for brief descriptions.
  - Refined internal documentation and comment phrasing for improved clarity and consistency without affecting functionality.
  - Added comprehensive documentation for the Quiescent State-based Reclamation (QSBR) memory reclamation scheme, including detailed explanations and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->