### PR TITLE
Remove operator!= methods to allow C++20 synthetization from operator==

### DIFF
--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -353,17 +353,13 @@ class [[nodiscard]] basic_node_ptr {
   }
 
   // same raw_val means same type and same ptr.
-  [[nodiscard, gnu::pure]] constexpr auto operator==(
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
       const basic_node_ptr &other) const noexcept {
     return tagged_ptr == other.tagged_ptr;
   }
 
-  [[nodiscard, gnu::pure]] auto operator==(std::nullptr_t) const noexcept {
+  [[nodiscard, gnu::pure]] bool operator==(std::nullptr_t) const noexcept {
     return tagged_ptr == reinterpret_cast<std::uintptr_t>(nullptr);
-  }
-
-  [[nodiscard, gnu::pure]] auto operator!=(std::nullptr_t) const noexcept {
-    return tagged_ptr != reinterpret_cast<std::uintptr_t>(nullptr);
   }
 
  private:

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -121,15 +121,9 @@ class [[nodiscard]] in_fake_critical_section final {
   constexpr T operator--(int) noexcept { return value--; }
 
   /// Checks whether the wrapped pointer is `nullptr`.
-  [[nodiscard, gnu::pure]] constexpr auto operator==(
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
       std::nullptr_t) const noexcept {
     return value == nullptr;
-  }
-
-  /// Checks whether the wrapped pointer is not `nullptr`.
-  [[nodiscard, gnu::pure]] constexpr auto operator!=(
-      std::nullptr_t) const noexcept {
-    return value != nullptr;
   }
 
   /// Convert to the wrapped value, implicitly if needed.

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -913,13 +913,8 @@ class [[nodiscard]] in_critical_section final {
   }
 
   /// Checks whether the wrapped pointer is `nullptr`.
-  [[nodiscard]] auto operator==(std::nullptr_t) const noexcept {
+  [[nodiscard]] bool operator==(std::nullptr_t) const noexcept {
     return load() == nullptr;
-  }
-
-  /// Checks whether the wrapped pointer is not `nullptr`.
-  [[nodiscard]] auto operator!=(std::nullptr_t) const noexcept {
-    return load() != nullptr;
   }
 
   /// Convert to the wrapped value, implicitly if needed.

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -132,17 +132,6 @@ class [[nodiscard]] qsbr_epoch final {
     return epoch_val == other.epoch_val;
   }
 
-  /// Compare not equal to \a other.
-  [[nodiscard, gnu::pure]] constexpr bool operator!=(
-      qsbr_epoch other) const noexcept {
-#ifndef NDEBUG
-    assert_invariant();
-    other.assert_invariant();
-#endif
-
-    return epoch_val != other.epoch_val;
-  }
-
   /// Output the epoch to \a os. For debug purposes only.
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream &os) const;
 

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -242,12 +242,6 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
     return get() == other.get();
   }
 
-  /// Compare not equal to \a other.
-  [[nodiscard, gnu::pure]] constexpr bool operator!=(
-      qsbr_ptr other) const noexcept {
-    return get() != other.get();
-  }
-
   /// Compare less than or equal to \a other.
   [[nodiscard, gnu::pure]] constexpr bool operator<=(
       qsbr_ptr other) const noexcept {


### PR DESCRIPTION
Replace a couple of auto return types with bool for operator==.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined pointer comparison logic: Equality checks now explicitly return boolean values while redundant inequality comparisons have been removed for improved consistency across the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->