### PR TITLE
Change default CMake Unix preset generator to Ninja

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,7 +20,7 @@
             "name": "base-unix",
             "hidden": true,
             "inherits": "base",
-            "generator": "Unix Makefiles"
+            "generator": "Ninja"
         },
         {
             "name": "base-msvc",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Unix build configuration to generate build files with Ninja instead of Makefiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->