### PR TITLE
Use std::popcount from C++20 instead of custom popcount function

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1703,7 +1703,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     const auto bit_field =
         static_cast<unsigned>(_mm_movemask_epi8(le_node_key_positions)) &
         node_key_mask;
-    return detail::popcount(bit_field);
+    return static_cast<unsigned>(std::popcount(bit_field));
   }
 #else
   // The baseline implementation compares key bytes with less-than past the

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -54,16 +54,6 @@ template <typename T>
 #endif  // UNODB_DETAIL_MSVC
 }
 
-/// Return the number of one bits in \a x.
-[[nodiscard, gnu::const]] UNODB_DETAIL_CONSTEXPR_NOT_MSVC unsigned popcount(
-    unsigned x) noexcept {
-#ifndef UNODB_DETAIL_MSVC
-  return static_cast<unsigned>(__builtin_popcount(x));
-#else
-  return static_cast<unsigned>(__popcnt(x));
-#endif
-}
-
 /// Reinterpret object representation as a different type.
 ///
 /// A replacement for `std::bit_cast` until it is provided by all supported


### PR DESCRIPTION
Replace the custom popcount implementation that relied on compiler-specific
intrinsics (__builtin_popcount for GCC/Clang, __popcnt for MSVC) with the
standard library equivalent std::popcount from the <bit> header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal bit-counting implementation to remove platform-specific branches.
* **Bug Fix**
  * Corrected an internal count-to-index conversion that could affect computed insert positions, ensuring consistent insertion behavior while preserving public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->