### PR TITLE
Use std::ranges::copy with std::span directly

### DIFF
--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -254,8 +254,8 @@ class [[nodiscard]] tree_verifier final {
     unodb::key_encoder enc;
     const auto kv{enc.encode(k).get_key_view()};
     key_views.emplace_back(std::array<std::byte, sz>{});
-    auto &a = key_views.back();  // a *reference* to data emplaced_back.
-    std::copy(kv.data(), kv.data() + sz, a.begin());  // copy data into array.
+    auto &a = key_views.back();        // a *reference* to data emplaced_back.
+    std::ranges::copy(kv, a.begin());  // copy data into array.
     // Return a key_view backed by the array that we just put on that
     // list.
     return unodb::key_view(a.data(), sz);  // view of array's data.

--- a/test/test_key_encode_decode.cpp
+++ b/test/test_key_encode_decode.cpp
@@ -677,9 +677,9 @@ class key_factory {
     const auto kv{enc.get_key_view()};
     const auto sz{kv.size()};
     key_views.emplace_back(sz);
-    auto& a = key_views.back();  // a *reference* to data emplaced_back.
-    std::copy(kv.data(), kv.data() + sz, a.begin());  // copy data to inner vec
-    return {a.data(), sz};  // view of inner vec's data.
+    auto& a = key_views.back();        // a *reference* to data emplaced_back.
+    std::ranges::copy(kv, a.begin());  // copy data to inner vec
+    return {a.data(), sz};             // view of inner vec's data.
   }
 };
 


### PR DESCRIPTION
Replace std::copy with pointer arithmetic on std::span with
std::ranges::copy that takes the span range directly, simplifying
the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test utilities and test cases to use modern C++ ranges-based copying and style improvements, maintaining existing behavior and public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->