### PR TITLE
Suppress new cppcheck 2.18 diagnostics as the fix performance impact is unknown

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -2363,6 +2363,7 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   [[nodiscard, gnu::pure]] constexpr typename basic_inode_48::iter_result
   begin() noexcept {
     for (std::uint64_t i = 0; i < 256; i++) {
+      // cppcheck-suppress useStlAlgorithm
       if (child_indexes[i] != empty_child) {
         const auto key = static_cast<std::byte>(i);
         const auto child_index = static_cast<std::uint8_t>(i);
@@ -2398,6 +2399,7 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   next(std::uint8_t child_index) noexcept {
     // loop over the remaining byte values in lexical order.
     for (auto i = static_cast<std::uint64_t>(child_index) + 1; i < 256; i++) {
+      // cppcheck-suppress useStlAlgorithm
       if (child_indexes[i] != empty_child) {
         const auto key = static_cast<std::byte>(i);
         const auto next_index = static_cast<std::uint8_t>(i);
@@ -2717,6 +2719,7 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
   [[nodiscard, gnu::pure]] constexpr typename basic_inode_256::iter_result
   begin() noexcept {
     for (std::uint64_t i = 0; i < basic_inode_256::capacity; i++) {
+      // cppcheck-suppress useStlAlgorithm
       if (children[i] != nullptr) {
         const auto key = static_cast<std::byte>(i);  // child_index is key byte
         const auto child_index = static_cast<std::uint8_t>(i);
@@ -2749,6 +2752,7 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
     // loop over the remaining byte values in lexical order.
     for (auto i = static_cast<std::uint64_t>(child_index) + 1;
          i < basic_inode_256::capacity; i++) {
+      // cppcheck-suppress useStlAlgorithm
       if (children[i] != nullptr) {
         const auto key = static_cast<std::byte>(i);
         const auto next_index = static_cast<std::uint8_t>(i);


### PR DESCRIPTION
cppcheck 2.18 suggests to use std::find_if, which is a reasonable suggestion,
but I have not verified the compiled code yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and quality improvements with no impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->