### PR TITLE
Pass -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to DeepState CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,8 @@ if(TESTS)
       ExternalProject_Add(3rd_party_deepstate
         SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rd_party/deepstate"
         BINARY_DIR "${CMAKE_BINARY_DIR}/3rd_party/deepstate"
-        CMAKE_ARGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+        CMAKE_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
         "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
         "-DCMAKE_C_FLAGS=-w -Wno-implicit-function-declaration"
         "-DCMAKE_CXX_FLAGS=-w" "${BUILD_DEEPSTATE_LIBFUZZER}"


### PR DESCRIPTION
This should fix a build error that CMake compatibility with versions lower than
3.5 has been removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the build configuration to enhance compatibility with updated development policies and ensure a smoother setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->