### PR TITLE
Use consteval for compile-time-only functions

### DIFF
--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -391,7 +391,7 @@ class [[nodiscard]] basic_node_ptr {
 
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-  [[nodiscard, gnu::const]] static constexpr unsigned mask_bits_needed(
+  [[nodiscard]] static consteval unsigned mask_bits_needed(
       unsigned count) noexcept {
     return count < 2 ? 1 : 1 + mask_bits_needed(count >> 1U);
   }


### PR DESCRIPTION
- mask_bits_needed: constexpr → consteval, remove redundant gnu::const
- is_internal_static_assert: add consteval, remove UNODB_DETAIL_CANNOT_HAPPEN()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enforced stricter compile-time evaluation for an internal pointer utility, tightening compilation checks while preserving existing runtime behavior and outward functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->