### PR TITLE
Remove redundant env commands from examples/CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,9 +37,9 @@ add_executable(example_olc_art example_olc_art.cpp)
 target_link_libraries(example_olc_art PRIVATE unodb)
 
 add_custom_target(examples
-  env ./example_art
-  COMMAND env ./example_art_stats
-  COMMAND env ./example_olc_art
+  ./example_art
+  COMMAND ./example_art_stats
+  COMMAND ./example_olc_art
   DEPENDS example_art example_art_stats example_olc_art)
 
 set(VALGRIND_COMMAND "valgrind" "--error-exitcode=1" "--leak-check=full"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the way example scripts are executed, providing a more direct and efficient workflow. Users running examples will benefit from a cleaner execution process, reducing unnecessary steps and simplifying the experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->