### PR TITLE
Bump GCC version in build.yml to 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,66 +36,66 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: GCC 13 Release
+          - name: GCC 14 Release
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
 
-          - name: GCC 13 Release with ASan
+          - name: GCC 14 Release with ASan
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 13 Release with TSan
+          - name: GCC 14 Release with TSan
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_THREAD: ON
 
-          - name: GCC 13 Release with UBSan
+          - name: GCC 14 Release with UBSan
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_UB: ON
 
-          - name: GCC 13 Debug
+          - name: GCC 14 Debug
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
 
-          - name: GCC 13 Debug with ASan
+          - name: GCC 14 Debug with ASan
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 13 Debug with TSan
+          - name: GCC 14 Debug with TSan
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_THREAD: ON
 
-          - name: GCC 13 Debug with UBSan
+          - name: GCC 14 Debug with UBSan
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_UB: ON
 
-          - name: GCC 13 Debug without AVX2
+          - name: GCC 14 Debug without AVX2
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             AVX2: OFF
 
-          - name: GCC 13 Release static analysis & cpplint
+          - name: GCC 14 Release static analysis & cpplint
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             STATIC_ANALYSIS: ON
             CPPLINT: ON
 
-          - name: GCC 13 default CMake configuration
+          - name: GCC 14 default CMake configuration
             os: ubuntu-latest
             COMPILER: gcc
 
@@ -285,7 +285,7 @@ jobs:
 
       - name: Setup dependencies for GCC
         run: |
-          sudo apt-get install -y g++-13 g++-13-multilib
+          sudo apt-get install -y g++-14 g++-14-multilib
         if: runner.os == 'Linux' && env.COMPILER == 'gcc'
 
       - name: Setup dependencies for Linux LLVM (common)
@@ -343,7 +343,7 @@ jobs:
             CBT=""
           fi
           if [[ $COMPILER == "gcc" ]]; then
-            V=13
+            V=14
             EXTRA_CMAKE_ARGS=()
             export CC=gcc-$V
             export CXX=g++-$V

--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -627,6 +627,64 @@ jobs:
             VERSION: 12
             STATS: OFF
 
+          - name: GCC 13 Release
+            BUILD_TYPE: Release
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+            BOOST: OFF
+
+          - name: GCC 13 Release with ASan
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+
+          - name: GCC 13 Release with TSan
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+            BOOST: OFF
+
+          - name: GCC 13 Release with UBSan
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+
+          - name: GCC 13 Debug
+            BUILD_TYPE: Debug
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+            BOOST: OFF
+
+          - name: GCC 13 Debug with ASan
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+
+          - name: GCC 13 Debug with TSan
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+            BOOST: OFF
+
+          - name: GCC 13 Debug with UBSan
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            COMPILER: gcc
+            VERSION: 13
+            STATS: OFF
+
     steps:
       - uses: actions/checkout@v5
         with:
@@ -668,6 +726,13 @@ jobs:
         run: |
           sudo apt-get install -y gcc
         if: env.COMPILER == 'gcc' && env.VERSION == '11'
+
+      - name: Setup dependencies for GCC 13 (PPA)
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y g++-13
+        if: env.COMPILER == 'gcc' && env.VERSION == '13'
 
       - name: Configure CMake
         # Use a bash shell so we can use the same syntax for environment


### PR DESCRIPTION
Enabled by build.yml now running on Ubuntu 24.04.

Add GCC 13 to old-compilers.yml.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline now uses GCC 14 as the primary compiler for build and sanitizer jobs and defaults toolchain/configuration to GCC 14.
  * Added a separate workflow preserving GCC 13 compatibility with a comprehensive job matrix and installation steps for the older compiler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->