### PR TITLE
Add LIFETIMEBOUND annotations to constructors storing references

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -200,7 +200,8 @@ class db final {
    protected:
     /// Construct an empty iterator (one that is logically not
     /// positioned on anything and which will report !valid()).
-    explicit iterator(db& tree) noexcept : db_(tree) {}
+    explicit iterator(db& tree UNODB_DETAIL_LIFETIMEBOUND) noexcept
+        : db_(tree) {}
 
     // iterator is not flyweight. disallow copy and move.
     iterator(const iterator&) = delete;

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -49,7 +49,8 @@ template <typename Iterator>
 class visitor {
  protected:
   Iterator &it;
-  explicit visitor(Iterator &it_) noexcept : it(it_) {}
+  explicit visitor(Iterator &it_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
+      : it(it_) {}
 
  public:
   using key_type = typename Iterator::key_type;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -312,7 +312,8 @@ class olc_db final {
    protected:
     /// Construct an empty iterator (one that is logically not
     /// positioned on anything and which will report !valid()).
-    explicit iterator(olc_db& tree) noexcept : db_(tree) {}
+    explicit iterator(olc_db& tree UNODB_DETAIL_LIFETIMEBOUND) noexcept
+        : db_(tree) {}
 
     // iterator is not flyweight. disallow copy and move.
     iterator(const iterator&) = delete;


### PR DESCRIPTION
Annotate constructors that store reference parameters with
UNODB_DETAIL_LIFETIMEBOUND to enable Clang's lifetime analysis
warnings for potential use-after-free bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added compiler-level lifetime annotations to internal iterator and visitor constructors across database components to improve code robustness; no change in behavior or public APIs, so end-user functionality remains unaffected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->