### PR TITLE
Cleanup Google Test macros and their wrappers

### DIFF
--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -632,8 +632,7 @@ class [[nodiscard]] tree_verifier final {
             prev = kv;
             first = false;
           } else {
-            // NOLINTNEXTLINE(readability/check)
-            EXPECT_TRUE(unodb::detail::compare(prev, kv) < 0);
+            UNODB_EXPECT_LT(unodb::detail::compare(prev, kv), 0);
             prev = kv;
           }
           n++;

--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -16,9 +16,7 @@
 // is not a bug: https://github.com/google/googletest/issues/2271
 #define UNODB_TYPED_TEST_SUITE(Suite, Types)                                \
   UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wgnu-zero-variadic-macro-arguments") \
-  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wpedantic")                          \
   TYPED_TEST_SUITE(Suite, Types);                                           \
-  UNODB_DETAIL_RESTORE_CLANG_WARNINGS()                                     \
   UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 #define UNODB_START_TESTS()                \
@@ -32,15 +30,6 @@
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS() \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS() \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
-
-// Because Google thinks
-// error: 'void {anonymous}::ARTCorrectnessTest_single_node_tree_empty_value_
-// Test<gtest_TypeParam_>::TestBody() [with gtest_TypeParam_ = unodb::db]'
-// can be marked override [-Werror=suggest-override] is not a bug:
-// https://github.com/google/googletest/issues/1063
-#define UNODB_START_TYPED_TESTS() \
-  UNODB_START_TESTS()             \
-  UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-override")
 
 #define UNODB_ASSERT_DEATH(statement, regex)                       \
   do {                                                             \
@@ -56,7 +45,7 @@
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26409) \
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26426) \
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26440) \
-  TEST((Suite), (Test))                    \
+  TEST(Suite, Test)                        \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
@@ -130,12 +119,12 @@
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   } while (0)
 
-#define UNODB_EXPECT_EQ(x, y)                \
-  do {                                       \
-    UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
-    EXPECT_EQ((x), (y));                     \
-    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
-  } while (0)
+// Do not wrap in a block to support streaming to EXPECT_EQ. Happens to be OK
+// because the warning macros are not statements.
+#define UNODB_EXPECT_EQ(x, y)              \
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
+  EXPECT_EQ((x), (y))                      \
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 #define UNODB_EXPECT_GT(x, y)                \
   do {                                       \
@@ -144,12 +133,19 @@
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   } while (0)
 
-#define UNODB_EXPECT_TRUE(cond)              \
+#define UNODB_EXPECT_LT(x, y)                \
   do {                                       \
     UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
-    EXPECT_TRUE(cond);                       \
+    EXPECT_LT((x), (y));                     \
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   } while (0)
+
+// Do not wrap in a block to support streaming to EXPECT_TRUE. Happens to be OK
+// because the warning macros are not statements.
+#define UNODB_EXPECT_TRUE(cond)            \
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
+  EXPECT_TRUE(cond)                        \
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 #define UNODB_EXPECT_FALSE(cond)             \
   do {                                       \

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -39,7 +39,7 @@ using ARTTypes =
 
 UNODB_TYPED_TEST_SUITE(ARTCorrectnessTest, ARTTypes)
 
-UNODB_START_TYPED_TESTS()
+UNODB_START_TESTS()
 
 TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeEmptyValue) {
   unodb::test::tree_verifier<TypeParam> verifier;

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -117,19 +117,19 @@ class ARTConcurrencyTest : public ::testing::Test {
           unodb::test::test_values[akey % unodb::test::test_values.size()];
       const auto actual = v.get_value();
       // LCOV_EXCL_START
-      EXPECT_TRUE(std::ranges::equal(actual, expected));
+      UNODB_EXPECT_TRUE(std::ranges::equal(actual, expected));
       std::ignore = v.get_value();
       if (fwd) {  // [k0,k1) -- k0 is from_key, k1 is to_key
-        EXPECT_TRUE(akey >= k0 && akey < k1)
+        UNODB_EXPECT_TRUE(akey >= k0 && akey < k1)
             << "fwd=" << fwd << ", key=" << akey << ", k0=" << k0
             << ", k1=" << k1;
       } else {  // (k1,k0]
-        EXPECT_TRUE(akey > k0 && akey <= k1)
+        UNODB_EXPECT_TRUE(akey > k0 && akey <= k1)
             << "fwd=" << fwd << ", key=" << akey << ", k0=" << k0
             << ", k1=" << k1;
       }
       if (n > 1) {
-        EXPECT_TRUE(fwd ? (akey > prior) : (akey < prior))
+        UNODB_EXPECT_TRUE(fwd ? (akey > prior) : (akey < prior))
             << "fwd=" << fwd << ", prior=" << prior << ", key=" << akey
             << ", k0=" << k0 << ", k1=" << k1;
       }
@@ -230,7 +230,7 @@ using ConcurrentARTTypes =
 
 UNODB_TYPED_TEST_SUITE(ARTConcurrencyTest, ConcurrentARTTypes)
 
-UNODB_START_TYPED_TESTS()
+UNODB_START_TESTS()
 
 TYPED_TEST(ARTConcurrencyTest, ParallelInsertOneTree) {
   constexpr auto thread_count = 4;

--- a/test/test_art_iter.cpp
+++ b/test/test_art_iter.cpp
@@ -44,7 +44,7 @@ using ARTTypes =
 
 UNODB_TYPED_TEST_SUITE(ARTIteratorTest, ARTTypes)
 
-UNODB_START_TYPED_TESTS()
+UNODB_START_TESTS()
 
 // unit test with an empty tree.
 TYPED_TEST(ARTIteratorTest, emptyTreeForwardScan) {
@@ -52,7 +52,7 @@ TYPED_TEST(ARTIteratorTest, emptyTreeForwardScan) {
   TypeParam& db = verifier.get_db();  // reference to test db instance.
   auto b = db.test_only_iterator();
   b.first();  // obtain iterator.
-  UNODB_EXPECT_TRUE(!b.valid());
+  UNODB_EXPECT_FALSE(b.valid());
 }
 
 // unit test with an empty tree.
@@ -183,21 +183,21 @@ TYPED_TEST(ARTIteratorTest, C0002) {
   b.last();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xab00);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xab00);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xaa01);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa01);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xaa00);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
   }
@@ -221,21 +221,21 @@ TYPED_TEST(ARTIteratorTest, C0003) {
   b.first();  // obtain iterators.
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xaa00);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xab0c);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0c);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xab0d);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0d);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
   }
@@ -259,21 +259,21 @@ TYPED_TEST(ARTIteratorTest, C0004) {
   b.last();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xab0d);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0d);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xab0c);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0c);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
-    UNODB_EXPECT_TRUE(decode(b.get_key()) == 0xaa00);
+    UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
   }
@@ -296,7 +296,7 @@ TYPED_TEST(ARTIteratorTest, emptyTreeSeek) {
     e.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0)}, match,
            true /*fwd*/);
     UNODB_EXPECT_FALSE(e.valid());
-    UNODB_EXPECT_EQ(match, false);
+    UNODB_EXPECT_FALSE(match);
   }
   {
     auto e = db.test_only_iterator();
@@ -304,7 +304,7 @@ TYPED_TEST(ARTIteratorTest, emptyTreeSeek) {
     e.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0)}, match,
            false /*fwd*/);
     UNODB_EXPECT_FALSE(e.valid());
-    UNODB_EXPECT_EQ(match, false);
+    UNODB_EXPECT_FALSE(match);
   }
 }
 
@@ -321,7 +321,7 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
                       match, true /*fwd*/);
     UNODB_EXPECT_TRUE(it.valid());
     UNODB_EXPECT_EQ(match, true);
-    UNODB_EXPECT_TRUE(decode(it.get_key()) == 1);
+    UNODB_EXPECT_EQ(decode(it.get_key()), 1);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     it.next();
@@ -333,8 +333,8 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     auto& it = e.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(1)},
                       match, false /*fwd*/);
     UNODB_EXPECT_TRUE(it.valid());
-    UNODB_EXPECT_EQ(match, true);
-    UNODB_EXPECT_TRUE(decode(it.get_key()) == 1);
+    UNODB_EXPECT_TRUE(match);
+    UNODB_EXPECT_EQ(decode(it.get_key()), 1);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     it.next();
@@ -348,8 +348,8 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0)}, match,
             true /*fwd*/);
     UNODB_EXPECT_TRUE(it.valid());
-    UNODB_EXPECT_EQ(match, false);
-    UNODB_EXPECT_TRUE(decode(it.get_key()) == 1);
+    UNODB_EXPECT_FALSE(match);
+    UNODB_EXPECT_EQ(decode(it.get_key()), 1);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     it.next();
@@ -362,7 +362,7 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(2)}, match,
             true /*fwd*/);
     UNODB_EXPECT_FALSE(it.valid());
-    UNODB_EXPECT_EQ(match, false);
+    UNODB_EXPECT_FALSE(match);
   }
   {  // reverse traversal, before the first key in the data.
     // match=false and iterator is invalidated.
@@ -371,7 +371,7 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0)}, match,
             false /*fwd*/);
     UNODB_EXPECT_FALSE(it.valid());
-    UNODB_EXPECT_EQ(match, false);
+    UNODB_EXPECT_FALSE(match);
   }
   {  // reverse traversal, after the last key in the data.  match=false
     // and iterator is positioned at the last key.
@@ -380,8 +380,8 @@ TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(2)}, match,
             false /*fwd*/);
     UNODB_EXPECT_TRUE(it.valid());
-    UNODB_EXPECT_EQ(match, false);
-    UNODB_EXPECT_TRUE(decode(it.get_key()) == 1);
+    UNODB_EXPECT_FALSE(match);
+    UNODB_EXPECT_EQ(decode(it.get_key()), 1);
     UNODB_EXPECT_TRUE(
         std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     it.next();
@@ -412,8 +412,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k0)}, match,
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k0);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k0);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
     }
@@ -423,8 +423,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k1)}, match,
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k1);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k1);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     }
@@ -434,8 +434,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k2)}, match,
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k2);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k2);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
     }
@@ -447,8 +447,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k0)}, match,
               false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k0);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k0);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
     }
@@ -458,8 +458,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k1)}, match,
               false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k1);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k1);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     }
@@ -469,8 +469,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k2)}, match,
               false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k2);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k2);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
     }
@@ -485,7 +485,7 @@ TYPED_TEST(ARTIteratorTest, C101) {
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_EQ(match, false);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k0);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k0);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
     }
@@ -496,7 +496,7 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0xffff)},
               match, true /*fwd*/);
       UNODB_EXPECT_FALSE(it.valid());
-      UNODB_EXPECT_EQ(match, false);
+      UNODB_EXPECT_FALSE(match);
     }
     {  // reverse traversal, before the first key in the data.
       // match=false and iterator is invalidated.
@@ -505,7 +505,7 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0)}, match,
               false /*fwd*/);
       UNODB_EXPECT_FALSE(it.valid());
-      UNODB_EXPECT_EQ(match, false);
+      UNODB_EXPECT_FALSE(match);
     }
     {  // reverse traversal, after the last key in the data.  match=false
       // and iterator is positioned at the last key.
@@ -514,8 +514,8 @@ TYPED_TEST(ARTIteratorTest, C101) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(0xffff)},
               match, false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, false);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k2);
+      UNODB_EXPECT_FALSE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k2);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
       it.next();
@@ -549,8 +549,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k0)}, match,
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k0);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k0);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
     }
@@ -560,8 +560,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k1)}, match,
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k1);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k1);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     }
@@ -571,8 +571,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k2)}, match,
               true /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k2);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k2);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
     }
@@ -584,8 +584,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k0)}, match,
               false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k0);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k0);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
     }
@@ -595,8 +595,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k1)}, match,
               false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k1);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k1);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
     }
@@ -606,8 +606,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       it.seek(unodb::detail::basic_art_key<Key>{verifier.coerce_key(k2)}, match,
               false /*fwd*/);
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, true);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k2);
+      UNODB_EXPECT_TRUE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k2);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
     }
@@ -625,8 +625,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
         it.dump(std::cerr);
       }
       UNODB_EXPECT_TRUE(it.valid());
-      UNODB_EXPECT_EQ(match, false);
-      UNODB_EXPECT_TRUE(decode(it.get_key()) == k0);
+      UNODB_EXPECT_FALSE(match);
+      UNODB_EXPECT_EQ(decode(it.get_key()), k0);
       UNODB_EXPECT_TRUE(
           std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
     }
@@ -641,7 +641,7 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
         it.dump(std::cerr);
       }
       UNODB_EXPECT_FALSE(it.valid());
-      UNODB_EXPECT_EQ(match, false);
+      UNODB_EXPECT_FALSE(match);
     }
     {
       {  // reverse traversal, before the first key in the data.
@@ -655,7 +655,7 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
           it.dump(std::cerr);
         }
         UNODB_EXPECT_FALSE(it.valid());
-        UNODB_EXPECT_EQ(match, false);
+        UNODB_EXPECT_FALSE(match);
       }
       {  // reverse traversal, after the last key in the data.
          // match=false and iterator is positioned at the last key.
@@ -668,8 +668,8 @@ TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
           it.dump(std::cerr);
         }
         UNODB_EXPECT_TRUE(it.valid());
-        UNODB_EXPECT_EQ(match, false);
-        UNODB_EXPECT_TRUE(decode(it.get_key()) == k2);
+        UNODB_EXPECT_FALSE(match);
+        UNODB_EXPECT_EQ(decode(it.get_key()), k2);
         UNODB_EXPECT_TRUE(
             std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
         it.next();

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -106,7 +106,7 @@ using ARTTypes =
 
 UNODB_TYPED_TEST_SUITE(ARTOOMTest, ARTTypes)
 
-UNODB_START_TYPED_TESTS()
+UNODB_START_TESTS()
 
 TYPED_TEST(ARTOOMTest, CtorDoesNotAllocate) {
   unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -115,7 +115,7 @@ void do_scan_range_test(std::uint64_t from_key, std::uint64_t to_key,
              eit2](const unodb::visitor<typename TypeParam::iterator>& v) {
     if (eit == eit2) {
       // LCOV_EXCL_START
-      EXPECT_TRUE(false) << "ART scan should have halted.";
+      ADD_FAILURE() << "ART scan should have halted.";
       return true;  // halt early.
       // LCOV_EXCL_STOP
     }
@@ -129,22 +129,23 @@ void do_scan_range_test(std::uint64_t from_key, std::uint64_t to_key,
     }
     if (akey != ekey) {
       // LCOV_EXCL_START
-      EXPECT_EQ(akey, ekey);
+      UNODB_EXPECT_EQ(akey, ekey);
       return true;  // halt early.
       // LCOV_EXCL_STOP
     }
-    EXPECT_TRUE(std::ranges::equal(aval, eval));
+    UNODB_EXPECT_TRUE(std::ranges::equal(aval, eval));
     nactual++;     // count #of visited keys.
     eit++;         // advance iterator over the expected keys.
     return false;  // !halt (aka continue scan).
   };
   db.scan_range(from_key, to_key, fn);
   // LCOV_EXCL_START
-  EXPECT_TRUE(eit == eit2)
+  UNODB_EXPECT_EQ(eit, eit2)
       << "Expected iterator should have been fully consumed, but was not (ART "
          "scan visited too little).";
-  EXPECT_EQ(nactual, nexpected) << ", from_key=" << from_key
-                                << ", to_key=" << to_key << ", limit=" << limit;
+  UNODB_EXPECT_EQ(nactual, nexpected)
+      << ", from_key=" << from_key << ", to_key=" << to_key
+      << ", limit=" << limit;
   // LCOV_EXCL_STOP
 }
 
@@ -164,7 +165,7 @@ using ARTTypes =
 
 UNODB_TYPED_TEST_SUITE(ARTScanTest, ARTTypes)
 
-UNODB_START_TYPED_TESTS()
+UNODB_START_TESTS()
 
 //
 // forward scan

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -4,14 +4,13 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <string>
+// IWYU pragma: no_include <gtest/gtest.h>
 
 #include <algorithm>
 #include <array>
 #include <iterator>
 #include <span>
 #include <utility>
-
-#include <gtest/gtest.h>
 
 #include "gtest_utils.hpp"
 #include "qsbr_ptr.hpp"
@@ -34,17 +33,17 @@ UNODB_START_TESTS()
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
 
-TEST(QSBRPtr, DefaultCtor) {
+UNODB_TEST(QSBRPtr, DefaultCtor) {
   const unodb::qsbr_ptr<const char> ptr;
   UNODB_ASSERT_EQ(ptr.get(), nullptr);
 }
 
-TEST(QSBRPtr, Ctor) {
+UNODB_TEST(QSBRPtr, Ctor) {
   const unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   UNODB_ASSERT_EQ(*ptr, x);
 }
 
-TEST(QSBRPtr, CopyCtor) {
+UNODB_TEST(QSBRPtr, CopyCtor) {
   const unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   const unodb::qsbr_ptr<const char> ptr2{ptr};
 
@@ -52,7 +51,7 @@ TEST(QSBRPtr, CopyCtor) {
   UNODB_ASSERT_EQ(*ptr, x);
 }
 
-TEST(QSBRPtr, MoveCtor) {
+UNODB_TEST(QSBRPtr, MoveCtor) {
   unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   const unodb::qsbr_ptr<const char> ptr2{std::move(ptr)};
 
@@ -61,7 +60,7 @@ TEST(QSBRPtr, MoveCtor) {
 }
 
 UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
-TEST(QSBRPtr, CopyAssignment) {
+UNODB_TEST(QSBRPtr, CopyAssignment) {
   const unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   unodb::qsbr_ptr<const char> ptr2{raw_ptr_y};
 
@@ -76,7 +75,7 @@ TEST(QSBRPtr, CopyAssignment) {
 }
 UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
-TEST(QSBRPtr, MoveAssignment) {
+UNODB_TEST(QSBRPtr, MoveAssignment) {
   unodb::qsbr_ptr<const char> ptr{raw_ptr_x};
   unodb::qsbr_ptr<const char> ptr2{raw_ptr_y};
 
@@ -87,7 +86,7 @@ TEST(QSBRPtr, MoveAssignment) {
   UNODB_ASSERT_EQ(ptr.get(), nullptr);
 }
 
-TEST(QSBRPtr, ModifyThroughDereference) {
+UNODB_TEST(QSBRPtr, ModifyThroughDereference) {
   char obj = 'A';
   const unodb::qsbr_ptr<char> ptr{&obj};
 
@@ -96,14 +95,14 @@ TEST(QSBRPtr, ModifyThroughDereference) {
   UNODB_ASSERT_EQ(*ptr, 'B');
 }
 
-TEST(QSBRPtr, ArraySubscript) {
+UNODB_TEST(QSBRPtr, ArraySubscript) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
   UNODB_ASSERT_EQ(ptr[0], two_chars[0]);
   UNODB_ASSERT_EQ(ptr[1], two_chars[1]);
 }
 
-TEST(QSBRPtr, Preincrement) {
+UNODB_TEST(QSBRPtr, Preincrement) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
 
@@ -113,7 +112,7 @@ TEST(QSBRPtr, Preincrement) {
   UNODB_ASSERT_EQ(ptr.get(), &two_chars[1]);
 }
 
-TEST(QSBRPtr, Postincrement) {
+UNODB_TEST(QSBRPtr, Postincrement) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
   const auto old_ptr = ptr++;
@@ -123,7 +122,7 @@ TEST(QSBRPtr, Postincrement) {
   UNODB_ASSERT_EQ(ptr.get(), &two_chars[1]);
 }
 
-TEST(QSBRPtr, Predecrement) {
+UNODB_TEST(QSBRPtr, Predecrement) {
   unodb::qsbr_ptr<const char> ptr{&two_chars[1]};
   UNODB_ASSERT_EQ(*ptr, two_chars[1]);
 
@@ -133,7 +132,7 @@ TEST(QSBRPtr, Predecrement) {
   UNODB_ASSERT_EQ(ptr.get(), &two_chars[0]);
 }
 
-TEST(QSBRPtr, Postdecrement) {
+UNODB_TEST(QSBRPtr, Postdecrement) {
   unodb::qsbr_ptr<const char> ptr{&two_chars[1]};
   const auto old_ptr = ptr--;
 
@@ -143,7 +142,7 @@ TEST(QSBRPtr, Postdecrement) {
   UNODB_ASSERT_EQ(ptr.get(), &two_chars[0]);
 }
 
-TEST(QSBRPtr, AdditionAssignment) {
+UNODB_TEST(QSBRPtr, AdditionAssignment) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
   ptr += 1;
@@ -155,7 +154,7 @@ TEST(QSBRPtr, AdditionAssignment) {
   UNODB_ASSERT_EQ(ptr.get(), &two_chars[1]);
 }
 
-TEST(QSBRPtr, Addition) {
+UNODB_TEST(QSBRPtr, Addition) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
   auto result = ptr + 1;
@@ -168,7 +167,7 @@ TEST(QSBRPtr, Addition) {
   UNODB_ASSERT_EQ(result.get(), &two_chars[0]);
 }
 
-TEST(QSBRPtr, FriendAddition) {
+UNODB_TEST(QSBRPtr, FriendAddition) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
   auto result = 1 + ptr;
@@ -181,7 +180,7 @@ TEST(QSBRPtr, FriendAddition) {
   UNODB_ASSERT_EQ(result.get(), &two_chars[0]);
 }
 
-TEST(QSBRPtr, SubtractionAssignment) {
+UNODB_TEST(QSBRPtr, SubtractionAssignment) {
   unodb::qsbr_ptr<const char> ptr{&two_chars[1]};
   ptr -= 1;
   UNODB_ASSERT_EQ(*ptr, two_chars[0]);
@@ -194,7 +193,7 @@ TEST(QSBRPtr, SubtractionAssignment) {
   UNODB_ASSERT_EQ(ptr.get(), &two_chars[0]);
 }
 
-TEST(QSBRPtr, SubtractionOperator) {
+UNODB_TEST(QSBRPtr, SubtractionOperator) {
   const unodb::qsbr_ptr<const char> ptr{&two_chars[1]};
   auto result = ptr - 1;
   UNODB_ASSERT_EQ(*result, two_chars[0]);
@@ -206,7 +205,7 @@ TEST(QSBRPtr, SubtractionOperator) {
   UNODB_ASSERT_EQ(result.get(), &two_chars[1]);
 }
 
-TEST(QSBRPtr, Subtraction) {
+UNODB_TEST(QSBRPtr, Subtraction) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr{&two_chars[0]};
 
@@ -220,13 +219,13 @@ TEST(QSBRPtr, Subtraction) {
   UNODB_ASSERT_EQ(ptr2 - ptr, 2);
 }
 
-TEST(QSBRPtr, Equal) {
+UNODB_TEST(QSBRPtr, Equal) {
   const unodb::qsbr_ptr<const char> ptr{&x};
   const unodb::qsbr_ptr<const char> ptr2{&x};
   UNODB_ASSERT_TRUE(ptr == ptr2);
 }
 
-TEST(QSBRPtr, NotEqual) {
+UNODB_TEST(QSBRPtr, NotEqual) {
   const unodb::qsbr_ptr<const char> ptr{&x};
   UNODB_ASSERT_FALSE(ptr != ptr);  // -V501
 
@@ -238,7 +237,7 @@ TEST(QSBRPtr, NotEqual) {
   UNODB_ASSERT_TRUE(ptr != ptr3);
 }
 
-TEST(QSBRPtr, LessThanEqual) {
+UNODB_TEST(QSBRPtr, LessThanEqual) {
   const unodb::qsbr_ptr<const char> ptr{&x};
   const unodb::qsbr_ptr<const char> ptr2{&x};
 
@@ -253,31 +252,31 @@ TEST(QSBRPtr, LessThanEqual) {
   UNODB_ASSERT_FALSE(ptr4 <= ptr3);
 }
 
-TEST(QSBRPtr, Get) {
+UNODB_TEST(QSBRPtr, Get) {
   const unodb::qsbr_ptr<const char> ptr{&x};
   UNODB_ASSERT_EQ(ptr.get(), &x);
 }
 
-TEST(QSBRPtrSpan, DefaultCtor) {
+UNODB_TEST(QSBRPtrSpan, DefaultCtor) {
   const unodb::qsbr_ptr_span<const char> span{};
   UNODB_ASSERT_EQ(std::cbegin(span).get(), nullptr);
   UNODB_ASSERT_EQ(span.size(), 0);
 }
 
-TEST(QSBRPtrSpan, CopyStdSpanCtor) {
+UNODB_TEST(QSBRPtrSpan, CopyStdSpanCtor) {
   const unodb::qsbr_ptr_span span{std_span};
 
   UNODB_ASSERT_TRUE(std::ranges::equal(span, std_span));
 }
 
-TEST(QSBRPtrSpan, CopyCtor) {
+UNODB_TEST(QSBRPtrSpan, CopyCtor) {
   const unodb::qsbr_ptr_span span{std_span};
   const unodb::qsbr_ptr_span span2{span};
 
   UNODB_ASSERT_TRUE(std::ranges::equal(span2, std_span));
 }
 
-TEST(QSBRPtrSpan, MoveCtor) {
+UNODB_TEST(QSBRPtrSpan, MoveCtor) {
   unodb::qsbr_ptr_span span{std_span};
   const unodb::qsbr_ptr_span span2{std::move(span)};
 
@@ -285,7 +284,7 @@ TEST(QSBRPtrSpan, MoveCtor) {
 }
 
 UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wself-assign-overloaded")
-TEST(QSBRPtrSpan, CopyAssignment) {
+UNODB_TEST(QSBRPtrSpan, CopyAssignment) {
   const unodb::qsbr_ptr_span span{std_span};
   unodb::qsbr_ptr_span span2{std_span2};
 
@@ -298,7 +297,7 @@ TEST(QSBRPtrSpan, CopyAssignment) {
 }
 UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
-TEST(QSBRPtrSpan, MoveAssignment) {
+UNODB_TEST(QSBRPtrSpan, MoveAssignment) {
   unodb::qsbr_ptr_span span{std_span};
   unodb::qsbr_ptr_span span2{std_span2};
 
@@ -307,13 +306,13 @@ TEST(QSBRPtrSpan, MoveAssignment) {
   UNODB_ASSERT_TRUE(std::ranges::equal(span2, std_span));
 }
 
-TEST(QSBRPtrSpan, Cbegin) {
+UNODB_TEST(QSBRPtrSpan, Cbegin) {
   const unodb::qsbr_ptr_span span{std_span};
   // NOLINTNEXTLINE(readability-container-data-pointer)
   UNODB_ASSERT_EQ(std::cbegin(span).get(), &two_chars[0]);
 }
 
-TEST(QSBRPtrSpan, Cend) {
+UNODB_TEST(QSBRPtrSpan, Cend) {
   const unodb::qsbr_ptr_span span{std_span};
   // Do not write &two_chars[2] directly or the libstdc++ debug assertions fire
   UNODB_ASSERT_EQ(std::cend(span).get(), &two_chars[1] + 1);
@@ -321,14 +320,14 @@ TEST(QSBRPtrSpan, Cend) {
 
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-TEST(QSBRPtrSpan, Size) {
+UNODB_TEST(QSBRPtrSpan, Size) {
   const unodb::qsbr_ptr_span span{std_span};
   UNODB_ASSERT_EQ(span.size(), std_span.size());
   const unodb::qsbr_ptr_span span2{std_span2};
   UNODB_ASSERT_EQ(span2.size(), std_span2.size());
 }
 
-TEST(QSBRPtr, GreaterThan) {
+UNODB_TEST(QSBRPtr, GreaterThan) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr1{&two_chars[0]};
   const unodb::qsbr_ptr<const char> ptr2{&two_chars[1]};
@@ -338,7 +337,7 @@ TEST(QSBRPtr, GreaterThan) {
   UNODB_ASSERT_FALSE(ptr1 > ptr2);
 }
 
-TEST(QSBRPtr, GreaterThanEqual) {
+UNODB_TEST(QSBRPtr, GreaterThanEqual) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr1{&two_chars[0]};
   const unodb::qsbr_ptr<const char> ptr2{&two_chars[1]};
@@ -348,7 +347,7 @@ TEST(QSBRPtr, GreaterThanEqual) {
   UNODB_ASSERT_FALSE(ptr1 >= ptr2);
 }
 
-TEST(QSBRPtr, LessThan) {
+UNODB_TEST(QSBRPtr, LessThan) {
   // NOLINTNEXTLINE(readability-container-data-pointer)
   const unodb::qsbr_ptr<const char> ptr1{&two_chars[0]};
   const unodb::qsbr_ptr<const char> ptr2{&two_chars[1]};


### PR DESCRIPTION
- Introduce UNODB_EXPECT_LT, use it instead of EXPECT_TRUE(a < b)
- Remove UNODB_TYPED_TEST_SUITE because compilation warnings have been fixed
  with regular TYPED_TEST_SUITE.
- Remove UNODB_START_TYPED_TESTS because compilation warnings have been fixed
  with regular START_TESTS.
- Remove extra parentheses from UNODB_TEST macro definition
- Adjust UNODB_EXPECT_EQ and UNODB_EXPECT_TRUE definitions to be able to take
  the stream output operator
- Make sure to always use wrapped macros when they're defined instead of plain
  Google Test macros
- Replace UNODB_EXPECT_TRUE(a == b) with UNODB_EXPECT_EQ(a, b),
  UNODB_EXPECT_EQ(a, false) with UNODB_EXPECT_FALSE(a), UNODB_EXPECT_EQ(a, true)
  with UNODB_EXPECT_TRUE(a), EXPECT_TRUE(false) with ADD_FAILURE()


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Streamlined and standardized test assertions and suite initialization.
	- Updated test cases to improve consistency, diagnostic clarity, and overall reliability.
	- Enhanced error reporting in test scenarios, aiding in smoother validation without affecting core functionality.
	- Transitioned to a custom testing framework for assertions, improving clarity and consistency across various test cases.
	- Replaced standard assertion macros with custom macros for better integration and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->