### PR TITLE
Move qsbr_epoch class to detail namespace

### DIFF
--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -28,7 +28,7 @@
 namespace {
 
 constexpr auto max_threads{1024};
-static_assert(max_threads <= unodb::max_qsbr_threads);
+static_assert(max_threads <= unodb::detail::max_qsbr_threads);
 constexpr auto max_thread_id{102400};
 
 constexpr std::uint64_t object_mem = 0xAABBCCDD22446688ULL;
@@ -683,10 +683,12 @@ TEST(QSBR, DeepStateFuzz) {
           }
           reset_stats();
         });
-    const auto unpaused_threads = static_cast<unodb::qsbr_thread_count_type>(
-        std::ranges::count_if(threads, [](const thread_info &info) noexcept {
-          return !info.is_paused;
-        }));
+    const auto unpaused_threads =
+        static_cast<unodb::detail::qsbr_thread_count_type>(
+            std::ranges::count_if(threads,
+                                  [](const thread_info &info) noexcept {
+                                    return !info.is_paused;
+                                  }));
     const auto current_qsbr_state = unodb::qsbr::instance().get_state();
     ASSERT(unodb::qsbr_state::single_thread_mode(current_qsbr_state) ==
            (unpaused_threads < 2));

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -69,7 +69,7 @@ thread_local std::unique_ptr<qsbr_per_thread>
     qsbr_per_thread::current_thread_instance;
 
 // LCOV_EXCL_START
-[[gnu::cold]] UNODB_DETAIL_NOINLINE void qsbr_epoch::dump(
+[[gnu::cold]] UNODB_DETAIL_NOINLINE void detail::qsbr_epoch::dump(
     std::ostream &os) const {
   os << "epoch = " << static_cast<std::uint64_t>(epoch_val);
 #ifndef NDEBUG
@@ -196,7 +196,7 @@ void qsbr_per_thread::orphan_deferred_requests() noexcept {
   UNODB_DETAIL_ASSERT(current_interval_orphan_list_node == nullptr);
 }
 
-qsbr_epoch qsbr::register_thread() noexcept {
+detail::qsbr_epoch qsbr::register_thread() noexcept {
   auto old_state = get_state();
 
   while (true) {
@@ -246,7 +246,7 @@ qsbr_epoch qsbr::register_thread() noexcept {
 }
 
 void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
-                             qsbr_epoch thread_epoch,
+                             detail::qsbr_epoch thread_epoch,
                              qsbr_per_thread &qsbr_thread)
 #ifndef UNODB_DETAIL_WITH_STATS
     noexcept
@@ -380,11 +380,11 @@ void qsbr::thread_epoch_change_barrier() noexcept {
 #endif
 }
 
-qsbr_epoch qsbr::remove_thread_from_previous_epoch(
-    qsbr_epoch current_global_epoch
+detail::qsbr_epoch qsbr::remove_thread_from_previous_epoch(
+    detail::qsbr_epoch current_global_epoch
 #ifndef NDEBUG
     ,
-    qsbr_epoch thread_epoch
+    detail::qsbr_epoch thread_epoch
 #endif
     ) noexcept {
   thread_epoch_change_barrier();
@@ -461,8 +461,8 @@ void qsbr::epoch_change_barrier_and_handle_orphans(
   }
 }
 
-qsbr_epoch qsbr::change_epoch(qsbr_epoch current_global_epoch,
-                              bool single_thread_mode) noexcept {
+detail::qsbr_epoch qsbr::change_epoch(detail::qsbr_epoch current_global_epoch,
+                                      bool single_thread_mode) noexcept {
   epoch_change_barrier_and_handle_orphans(single_thread_mode);
 
   auto old_state = state.load(std::memory_order_acquire);

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -5,6 +5,8 @@
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
+// IWYU pragma: no_include <cstddef>
+// IWYU pragma: no_include <cstdint>
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include "gtest/gtest.h"
 
@@ -262,7 +264,7 @@ class QSBRTestBase : public ::testing::Test {
   QSBRTestBase &operator=(QSBRTestBase &&) = delete;
 
  private:
-  unodb::qsbr_epoch last_epoch{0};
+  unodb::detail::qsbr_epoch last_epoch{0};
 };
 
 }  // namespace unodb::test


### PR DESCRIPTION
At the same time:
- Add get_val method, make qsbr_state call it instead of being a friend
- Replace auto return types with exact types
- Add gnu::const attributes where applicable
- For struct deallocation_request, suppress the const field warning and
  explicitly default and delete the special member functions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new value accessor that simplifies how internal state information is retrieved.

- **Refactor**
  - Enhanced API consistency and maintainability by reorganizing type definitions and updating method interfaces.
  - Improved encapsulation of types within a new namespace for better organization.

- **Tests**
  - Adjusted testing utilities to align with the updated API and improved internal data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->