### PR TITLE
Add -Wunsafe-buffer-usage to clang 16+ builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(CLANG_CXX_WARNING_FLAGS
   "-Wweak-template-vtables" "-Wweak-vtables" "-Wzero-as-null-pointer-constant")
 set(CLANG_LT_13_CXX_WARNING_FLAGS "-Wreserved-id-macro")
 set(CLANG_GE_13_CXX_WARNING_FLAGS "-Wreserved-identifier")
+set(CLANG_GE_16_CXX_WARNING_FLAGS "-Wunsafe-buffer-usage")
 
 set(GCC_CXX_WARNING_FLAGS
   # Warning groups
@@ -400,9 +401,11 @@ set(cxx_ge_12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12.0>")
 set(cxx_lt_13 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,13.0>")
 set(cxx_ge_13 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,13.0>")
 set(cxx_ge_14 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0>")
+set(cxx_ge_16 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,16.0>")
 set(is_clang_lt_13_not_windows "$<AND:${is_clang_not_windows},${cxx_lt_13}>")
 set(is_clang_ge_13_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_13}>")
 set(is_clang_ge_14_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_14}>")
+set(is_clang_ge_16_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_16}>")
 set(is_gxx_ge_11 "$<AND:${is_gxx_genex},${cxx_ge_11}>")
 set(is_gxx_ge_12 "$<AND:${is_gxx_genex},${cxx_ge_12}>")
 set(is_gxx_ge_14 "$<AND:${is_gxx_genex},${cxx_ge_14}>")
@@ -707,6 +710,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     "$<$<AND:${is_standalone},${is_any_clang_genex},${is_not_windows}>:${CLANG_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_clang_lt_13_not_windows}>:${CLANG_LT_13_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_clang_ge_13_not_windows}>:${CLANG_GE_13_CXX_WARNING_FLAGS}>"
+    "$<$<AND:${is_standalone},${is_clang_ge_16_not_windows}>:${CLANG_GE_16_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_gxx_genex}>:${GCC_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_gxx_ge_11}>:${GCC_GE_11_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_gxx_ge_12}>:${GCC_GE_12_CXX_WARNING_FLAGS}>"

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -333,12 +333,14 @@ class qsbr_ptr_span : public std::ranges::view_base {
     return start;
   }
 
+  UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wunsafe-buffer-usage")
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
   /// Get the past-the-end iterator.
   [[nodiscard, gnu::pure]] constexpr qsbr_ptr<T> end() const noexcept {
     return qsbr_ptr<T>{start.get() + length};
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+  UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
   /// Get the number of elements.
   [[nodiscard, gnu::pure]] constexpr std::size_t size() const noexcept {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for Clang 16+ compiler warnings with a new compiler-version gate and build logic to apply these warnings on non-Windows standalone builds.
  * Suppressed a specific Clang diagnostic around an object-span end() method to reduce noisy compiler warnings during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->