### PR TITLE
Add MSVC STL hardening support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,7 +484,9 @@ function(GLOBAL_CXX_TARGET_PROPERTIES TARGET)
   target_compile_definitions(${TARGET} PUBLIC
     "$<${is_standalone_not_release}:_GLIBCXX_DEBUG>"
     "$<${is_standalone_not_release}:_GLIBCXX_DEBUG_PEDANTIC>"
-    "$<${is_standalone_asan}:_GLIBCXX_SANITIZE_VECTOR>")
+    "$<${is_standalone_asan}:_GLIBCXX_SANITIZE_VECTOR>"
+    "$<$<AND:${is_any_msvc},${is_standalone_not_release}>:_MSVC_STL_HARDENING=1>"
+    "$<$<AND:${is_any_msvc},${is_standalone_not_release}>:_MSVC_STL_DESTRUCTOR_TOMBSTONES=1>")
 endfunction()
 
 if(TESTS)

--- a/global.hpp
+++ b/global.hpp
@@ -171,6 +171,14 @@
 /// with AddressSanitizer.
 #define _GLIBCXX_SANITIZE_VECTOR
 
+/// Enables the MSVC STL debug checks (iterator debugging, bounds checking)
+/// when compiling in the standalone debug configuration.
+#define _MSVC_STL_HARDENING
+
+/// Enables the MSVC STL destructor tombstone feature to catch use-after-
+/// destruction bugs when compiling in the standalone debug configuration.
+#define _MSVC_STL_DESTRUCTOR_TOMBSTONES
+
 #endif  // UNODB_DETAIL_DOXYGEN
 /// \}
 


### PR DESCRIPTION
Enable _MSVC_STL_HARDENING and _MSVC_STL_DESTRUCTOR_TOMBSTONES for standalone
non-release MSVC builds, following the existing pattern for libstdc++ debug
mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added MSVC-specific build options that enable extra STL hardening and destructor-tombstone checks for standalone non-release builds to improve safety diagnostics in those configurations.
* **Documentation**
  * Public docs updated to expose two new MSVC-related configuration macros so they appear in generated documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->