### PR TITLE
Configure clang-format include ordering with IncludeCategories

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,16 @@
 ---
 Standard: c++20
 BasedOnStyle: Google
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^"global\.hpp"$'
+    Priority: -1
+  - Regex: '^<[a-z_]+>$'
+    Priority: 2
+  - Regex: '^<.*>$'
+    Priority: 3
+  - Regex: '^".*"$'
+    Priority: 4
 AttributeMacros:
   - UNODB_DETAIL_UNUSED
   - UNODB_DETAIL_USED_IN_DEBUG

--- a/art_internal.cpp
+++ b/art_internal.cpp
@@ -5,13 +5,12 @@
 
 // IWYU pragma: no_include <__ostream/basic_ostream.h>
 
-#include "art_internal.hpp"  // IWYU pragma: keep
-
-#include "art_common.hpp"
-
 #include <cstddef>
 #include <iomanip>
 #include <iostream>  // IWYU pragma: keep
+
+#include "art_common.hpp"
+#include "art_internal.hpp"  // IWYU pragma: keep
 
 namespace unodb::detail {
 

--- a/benchmark/micro_benchmark.cpp
+++ b/benchmark/micro_benchmark.cpp
@@ -15,10 +15,9 @@
 
 #include "art_common.hpp"
 #include "art_internal.hpp"  // IWYU pragma: keep
-#include "node_type.hpp"
-
 #include "micro_benchmark_node_utils.hpp"
 #include "micro_benchmark_utils.hpp"
+#include "node_type.hpp"
 
 namespace {
 

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -14,8 +14,6 @@
 // IWYU pragma: no_include <__new/exceptions.h>
 // IWYU pragma: no_include <__hash_table>
 
-#include "qsbr.hpp"
-
 #include <atomic>
 #include <cstdint>
 #include <exception>
@@ -23,6 +21,8 @@
 #include <memory>
 #include <new>  // IWYU pragma: keep
 #include <utility>
+
+#include "qsbr.hpp"
 
 #ifdef UNODB_DETAIL_WITH_STATS
 #include <mutex>

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -28,12 +28,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "gtest_utils.hpp"
-
 #include "art.hpp"
 #include "art_common.hpp"
 #include "art_internal.hpp"
 #include "assert.hpp"
+#include "gtest_utils.hpp"
 #include "mutex_art.hpp"
 #include "node_type.hpp"
 #include "olc_art.hpp"

--- a/test/qsbr_gtest_utils.cpp
+++ b/test/qsbr_gtest_utils.cpp
@@ -6,7 +6,6 @@
 #include "qsbr_gtest_utils.hpp"  // IWYU pragma: keep
 
 #include "qsbr.hpp"
-
 #include "qsbr_test_utils.hpp"
 
 namespace unodb::test {


### PR DESCRIPTION
Change IncludeBlocks from Preserve to Regroup and define priority
categories to enforce consistent include ordering: global.hpp first,
then standard library headers, then third-party headers, then project
headers.

🤖 Commit message by [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated formatting configuration to standardize include grouping and ordering.
  * Added prioritized include-category rules to better classify headers (system, lowercase, angle, quoted).
  * Introduced additional attribute-like macros for inlining, lifetime bounds, C-string handling, and release-time constness.
  * Harmonized include ordering across sources and tests for more consistent compilation and maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->