### PR TITLE
Use C++20 defaulted operator== for single-member comparisons

### DIFF
--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -368,9 +368,7 @@ class [[nodiscard]] basic_node_ptr {
 
   // same raw_val means same type and same ptr.
   [[nodiscard, gnu::pure]] constexpr bool operator==(
-      const basic_node_ptr &other) const noexcept {
-    return tagged_ptr == other.tagged_ptr;
-  }
+      const basic_node_ptr &) const noexcept = default;
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26490)
 

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -337,9 +337,8 @@ class [[nodiscard]] optimistic_lock final {
 
     /// Compare two lock words for equality, including all the version and lock
     /// / obsolete bits.
-    [[nodiscard]] constexpr bool operator==(version_type other) const noexcept {
-      return version == other.version;
-    }
+    [[nodiscard]] constexpr bool operator==(version_type) const noexcept =
+        default;
 
     /// Output the lock word to \a os output stream. Should only be used
     /// for debug dumping.


### PR DESCRIPTION
Simplify operator== implementations in basic_node_ptr and version_type
by using = default, which compiles to the same comparison logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal comparison logic for improved code maintainability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->