### PR TITLE
Add GCC 15 support, excluding CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,8 +84,8 @@
       "name": "gcc",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "gcc-14",
-        "CMAKE_CXX_COMPILER": "g++-14"
+        "CMAKE_C_COMPILER": "gcc-15",
+        "CMAKE_CXX_COMPILER": "g++-15"
       }
     },
     {

--- a/test/test_key_encode_decode.cpp
+++ b/test/test_key_encode_decode.cpp
@@ -348,7 +348,7 @@ UNODB_TEST(ARTKeyEncodeDecodeTest, UInt64C00010) {
   do_encode_decode_lt_test<T>(0x0102030405060708ULL, 0x090A0B0C0D0F1011ULL);
   do_encode_decode_lt_test(static_cast<T>(0), static_cast<T>(1));
   do_encode_decode_lt_test<T>(0x7FFFFFFFFFFFFFFFULL, 0x8000000000000000ULL);
-  do_encode_decode_lt_test<T>(0xFFFFFFFFFFFFFFFEULL, static_cast<T>(~0ULL));
+  do_encode_decode_lt_test<T>(0xFFFFFFFFFFFFFFFEULL, ~0ULL);
 }
 
 UNODB_TEST(ARTKeyEncodeDecodeTest, Int64C00010) {


### PR DESCRIPTION
- Fix a build warning
- Bump GCC version in CMakePresets.json

CI is excluded because of no simple way to get GCC 15 on Ubuntu 24.04 (or 22.04)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to target newer compiler versions.

* **Tests**
  * Refined test code for encoding and decoding verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->