### PR TITLE
Remove redundant reinterpret_cast from detail::bit_cast

### DIFF
--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -117,7 +117,7 @@ template <typename To, typename From>
   // must be the same stride
   static_assert(sizeof(To) == sizeof(From));
   typename std::aligned_storage<sizeof(To), alignof(To)>::type tmp;
-  std::memcpy(reinterpret_cast<void*>(&tmp), &input, sizeof(To));
+  std::memcpy(&tmp, &input, sizeof(To));
   return reinterpret_cast<const To&>(tmp);
 }
 


### PR DESCRIPTION
Found by MSVC 17.13 static analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the internal memory handling process for improved code clarity without impacting any observable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->