### PR TITLE
Fix noexcept specification in qsbr_thread::make_qsbr_thread

### DIFF
--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1591,9 +1591,13 @@ class [[nodiscard]] qsbr_thread : public std::thread {
     auto new_qsbr_per_thread = std::make_unique<qsbr_per_thread>();
     return std::thread{
         [inner_new_qsbr_per_thread = std::move(new_qsbr_per_thread)](
-            auto &&f2, auto &&...args2) mutable noexcept(noexcept(f2)) {
+            auto &&f2,
+            auto
+                &&...a2) mutable noexcept(noexcept(f2(std::
+                                                          forward<decltype(a2)>(
+                                                              a2)...))) {
           qsbr_per_thread::set_instance(std::move(inner_new_qsbr_per_thread));
-          f2(std::forward<Args>(args2)...);
+          f2(std::forward<decltype(a2)>(a2)...);
         },
         std::forward<Function>(f), std::forward<Args>(args)...};
   }

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -56,7 +56,11 @@ class QSBRTestBase : public ::testing::Test {
         []() noexcept { return unodb::this_thread().is_qsbr_paused(); });
   }
 
-  static void qsbr_pause() {
+  static void qsbr_pause()
+#ifndef UNODB_DETAIL_WITH_STATS
+      noexcept
+#endif
+  {
     unodb::test::must_not_allocate([]()
 #ifndef UNODB_DETAIL_WITH_STATS
                                        noexcept

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -58,7 +58,11 @@ UNODB_TEST_F(QSBR, TwoThreads) {
 }
 
 UNODB_TEST_F(QSBR, TwoThreadsSecondQuitPaused) {
-  unodb::qsbr_thread second_thread([] { qsbr_pause(); });
+  unodb::qsbr_thread second_thread([]()
+#ifndef UNODB_DETAIL_WITH_STATS
+                                       noexcept
+#endif
+                                   { qsbr_pause(); });
   join(second_thread);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened exception specifications and strengthened argument forwarding for thread startup, preserving runtime behavior while improving compile-time checks.
  * Made test utilities and a thread test's exception specifications conditional on build configuration, aligning test behavior with build-time settings without changing control flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->