### PR TITLE
Introduce UNODB_EXPECT_NE macro

### DIFF
--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -143,6 +143,15 @@
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
+#define UNODB_EXPECT_NE(x, y)                \
+  do {                                       \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)  \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
+    EXPECT_NE((x), (y));                     \
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+  } while (0)
+
 #define UNODB_EXPECT_GT(x, y)                \
   do {                                       \
     UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)  \

--- a/test/test_key_encode_decode.cpp
+++ b/test/test_key_encode_decode.cpp
@@ -57,10 +57,10 @@ void do_encode_decode_lt_test(const T ekey1, const T ekey2) {
     // Note: floating point +0 and -0 compare as equal, so we do not
     // compare the keys for non-quality if one of the keys is zero.
     if (std::fpclassify(ekey1) != FP_ZERO) {
-      EXPECT_NE(ekey1, ekey2);  // not the same ekey.
+      UNODB_EXPECT_NE(ekey1, ekey2);  // not the same ekey.
     }
   } else {
-    EXPECT_NE(ekey1, ekey2);  // not the same ekey.
+    UNODB_EXPECT_NE(ekey1, ekey2);  // not the same ekey.
   }
   unodb::key_encoder enc1{};
   unodb::key_encoder enc2{};  // separate decoder (backed by different span).
@@ -68,7 +68,7 @@ void do_encode_decode_lt_test(const T ekey1, const T ekey2) {
   const auto ikey2 = enc2.encode(ekey2).get_key_view();  // into encoder buf!
   UNODB_EXPECT_EQ(compare(ikey1, ikey1), 0);             // compare w/ self
   UNODB_EXPECT_EQ(compare(ikey2, ikey2), 0);             // compare w/ self
-  EXPECT_NE(compare(ikey1, ikey2), 0);                   // not the same ikey.
+  UNODB_EXPECT_NE(compare(ikey1, ikey2), 0);             // not the same ikey.
   // Check the core assertion for this test helper. The internal keys
   // (after encoding) obey the asserted ordering over the external
   // keys (before encoding).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced a new assertion macro, `UNODB_EXPECT_NE`, to enhance testing capabilities and manage compiler warnings effectively.
  - Updated test assertions to utilize the new macro, improving consistency and reliability in error detection during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->