### PR TITLE
Replace std::enable_if with C++20 requires clauses

### DIFF
--- a/art_common.hpp
+++ b/art_common.hpp
@@ -136,8 +136,8 @@ template <typename T>
 /// 32bit int shift-or utility function that is used by
 /// unodb::detail::next_power_of_two.
 template <typename T>
-constexpr typename std::enable_if<std::is_integral<T>::value, T>::type
-shift_or_32bit_int(T i) {
+  requires std::is_integral_v<T>
+constexpr T shift_or_32bit_int(T i) {
   i |= (i >> 1);
   i |= (i >> 2);
   i |= (i >> 4);
@@ -151,18 +151,14 @@ shift_or_32bit_int(T i) {
 /// \note it will overflow if the there is no higher power of \c 2 for a given
 /// type \c T.
 template <typename T>
-[[nodiscard, gnu::pure]] constexpr
-    typename std::enable_if<std::is_integral<T>::value && sizeof(T) == 4,
-                            T>::type
-    next_power_of_two(T i) noexcept {
+  requires(std::is_integral_v<T> && sizeof(T) == 4)
+[[nodiscard, gnu::pure]] constexpr T next_power_of_two(T i) noexcept {
   return shift_or_32bit_int(i) + static_cast<T>(1);
 }
 
 template <typename T>
-[[nodiscard, gnu::pure]] constexpr
-    typename std::enable_if<std::is_integral<T>::value && sizeof(T) == 8,
-                            T>::type
-    next_power_of_two(T i) noexcept {
+  requires(std::is_integral_v<T> && sizeof(T) == 8)
+[[nodiscard, gnu::pure]] constexpr T next_power_of_two(T i) noexcept {
   i = shift_or_32bit_int(i);
   i |= (i >> 32U);
   return ++i;

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -102,9 +102,8 @@ struct [[nodiscard]] basic_art_key final {
   ///
   /// Note: Use a key_encoder for complex keys, including multiple key
   /// components or Unicode data.
-  template <typename U = KeyType,
-            typename std::enable_if<std::is_integral<U>::value, int>::type = 0>
   UNODB_DETAIL_CONSTEXPR_NOT_MSVC explicit basic_art_key(KeyType key_) noexcept
+    requires std::is_integral_v<KeyType>
       : key{make_binary_comparable(key_)} {}
 
   /// Construct converts a key_view which must already be


### PR DESCRIPTION
Modernize SFINAE patterns in art_common.hpp and art_internal.hpp to use
C++20 requires clauses, improving readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized compile-time type constraints to C++20 requires-clauses for several utilities and constructors. Preserves public APIs and runtime behavior while improving readability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->