### PR TITLE
Disable Python warnings for DeepState build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,7 +413,7 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make -j3 -k
+        run: PYTHONWARNINGS=ignore make -j3 -k
         if: env.STATIC_ANALYSIS != 'ON' || env.COMPILER != 'clang'
 
       - name: clang static analysis


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Suppressed Python warnings during the build process in the automated workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->