### PR TITLE
ci: add GitHub Actions workflow for benchmark tracking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,87 @@
+---
+name: benchmarks
+
+# Do not run this workflow on pull request since this workflow has permission
+# to modify contents.
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+
+jobs:
+  benchmark:
+    runs-on: ${{matrix.os}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux Intel
+            os: ubuntu-latest
+            arch: x64
+
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            arch: arm64
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-dev
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          cmake -B build "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Release \
+              -DSTANDALONE=ON -DBENCHMARKS=ON
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: make -j3 -k
+
+      - name: Run benchmarks
+        working-directory: ${{github.workspace}}/build
+        run: |
+          ./micro_benchmark_key_prefix --benchmark_out=benchmark_key_prefix.json --benchmark_out_format=json
+          ./micro_benchmark_n4 --benchmark_out=benchmark_n4.json --benchmark_out_format=json
+          ./micro_benchmark_n16 --benchmark_out=benchmark_n16.json --benchmark_out_format=json
+          ./micro_benchmark_n48 --benchmark_out=benchmark_n48.json --benchmark_out_format=json
+          ./micro_benchmark_n256 --benchmark_out=benchmark_n256.json --benchmark_out_format=json
+          ./micro_benchmark --benchmark_out=benchmark_main.json --benchmark_out_format=json
+          ./micro_benchmark_mutex --benchmark_out=benchmark_mutex.json --benchmark_out_format=json
+          ./micro_benchmark_olc --benchmark_out=benchmark_olc.json --benchmark_out_format=json
+
+      - name: Combine benchmark results
+        working-directory: ${{github.workspace}}/build
+        run: |
+          jq -s '{ benchmarks: map(.benchmarks) | add }' \
+            benchmark_key_prefix.json benchmark_n4.json benchmark_n16.json \
+            benchmark_n48.json benchmark_n256.json benchmark_main.json \
+            benchmark_mutex.json benchmark_olc.json > benchmark_results.json
+
+      - name: Store benchmark result
+        uses: nyrkio/github-action-benchmark@v1 # zizmor: ignore[unpinned-uses]
+        with:
+          name: UnoDB Benchmarks (${{matrix.arch}})
+          tool: "googlecpp"
+          output-file-path: build/benchmark_results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "200%"
+          comment-on-alert: true
+          alert-comment-cc-users: "@laurynas-biveinis"
+          fail-on-alert: true
+          summary-always: true
+          nyrkio-enable: true


### PR DESCRIPTION
Add new GitHub Actions workflow to run all 8 benchmark executables with
Google Benchmark JSON output format. The workflow runs on push to master
across a matrix of Linux Intel (ubuntu-latest) and Linux ARM64
(ubuntu-24.04-arm) platforms.

The workflow integrates with nyrkio/github-action-benchmark to track
performance metrics over time, automatically pushing results to the
gh-pages branch for GitHub Pages visualization. Performance regressions
trigger alerts to @laurynas-biveinis.

Configured to run only on master branch pushes, not on pull requests,
since the workflow requires write permissions to the gh-pages branch.
Nyrkio integration is enabled for centralized performance tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated benchmark testing infrastructure that runs on multiple Linux architectures, generates performance metrics, and publishes results for tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->