### PR TITLE
Delete all unused key_encoder special members

### DIFF
--- a/art_common.hpp
+++ b/art_common.hpp
@@ -478,6 +478,11 @@ class key_encoder {
         reinterpret_cast<const std::byte *>(sv.data()), sv.size()));
   }
 
+  key_encoder(const key_encoder &) = delete;
+  key_encoder(key_encoder &&) = delete;
+  key_encoder &operator=(const key_encoder &) = delete;
+  key_encoder &operator=(key_encoder &&) = delete;
+
  private:
   /// Ensure that we have at least the specified capacity in the buffer.
   void ensure_capacity(size_t min_capacity) {


### PR DESCRIPTION
This fixes an MSVC 17.13 static analysis warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Improved the key encoding functionality by enforcing exclusive instance handling, which minimizes the risk of unintended duplication while enhancing resource safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->