### PR TITLE
Add LLVM 20 support to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     default: "14"
   CLANG_VERSION:
     type: string
-    default: "19"
+    default: "20"
 
 jobs:
   build-linux:
@@ -56,6 +56,11 @@ jobs:
             - run:
                 name: Installing dependencies (LLVM common)
                 command: |
+                  curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
+                    | sudo apt-key add -
+                  sudo add-apt-repository -y \
+                    "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main"
+                  sudo apt-get update
                   sudo apt-get install -y clang-${CLANG_VERSION} \
                     clang-tidy-${CLANG_VERSION} iwyu \
                     libstdc++-${GCC_VERSION}-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,59 +101,59 @@ jobs:
             os: ubuntu-22.04
             COMPILER: gcc
 
-          - name: clang 19 Release
+          - name: clang 20 Release
             os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
 
-          - name: clang 19 Release with ASan
+          - name: clang 20 Release with ASan
             os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_ADDRESS: ON
             COMPILER: clang
 
-          - name: clang 19 Release with TSan
+          - name: clang 20 Release with TSan
             os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_THREAD: ON
             COMPILER: clang
 
-          - name: clang 19 Release with UBSan
+          - name: clang 20 Release with UBSan
             os: ubuntu-22.04
             BUILD_TYPE: Release
             SANITIZE_UB: ON
             COMPILER: clang
 
-          - name: clang 19 Debug
+          - name: clang 20 Debug
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
 
-          - name: clang 19 Debug with ASan
+          - name: clang 20 Debug with ASan
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_ADDRESS: ON
             COMPILER: clang
 
-          - name: clang 19 Debug with TSan
+          - name: clang 20 Debug with TSan
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_THREAD: ON
             COMPILER: clang
 
-          - name: clang 19 Debug with UBSan
+          - name: clang 20 Debug with UBSan
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             SANITIZE_UB: ON
             COMPILER: clang
 
-          - name: clang 19 Release static analysis
+          - name: clang 20 Release static analysis
             os: ubuntu-22.04
             BUILD_TYPE: Release
             COMPILER: clang
             STATIC_ANALYSIS: ON
 
-          - name: clang 19 Debug static analysis
+          - name: clang 20 Debug static analysis
             os: ubuntu-22.04
             BUILD_TYPE: Debug
             COMPILER: clang
@@ -310,26 +310,26 @@ jobs:
         run: |
           curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
             | sudo apt-key add -
-          echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main' \
-            | sudo tee -a /etc/apt/sources.list
+          sudo add-apt-repository -y \
+            "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main"
           sudo apt-get update
-          sudo apt-get install -y clang-19 iwyu
+          sudo apt-get install -y clang-20 iwyu
         if: runner.os == 'Linux' && env.COMPILER == 'clang'
 
       - name: Setup dependencies for Linux LLVM (Release)
-        run: sudo apt-get install -y libomp5-19 llvm-19 lld-19
+        run: sudo apt-get install -y libomp5-20 llvm-20 lld-20
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
           && env.BUILD_TYPE == 'Release'
 
       - name: Setup dependencies for Linux LLVM (static analysis)
-        run: sudo apt-get install -y clang-tools-19
+        run: sudo apt-get install -y clang-tools-20
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
           && env.STATIC_ANALYSIS == 'ON'
 
       - name: Setup dependencies for Linux LLVM (not static analysis)
-        run: sudo apt-get install -y clang-tidy-19
+        run: sudo apt-get install -y clang-tidy-20
         if: >
           runner.os == 'Linux' && env.COMPILER == 'clang'
           && env.STATIC_ANALYSIS != 'ON'
@@ -377,7 +377,7 @@ jobs:
             export CC=gcc-$V
             export CXX=g++-$V
           elif [[ $COMPILER == "clang" ]]; then
-            V=19
+            V=20
             export CC=clang-$V
             export CXX=clang++-$V
             if [[ $BUILD_TYPE == "Release" ]]; then
@@ -394,7 +394,7 @@ jobs:
               # Workaround https://github.com/llvm/llvm-project/issues/61576
               # scan-build defaults to -std=c++14
               EXTRA_CMAKE_ARGS=("${EXTRA_CMAKE_ARGS[@]}" \
-                  "-DCMAKE_CXX_FLAGS=-std=c++17")
+                  "-DCMAKE_CXX_FLAGS=-std=c++20")
             else
               EXTRA_CMAKE_ARGS=("${EXTRA_CMAKE_ARGS[@]}" \
                   "-DCLANG_TIDY_EXE=/usr/bin/clang-tidy-$V")
@@ -419,7 +419,7 @@ jobs:
       - name: clang static analysis
         working-directory: ${{github.workspace}}/build
         run: |
-          /usr/bin/scan-build-19 --status-bugs -stats -analyze-headers \
+          /usr/bin/scan-build-20 --status-bugs -stats -analyze-headers \
             --force-analyze-debug-code make -j3 -k;
         if: env.STATIC_ANALYSIS == 'ON' && env.COMPILER == 'clang'
 

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -331,6 +331,52 @@ jobs:
             COMPILER: clang
             VERSION: 18
 
+          - name: clang 19 Release
+            BUILD_TYPE: Release
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Release with ASan
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Release with TSan
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Release with UBSan
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Debug
+            BUILD_TYPE: Debug
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Debug with ASan
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Debug with TSan
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: clang
+            VERSION: 19
+
+          - name: clang 19 Debug with UBSan
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: clang
+            VERSION: 19
+
           - name: GCC 11 Release
             BUILD_TYPE: Release
             COMPILER: gcc
@@ -461,9 +507,8 @@ jobs:
         run: |
           curl 'https://apt.llvm.org/llvm-snapshot.gpg.key' \
             | sudo apt-key add -
-          echo "deb http://apt.llvm.org/jammy/ \
-            llvm-toolchain-jammy-${VERSION} main" \
-            | sudo tee -a /etc/apt/sources.list
+          sudo add-apt-repository -y \
+            "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${VERSION} main"
           sudo apt-get update
           sudo apt-get install -y "llvm-${VERSION}-linker-tools" \
                 "clang-${VERSION}" "clang-tidy-${VERSION}"

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -700,6 +700,7 @@ TEST(QSBR, DeepStateFuzz) {
     for (const auto &tinfo : threads)
       for (const auto &active_ptr : tinfo.active_ptrs)
         ASSERT(*active_ptr == object_mem);
+    // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (const auto *const ptr : allocated_pointers) ASSERT(*ptr == object_mem);
 
     // Check that dump does not crash
@@ -739,6 +740,7 @@ TEST(QSBR, DeepStateFuzz) {
     }
   }
 
+  // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
   for (const auto &ptr : allocated_pointers) {
     LOG(TRACE) << "Deallocating pointer at the test end";
     deallocate_pointer(ptr);


### PR DESCRIPTION
At the same time:
- Use add-apt-repository instead of directly manipulating /etc/apt/sources.list
- Fix LLVM static analysis job setting C++ standard version to 17 instead of 20
- Move LLVM 19 testing to old-compilers.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build configurations to adopt Clang version 20 for improved performance and compatibility.
  - Enhanced installation steps for the compiler toolchain to ensure a smoother build process.
  - Extended support by maintaining legacy build options for Clang version 19.
- **Documentation**
  - Added comments to suppress warnings related to pointer iteration order in fuzz testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->