### PR TITLE
Mark unodb::detail::compare functions as noexcept

### DIFF
--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -35,7 +35,8 @@ class [[nodiscard]] basic_db_leaf_deleter;
 ///
 /// @return -1, 0, or 1 if this key is LT, EQ, or GT the other key.
 [[nodiscard, gnu::pure]] inline int compare(const void *a, const size_t alen,
-                                            const void *b, const size_t blen) {
+                                            const void *b,
+                                            const size_t blen) noexcept {
   // TODO(thompsonbry) consider changing this over to std::span
   // arguments and do not let the (ptr,len) pattern progagate
   // outwards.
@@ -49,7 +50,7 @@ class [[nodiscard]] basic_db_leaf_deleter;
 ///
 /// @return -1, 0, or 1 if this key is LT, EQ, or GT the other key.
 [[nodiscard, gnu::pure]] inline int compare(const unodb::key_view a,
-                                            const unodb::key_view b) {
+                                            const unodb::key_view b) noexcept {
   return compare(a.data(), a.size_bytes(), b.data(), b.size_bytes());
 }
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -757,7 +757,8 @@ class [[nodiscard]] tree_verifier final {
  private:
   // Custom comparator is required for key_view.
   struct comparator {
-    bool operator()(const ikey_type<Db> &lhs, const ikey_type<Db> &rhs) const {
+    bool operator()(const ikey_type<Db> &lhs,
+                    const ikey_type<Db> &rhs) const noexcept {
       if constexpr (std::is_same_v<typename Db::key_type, unodb::key_view>) {
         // Handle wrapped keys.
         return unodb::detail::compare(lhs->data(), lhs->size(), rhs->data(),


### PR DESCRIPTION
Found by MSVC 17.13 static analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved internal stability by enhancing error handling, leading to a more reliable overall experience.
  - Updated function signatures to include exception safety guarantees, ensuring more robust comparison operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->