### PR TITLE
Pass other by value for basic_node_ptr::operator==

### DIFF
--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -367,7 +367,7 @@ class [[nodiscard]] basic_node_ptr {
 
   // same raw_val means same type and same ptr.
   [[nodiscard, gnu::pure]] constexpr bool operator==(
-      const basic_node_ptr &other) const noexcept {
+      basic_node_ptr other) const noexcept {
     return tagged_ptr == other.tagged_ptr;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated an internal method signature to change how a comparison argument is passed, yielding a minor efficiency improvement in internal comparison operations without altering external behavior or results.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->