### PR TITLE
Replace custom ctz() with C++20 std::countr_zero

### DIFF
--- a/art_common.hpp
+++ b/art_common.hpp
@@ -187,7 +187,7 @@ template <typename T>
   const T t = v | (v - 1u);  // t gets v's least significant 0 bits set to 1
   // Next set to 1 the most significant bit to change, set to 0 the
   // least significant ones, and add the necessary 1 bits.
-  const T w = (t + 1) | (((~t & -~t) - 1) >> (ctz(v) + 1));
+  const T w = (t + 1) | (((~t & -~t) - 1) >> (std::countr_zero(v) + 1));
   return w;
 }
 

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -54,48 +54,6 @@ template <typename T>
 #endif  // UNODB_DETAIL_MSVC
 }
 
-/// Return the number of trailing zero bits in \a x.
-/// \pre Argument may not be zero
-template <typename T>
-[[nodiscard, gnu::const]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC std::uint8_t ctz(
-    T x) noexcept {
-  static_assert(std::is_same_v<unsigned, T> ||
-                // NOLINTNEXTLINE(google-runtime-int)
-                std::is_same_v<unsigned long, T> ||  // NOLINT(runtime/int)
-                // NOLINTNEXTLINE(google-runtime-int)
-                std::is_same_v<unsigned long long, T>);  // NOLINT(runtime/int)
-
-  if constexpr (std::is_same_v<unsigned, T>) {
-#ifndef UNODB_DETAIL_MSVC
-    return static_cast<std::uint8_t>(__builtin_ctz(x));
-#else
-    unsigned long result;  // NOLINT(runtime/int)
-    _BitScanForward(&result, x);
-    return static_cast<std::uint8_t>(result);
-#endif
-  }
-  // NOLINTNEXTLINE(google-runtime-int)
-  if constexpr (std::is_same_v<unsigned long, T>) {  // NOLINT(runtime/int)
-#ifndef UNODB_DETAIL_MSVC
-    return static_cast<std::uint8_t>(__builtin_ctzl(x));
-#else
-    unsigned long result;  // NOLINT(runtime/int)
-    _BitScanForward(&result, x);
-    return static_cast<std::uint8_t>(result);
-#endif
-  }
-  // NOLINTNEXTLINE(google-runtime-int)
-  if constexpr (std::is_same_v<unsigned long long, T>) {  // NOLINT(runtime/int)
-#ifndef UNODB_DETAIL_MSVC
-    return static_cast<std::uint8_t>(__builtin_ctzll(x));
-#else
-    unsigned long result;  // NOLINT(runtime/int)
-    _BitScanForward64(&result, x);
-    return static_cast<std::uint8_t>(result);
-#endif
-  }  // cppcheck-suppress missingReturn
-}
-
 /// Return the number of one bits in \a x.
 [[nodiscard, gnu::const]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned popcount(
     unsigned x) noexcept {


### PR DESCRIPTION
Remove the custom platform-specific count trailing zeros implementation
and use std::countr_zero from the <bit> header instead.

This also enables upgrading shared_len() and get_shared_length() to
full constexpr, since std::countr_zero is constexpr on all platforms
including MSVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced custom bit-utility implementations with C++20 standard equivalents for improved portability and maintainability.
* **Chore**
  * Removed an internal trailing-zero helper, added a standard header, and introduced a small overload for consistent behavior across internal APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->