### PR TITLE
Fully update cppcheck support for 2.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,17 +621,8 @@ set(CPPCHECK_ARGS
   # False positive on Google Test TEST macro and compilers are much better
   # for syntax checking anyway
   "--suppress=syntaxError"
-  # Likewise
-  "--suppress=internalAstError"
-  # False positives with conditional noexcept
-  "--suppress=throwInNoexceptFunction"
-  # Leave it for the compilers to diagnose
-  "--suppress=unreadVariable"
-  # False positives on structured bindings with 2.5
-  "--suppress=unassignedVariable"
-  "--suppress=unusedVariable"
-  # Informational message that fails the build. Remove once cppcheck 2.11 is the
-  # minimum
+  # Non-actionable informational message that even fails the build before
+  # cppcheck 2.11.
   "--suppress=normalCheckLevelMaxBranches")
 
 option(CPPCHECK_AGGRESSIVE "Enable inconclusive cppcheck checks")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -75,6 +75,13 @@
             }
         },
         {
+            "name": "cppcheck-aggressive",
+            "hidden": true,
+            "cacheVariables": {
+                "CPPCHECK_AGGRESSIVE": "ON"
+            }
+        },
+        {
             "name": "gcc",
             "hidden": true,
             "cacheVariables": {
@@ -131,6 +138,13 @@
             ]
         },
         {
+            "name": "release-cppcheck-aggressive",
+            "inherits": [
+                "release",
+                "cppcheck-aggressive"
+            ]
+        },
+        {
             "name": "debug",
             "inherits": "base-unix",
             "cacheVariables": {
@@ -156,6 +170,13 @@
             "inherits": [
                 "debug",
                 "ubsan"
+            ]
+        },
+        {
+            "name": "debug-cppcheck-aggressive",
+            "inherits": [
+                "debug",
+                "cppcheck-aggressive"
             ]
         },
         {
@@ -408,6 +429,11 @@
             "inherits": "base"
         },
         {
+            "name": "release-cppcheck-aggressive",
+            "configurePreset": "release-cppcheck-aggressive",
+            "inherits": "base"
+        },
+        {
             "name": "debug",
             "configurePreset": "debug",
             "inherits": "base"
@@ -425,6 +451,11 @@
         {
             "name": "debug-ubsan",
             "configurePreset": "debug-ubsan",
+            "inherits": "base"
+        },
+        {
+            "name": "debug-cppcheck-aggressive",
+            "configurePreset": "debug-cppcheck-aggressive",
             "inherits": "base"
         },
         {
@@ -603,6 +634,11 @@
             "inherits": "base"
         },
         {
+            "name": "release-cppcheck-aggressive",
+            "configurePreset": "release-cppcheck-aggressive",
+            "inherits": "base"
+        },
+        {
             "name": "debug",
             "configurePreset": "debug",
             "inherits": "base"
@@ -620,6 +656,11 @@
         {
             "name": "debug-ubsan",
             "configurePreset": "debug-ubsan",
+            "inherits": "base"
+        },
+        {
+            "name": "debug-cppcheck-aggressive",
+            "configurePreset": "debug-cppcheck-aggressive",
             "inherits": "base"
         },
         {

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -249,6 +249,7 @@ class [[nodiscard]] tree_depth final {
  public:
   using value_type = std::uint32_t;  // explicitly since also used in leaf.
 
+  // cppcheck-suppress passedByValue
   explicit constexpr tree_depth(value_type value_ = 0) noexcept
       : value{value_} {}
 
@@ -262,6 +263,7 @@ class [[nodiscard]] tree_depth final {
     return *this;
   }
 
+  // cppcheck-suppress passedByValue
   constexpr void operator+=(value_type delta) noexcept { value += delta; }
 
  private:

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -155,6 +155,7 @@ class [[nodiscard]] basic_leaf final : public Header {
   //
   // TODO(thompsonbry) : Partial or no key in leaf?
   [[nodiscard, gnu::pure]] constexpr auto matches(
+      // cppcheck-suppress passedByValue
       art_key_type k) const noexcept {
     return cmp(k) == 0;
   }
@@ -205,6 +206,7 @@ class [[nodiscard]] basic_leaf final : public Header {
   ///
   /// \param val_size The size in bytes of the the value stored in the leaf.
   [[nodiscard, gnu::const]] static constexpr auto compute_size(
+      // cppcheck-suppress passedByValue
       key_size_type key_size, value_size_type val_size) noexcept {
     return sizeof(basic_leaf<Key, Header>) + key_size + val_size -
            1  // because of the [1] byte on the end of the struct.
@@ -433,6 +435,7 @@ struct basic_art_policy final {
           return;
         }
         case node_type::I4: {
+          // cppcheck-suppress throwInNoexceptFunction
           const auto r{make_db_inode_unique_ptr(
               node_ptr.template ptr<inode4_type *>(), db)};
           return;
@@ -1280,26 +1283,28 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   using typename parent_class::node_ptr;
   using tree_depth_type = tree_depth<art_key_type>;
 
-  constexpr basic_inode_4(db_type &, unodb::key_view k1,
-                          art_key_type shifted_k2,
+  constexpr basic_inode_4(db_type&, unodb::key_view k1, art_key_type shifted_k2,
+                          // cppcheck-suppress passedByValue
                           tree_depth_type depth) noexcept
       : parent_class{k1, shifted_k2, depth} {}
 
-  constexpr basic_inode_4(db_type &, key_view k1, art_key_type shifted_k2,
-                          tree_depth_type depth, leaf_type *child1,
-                          db_leaf_unique_ptr &&child2) noexcept
+  constexpr basic_inode_4(db_type&, key_view k1, art_key_type shifted_k2,
+                          // cppcheck-suppress passedByValue
+                          tree_depth_type depth, leaf_type* child1,
+                          db_leaf_unique_ptr&& child2) noexcept
       : parent_class{k1, shifted_k2, depth} {
     init(k1, shifted_k2, depth, child1, std::move(child2));
   }
 
-  constexpr basic_inode_4(db_type &, node_ptr source_node,
-                          unsigned len) noexcept
-      : parent_class{len, *source_node.template ptr<inode_type *>()} {}
+  // cppcheck-suppress passedByValue
+  constexpr basic_inode_4(db_type&, node_ptr source_node, unsigned len) noexcept
+      : parent_class{len, *source_node.template ptr<inode_type*>()} {}
 
-  constexpr basic_inode_4(db_type &, node_ptr source_node, unsigned len,
+  constexpr basic_inode_4(db_type&, node_ptr source_node, unsigned len,
+                          // cppcheck-suppress passedByValue
                           tree_depth_type depth,
-                          db_leaf_unique_ptr &&child1) noexcept
-      : parent_class{len, *source_node.template ptr<inode_type *>()} {
+                          db_leaf_unique_ptr&& child1) noexcept
+      : parent_class{len, *source_node.template ptr<inode_type*>()} {
     init(source_node, len, depth, std::move(child1));
   }
 
@@ -1361,15 +1366,17 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   }
 
   constexpr void init(key_view k1, art_key_type shifted_k2,
-                      tree_depth_type depth, const leaf_type *child1,
-                      db_leaf_unique_ptr &&child2) noexcept {
+                      // cppcheck-suppress passedByValue
+                      tree_depth_type depth, const leaf_type* child1,
+                      db_leaf_unique_ptr&& child2) noexcept {
     const auto k2_next_byte_depth = this->get_key_prefix().length();
     const auto k1_next_byte_depth = k2_next_byte_depth + depth;
     add_two_to_empty(k1[k1_next_byte_depth], node_ptr{child1, node_type::LEAF},
                      shifted_k2[k2_next_byte_depth], std::move(child2));
   }
 
-  constexpr void add_to_nonfull(db_leaf_unique_ptr &&child,
+  constexpr void add_to_nonfull(db_leaf_unique_ptr&& child,
+                                // cppcheck-suppress passedByValue
                                 tree_depth_type depth,
                                 std::uint8_t children_count_) noexcept {
     UNODB_DETAIL_ASSERT(children_count_ == this->children_count);

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -40,11 +40,13 @@ class [[nodiscard]] fake_read_critical_section final {
 
   /// Check whether this fake read critical section is invalid after
   /// construction, always succeeds.
+  // cppcheck-suppress functionStatic
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   [[nodiscard]] bool must_restart() const noexcept { return false; }
 
   /// Check whether this fake read critical section is still valid, always
   /// succeeds.
+  // cppcheck-suppress functionStatic
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   [[nodiscard]] bool check() UNODB_DETAIL_RELEASE_CONST noexcept {
     return true;
@@ -58,6 +60,7 @@ class [[nodiscard]] fake_read_critical_section final {
   }
 
   /// Try to read unlock this read fake critical section, always succeeds.
+  // cppcheck-suppress functionStatic
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   [[nodiscard]] bool try_read_unlock() const noexcept { return true; }
 
@@ -72,6 +75,7 @@ class [[nodiscard]] fake_read_critical_section final {
 class [[nodiscard]] fake_lock final {
  public:
   /// Acquire and return an always-valid fake critical section for a fake lock.
+  // cppcheck-suppress functionStatic
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   [[nodiscard]] fake_read_critical_section try_read_lock() noexcept {
     return fake_read_critical_section{};

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -897,7 +897,6 @@ class db_inode_qsbr_deleter
   using db_inode_qsbr_deleter_parent<Key, Value,
                                      INode>::db_inode_qsbr_deleter_parent;
 
-  // cppcheck-suppress duplInheritedMember
   void operator()(INode* inode_ptr) {
     static_assert(std::is_trivially_destructible_v<INode>);
 
@@ -1119,7 +1118,6 @@ class [[nodiscard]] olc_inode_4 final : public olc_inode_4_parent<Key, Value> {
     return parent_class::leave_last_child(child_to_delete, db_instance);
   }
 
-  // cppcheck-suppress duplInheritedMember
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
                                                 bool recursive) const {
     os << ", ";
@@ -1196,7 +1194,6 @@ class [[nodiscard]] olc_inode_16 final
     parent_class::remove(child_index, db_instance);
   }
 
-  // cppcheck-suppress duplInheritedMember
   [[nodiscard]] find_result find_child(std::byte key_byte) noexcept {
 #ifdef UNODB_DETAIL_THREAD_SANITIZER
     const auto children_count_ = this->get_children_count();
@@ -1209,7 +1206,6 @@ class [[nodiscard]] olc_inode_16 final
 #endif
   }
 
-  // cppcheck-suppress duplInheritedMember
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
                                                 bool recursive) const {
     os << ", ";
@@ -1293,7 +1289,6 @@ class [[nodiscard]] olc_inode_48 final
     parent_class::remove(child_index, db_instance);
   }
 
-  // cppcheck-suppress duplInheritedMember
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
                                                 bool recursive) const {
     os << ", ";
@@ -1376,7 +1371,6 @@ class [[nodiscard]] olc_inode_256 final
     parent_class::remove(child_index, db_instance);
   }
 
-  // cppcheck-suppress duplInheritedMember
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
                                                 bool recursive) const {
     os << ", ";
@@ -1767,13 +1761,14 @@ typename olc_db<Key, Value>::try_get_result_type olc_db<Key, Value>::try_get(
 }
 
 template <typename Key, typename Value>
-bool olc_db<Key, Value>::insert_internal(art_key_type k, value_type v) {
+bool olc_db<Key, Value>::insert_internal(art_key_type insert_key,
+                                         value_type v) {
   try_update_result_type result;
   olc_db_leaf_unique_ptr_type cached_leaf{
       nullptr, detail::basic_db_leaf_deleter<olc_db<Key, Value>>{*this}};
 
   while (true) {
-    result = try_insert(k, v, cached_leaf);
+    result = try_insert(insert_key, v, cached_leaf);
     if (result) break;
   }
 
@@ -1929,10 +1924,10 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
 }
 
 template <typename Key, typename Value>
-bool olc_db<Key, Value>::remove_internal(art_key_type k) {
+bool olc_db<Key, Value>::remove_internal(art_key_type remove_key) {
   try_update_result_type result;
   while (true) {
-    result = try_remove(k);
+    result = try_remove(remove_key);
     if (result) break;
   }
 

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -50,7 +50,7 @@ template <typename T>
   }
   if constexpr (std::is_same_v<std::uint64_t, T>) {
     return __builtin_bswap64(x);
-  }  // cppcheck-suppress missingReturn
+  }
 #endif  // UNODB_DETAIL_MSVC
 }
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1527,7 +1527,6 @@ struct quiescent_state_on_scope_exit final {
     }
     // LCOV_EXCL_START
     catch (const std::system_error &e) {
-      // cppcheck-suppress exceptThrowInDestructor
       if (exceptions_at_ctor == std::uncaught_exceptions()) throw;
       std::cerr << "QSBR quiescent state failed to register QSBR stats: "
                 << e.what() << '\n';

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -362,6 +362,7 @@ class [[nodiscard]] tree_verifier final {
   // NOLINTEND(modernize-use-constraints)
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
+  // cppcheck-suppress passedByValue
   void insert_internal(key_type k, unodb::value_view v,
                        bool bypass_verifier = false) {
     const auto empty_before = test_db.empty();
@@ -423,6 +424,7 @@ class [[nodiscard]] tree_verifier final {
     }
   }
 
+  // cppcheck-suppress passedByValue
   void insert_key_range_internal(key_type start_key, std::size_t count,
                                  bool bypass_verifier = false) {
     if constexpr (std::is_same_v<key_type, key_view>) {

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -155,8 +155,9 @@ class QSBRTestBase : public ::testing::Test {
 #ifndef NDEBUG
   static void check_ptr_on_qsbr_dealloc(const void *ptr) noexcept {
     // The pointer must be readable
+    // cppcheck-suppress unreadVariable
     static const volatile char sink UNODB_DETAIL_UNUSED =
-        *static_cast<const char *>(ptr);
+        *static_cast<const char*>(ptr);
   }
 #endif
 


### PR DESCRIPTION
- Fix method definitions parameter names mismatches with method declarations
- Remove obsolete suppressions, both inline and command line
- Add new suppressions, especially for aggressive check false positives

At the same time add new CMake presets for building with aggressive cppcheck
checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced new aggressive code-checking build presets for enhanced static analysis.
  * Refined internal parameter naming for improved code clarity and consistency.
  * Streamlined build configuration suppressions to focus on essential warnings.
  * Added targeted static analysis annotations throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->