### PR TITLE
Fix MSVC 17.43 static analysis findings

### DIFF
--- a/assert.hpp
+++ b/assert.hpp
@@ -115,6 +115,8 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 // Definitions that only depend on standalone vs part of another project
 #ifdef UNODB_DETAIL_STANDALONE
 
+UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
+
 /// Intentionally crash from a given source location.
 ///
 /// Should not be called directly - use UNODB_DETAIL_CRASH instead.
@@ -127,6 +129,8 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
       << "\", thread " << std::this_thread::get_id() << '\n';
   msg_stacktrace_abort(buf.str());
 }
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 #define UNODB_DETAIL_CRASH() unodb::detail::crash(__FILE__, __LINE__, __func__)
 

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -22,7 +22,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(4514)
 /// Test helper class may be used to inject memory allocation faults, throwing
 /// `std::bad_alloc` once some number of allocations have been made.
 class allocation_failure_injector final {
-  friend class pause_heap_faults;
+  friend struct pause_heap_faults;
 
  public:
   /// Reset the counters tracking the number of allocations and the allocation
@@ -83,12 +83,25 @@ class allocation_failure_injector final {
 
 /// Lexically scoped guard to pause heap allocation tracking and faulting for
 /// the current thread.
-class pause_heap_faults {
+struct [[nodiscard]] pause_heap_faults final {
  public:
   /// Pause heap faults for this thread.
   pause_heap_faults() noexcept { allocation_failure_injector::paused = true; }
+
   /// Resumes heap faults for this thread.
   ~pause_heap_faults() { allocation_failure_injector::paused = false; }
+
+  /// Copy construction is disabled.
+  pause_heap_faults(const pause_heap_faults&) = delete;
+
+  /// Move construction is disabled.
+  pause_heap_faults(pause_heap_faults&&) = delete;
+
+  /// Copy assignment is disabled.
+  pause_heap_faults& operator=(const pause_heap_faults&) = delete;
+
+  /// Move assignment is disabled.
+  pause_heap_faults& operator=(pause_heap_faults&&) = delete;
 };
 
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()


### PR DESCRIPTION
- Delete all unused special members for pause_heap_faults, make this class a
  struct, make it final and nodiscard.
- Suppress "noexcept method calling a potentially-throwing function" for an
  assert.hpp helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced internal error and warning management to improve build stability.
  - Streamlined memory fault handling, ensuring tighter control of internal test utilities.

- **Tests**
  - Updated testing components to prevent unintended behavior during memory fault simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->