### PR TITLE
Add constexpr to basic_inode_4::key_union constructor

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1670,7 +1670,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     critical_section_policy<std::uint32_t> integer;
 
     UNODB_DETAIL_DISABLE_MSVC_WARNING(26495)
-    key_union() noexcept {}
+    constexpr key_union() noexcept {}
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
   } keys;
 


### PR DESCRIPTION
Enables constexpr construction of the key_union type within basic_inode_4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **No user-visible changes**
  * Internal compilation optimizations applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->