### PR TITLE
Add -Wno-dev to DeepState CMake invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ if(TESTS)
       ExternalProject_Add(3rd_party_deepstate
         SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rd_party/deepstate"
         BINARY_DIR "${CMAKE_BINARY_DIR}/3rd_party/deepstate"
-        CMAKE_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+        CMAKE_ARGS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" "-Wno-dev"
         "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
         "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
         "-DCMAKE_C_FLAGS=-w -Wno-implicit-function-declaration"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Suppressed developer warnings during the build process for external dependencies, resulting in cleaner build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->