### PR TITLE
Add Doxygen comments for bit_cast

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1096,7 +1096,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which Doxygen is
 # run.
 
-EXCLUDE                = 3rd_party/ docs/ build/
+EXCLUDE                = 3rd_party/ docs/ build/ examples/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -2495,6 +2495,7 @@ PREDEFINED            += UNODB_DETAIL_CONSTEXPR_NOT_MSVC
 PREDEFINED            += UNODB_DETAIL_NOINLINE=
 PREDEFINED            += UNODB_DETAIL_FORCE_INLINE=
 PREDEFINED            += UNODB_DETAIL_RELEASE_CONSTEXPR=
+PREDEFINED            += UNODB_DETAIL_LIFETIMEBOUND=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -106,15 +106,22 @@ template <typename T>
 #endif
 }
 
-// Performs a "bit_cast".
-//
+/// Reinterpret object representation as a different type.
+///
+/// A replacement for `std::bit_cast` until it is provided by all supported
+/// compilers.
+///
+/// \tparam To Destination type for the conversion
+/// \tparam From Source type of the input value
+/// \param input Object to convert
+/// \return Object of type \a To with the same bit pattern as \a input.
+///
+/// \pre `sizeof(To) == sizeof(From)`
 // TODO(laurynas) We can use std::bit_cast at GCC 11 clang 14 minimums.
-//
-// See https://github.com/jfbastien/bit_cast for an implementation
-// using memcpy (MIT license).
 template <typename To, typename From>
 [[nodiscard, gnu::const]] constexpr To bit_cast(From input) noexcept {
-  // must be the same stride
+  // See https://github.com/jfbastien/bit_cast for an implementation using
+  // memcpy (MIT license).
   static_assert(sizeof(To) == sizeof(From));
   typename std::aligned_storage<sizeof(To), alignof(To)>::type tmp;
   std::memcpy(&tmp, &input, sizeof(To));


### PR DESCRIPTION
At the same time:
- exclude examples/ dir from Doxygen processing
- define UNODB_DETAIL_LIFETIMEBOUND as empty macro for Doxygen processing
