### PR TITLE
Remove specific toolset version from MSVC in GitHub Actions [circle skip]

### DIFF
--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -73,8 +73,6 @@ jobs:
 
       - name: Setup command line tools
         uses: ilammy/msvc-dev-cmd@v1
-        with:
-          toolset: 14.42
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Because there's only one version there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the build process by removing a fixed toolset version during command line tool setup, allowing the workflow to utilize the default or latest available version for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->