### PR TITLE
Replace auto return types with explicit types

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -141,7 +141,7 @@ class db final {
   }
 
   /// Return true iff the index is empty.
-  [[nodiscard, gnu::pure]] auto empty() const noexcept {
+  [[nodiscard, gnu::pure]] bool empty() const noexcept {
     return root == nullptr;
   }
 
@@ -512,50 +512,52 @@ class db final {
   //
 
   // Used to write the iterator tests.
-  auto test_only_iterator() noexcept { return iterator(*this); }
+  iterator test_only_iterator() noexcept { return iterator(*this); }
 
   // Stats
 
 #ifdef UNODB_DETAIL_WITH_STATS
 
   // Return current memory use by tree nodes in bytes.
-  [[nodiscard, gnu::pure]] constexpr auto get_current_memory_use()
+  [[nodiscard, gnu::pure]] constexpr std::size_t get_current_memory_use()
       const noexcept {
     return current_memory_use;
   }
 
   template <node_type NodeType>
-  [[nodiscard, gnu::pure]] constexpr auto get_node_count() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr std::uint64_t get_node_count()
+      const noexcept {
     return node_counts[as_i<NodeType>];
   }
 
-  [[nodiscard, gnu::pure]] constexpr auto get_node_counts() const noexcept {
+  [[nodiscard, gnu::pure]] constexpr node_type_counter_array get_node_counts()
+      const noexcept {
     return node_counts;
   }
 
   template <node_type NodeType>
-  [[nodiscard, gnu::pure]] constexpr auto get_growing_inode_count()
+  [[nodiscard, gnu::pure]] constexpr std::uint64_t get_growing_inode_count()
       const noexcept {
     return growing_inode_counts[internal_as_i<NodeType>];
   }
 
-  [[nodiscard, gnu::pure]] constexpr auto get_growing_inode_counts()
-      const noexcept {
+  [[nodiscard, gnu::pure]] constexpr inode_type_counter_array
+  get_growing_inode_counts() const noexcept {
     return growing_inode_counts;
   }
 
   template <node_type NodeType>
-  [[nodiscard, gnu::pure]] constexpr auto get_shrinking_inode_count()
+  [[nodiscard, gnu::pure]] constexpr std::uint64_t get_shrinking_inode_count()
       const noexcept {
     return shrinking_inode_counts[internal_as_i<NodeType>];
   }
 
-  [[nodiscard, gnu::pure]] constexpr auto get_shrinking_inode_counts()
-      const noexcept {
+  [[nodiscard, gnu::pure]] constexpr inode_type_counter_array
+  get_shrinking_inode_counts() const noexcept {
     return shrinking_inode_counts;
   }
 
-  [[nodiscard, gnu::pure]] constexpr auto get_key_prefix_splits()
+  [[nodiscard, gnu::pure]] constexpr std::uint64_t get_key_prefix_splits()
       const noexcept {
     return key_prefix_splits;
   }
@@ -563,7 +565,7 @@ class db final {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   // Public utils
-  [[nodiscard, gnu::const]] static constexpr auto key_found(
+  [[nodiscard, gnu::const]] static constexpr bool key_found(
       const get_result& result) noexcept {
     return static_cast<bool>(result);
   }

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -400,7 +400,7 @@ class [[nodiscard]] basic_node_ptr {
   static constexpr auto tag_bit_mask = lowest_non_tag_bit - 1;
   static constexpr auto ptr_bit_mask = ~tag_bit_mask;
 
-  static auto static_asserts() {
+  static void static_asserts() {
     static_assert(sizeof(basic_node_ptr<Header>) == sizeof(void *));
     static_assert(alignof(header_type) - 1 > lowest_non_tag_bit);
   }

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -34,7 +34,7 @@ constexpr void concurrency_ranges32(::benchmark::internal::Benchmark *b) {
 }
 
 template <typename T>
-[[nodiscard]] constexpr auto to_counter(T value) {
+[[nodiscard]] ::benchmark::Counter to_counter(T value) {
   return ::benchmark::Counter{static_cast<double>(value)};
 }
 

--- a/fuzz_deepstate/deepstate_utils.hpp
+++ b/fuzz_deepstate/deepstate_utils.hpp
@@ -45,7 +45,7 @@
 /// \tparam T Container type that supports `std::empty()` and `std::size()`
 /// \pre Container must not be empty
 template <class T>
-[[nodiscard]] auto DeepState_ContainerIndex(const T &container) {
+[[nodiscard]] std::size_t DeepState_ContainerIndex(const T &container) {
   ASSERT(!std::empty(container));
   return DeepState_SizeTInRange(0, std::size(container) - 1);
 }

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -37,7 +37,7 @@ using values_type = std::vector<dynamic_value>;
 
 using oracle_type = std::unordered_map<std::uint64_t, unodb::value_view>;
 
-[[nodiscard]] auto make_random_value(dynamic_value::size_type length) {
+[[nodiscard]] dynamic_value make_random_value(dynamic_value::size_type length) {
   dynamic_value result{length};
   for (dynamic_value::size_type i = 0; i < length; i++) {
     // Ideally we would take random bytes from DeepState, but we'd end up
@@ -48,8 +48,8 @@ using oracle_type = std::unordered_map<std::uint64_t, unodb::value_view>;
   return result;
 }
 
-[[nodiscard]] auto get_value(dynamic_value::size_type max_length,
-                             values_type &values) {
+[[nodiscard]] unodb::value_view get_value(dynamic_value::size_type max_length,
+                                          values_type &values) {
   const auto make_new_value = values.empty() || DeepState_Bool();
   ASSERT(max_length <= std::numeric_limits<std::uint32_t>::max());
   if (make_new_value) {

--- a/heap.hpp
+++ b/heap.hpp
@@ -26,7 +26,7 @@ namespace unodb::detail {
 
 /// Get minimum alignment to use when allocating objects of type \a T.
 template <typename T>
-[[nodiscard]] consteval auto alignment_for_new() noexcept {
+[[nodiscard]] consteval std::size_t alignment_for_new() noexcept {
   return std::max(alignof(T),
                   static_cast<std::size_t>(__STDCPP_DEFAULT_NEW_ALIGNMENT__));
 }

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -699,54 +699,56 @@ class olc_db final {
   //
 
   // Used to write the iterator tests.
-  auto test_only_iterator() noexcept { return iterator(*this); }
+  iterator test_only_iterator() noexcept { return iterator(*this); }
 
   // Stats
 
 #ifdef UNODB_DETAIL_WITH_STATS
 
   // Return current memory use by tree nodes in bytes
-  [[nodiscard]] auto get_current_memory_use() const noexcept {
+  [[nodiscard]] std::size_t get_current_memory_use() const noexcept {
     return current_memory_use.load(std::memory_order_relaxed);
   }
 
   template <node_type NodeType>
-  [[nodiscard]] auto get_node_count() const noexcept {
+  [[nodiscard]] std::uint64_t get_node_count() const noexcept {
     return node_counts[as_i<NodeType>].load(std::memory_order_relaxed);
   }
 
-  [[nodiscard]] auto get_node_counts() const noexcept {
+  [[nodiscard]] node_type_counter_array get_node_counts() const noexcept {
     return detail::copy_atomic_to_nonatomic(node_counts);
   }
 
   template <node_type NodeType>
-  [[nodiscard]] auto get_growing_inode_count() const noexcept {
+  [[nodiscard]] std::uint64_t get_growing_inode_count() const noexcept {
     return growing_inode_counts[internal_as_i<NodeType>].load(
         std::memory_order_relaxed);
   }
 
-  [[nodiscard]] auto get_growing_inode_counts() const noexcept {
+  [[nodiscard]] inode_type_counter_array get_growing_inode_counts()
+      const noexcept {
     return detail::copy_atomic_to_nonatomic(growing_inode_counts);
   }
 
   template <node_type NodeType>
-  [[nodiscard]] auto get_shrinking_inode_count() const noexcept {
+  [[nodiscard]] std::uint64_t get_shrinking_inode_count() const noexcept {
     return shrinking_inode_counts[internal_as_i<NodeType>].load(
         std::memory_order_relaxed);
   }
 
-  [[nodiscard]] auto get_shrinking_inode_counts() const noexcept {
+  [[nodiscard]] inode_type_counter_array get_shrinking_inode_counts()
+      const noexcept {
     return detail::copy_atomic_to_nonatomic(shrinking_inode_counts);
   }
 
-  [[nodiscard]] auto get_key_prefix_splits() const noexcept {
+  [[nodiscard]] std::uint64_t get_key_prefix_splits() const noexcept {
     return key_prefix_splits.load(std::memory_order_relaxed);
   }
 
 #endif  // UNODB_DETAIL_WITH_STATS
 
   // Public utils
-  [[nodiscard]] static constexpr auto key_found(
+  [[nodiscard]] static constexpr bool key_found(
       const get_result& result) noexcept {
     return static_cast<bool>(result);
   }

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -86,7 +86,7 @@ thread_local std::unique_ptr<qsbr_per_thread>
     qsbr_per_thread::current_thread_instance;
 
 // LCOV_EXCL_START
-[[gnu::cold]] UNODB_DETAIL_NOINLINE void detail::qsbr_epoch::dump(
+[[gnu::cold]] UNODB_DETAIL_NOINLINE void qsbr_epoch::dump(
     std::ostream &os) const {
   os << "epoch = " << static_cast<std::uint64_t>(epoch_val);
 #ifndef NDEBUG
@@ -232,7 +232,7 @@ void qsbr_per_thread::orphan_pending_requests() noexcept {
 }
 
 UNODB_DETAIL_DISABLE_CLANG_21_WARNING("-Wnrvo")
-detail::qsbr_epoch qsbr::register_thread() noexcept {
+qsbr_epoch qsbr::register_thread() noexcept {
   auto old_state = get_state();
 
   while (true) {
@@ -283,7 +283,7 @@ detail::qsbr_epoch qsbr::register_thread() noexcept {
 UNODB_DETAIL_RESTORE_CLANG_21_WARNINGS()
 
 void qsbr::unregister_thread(std::uint64_t quiescent_states_since_epoch_change,
-                             detail::qsbr_epoch thread_epoch,
+                             qsbr_epoch thread_epoch,
                              qsbr_per_thread &qsbr_thread)
 #ifndef UNODB_DETAIL_WITH_STATS
     noexcept
@@ -417,11 +417,11 @@ void qsbr::thread_epoch_change_barrier() noexcept {
 #endif
 }
 
-detail::qsbr_epoch qsbr::remove_thread_from_previous_epoch(
-    detail::qsbr_epoch current_global_epoch
+qsbr_epoch qsbr::remove_thread_from_previous_epoch(
+    qsbr_epoch current_global_epoch
 #ifndef NDEBUG
     ,
-    detail::qsbr_epoch thread_epoch
+    qsbr_epoch thread_epoch
 #endif
     ) noexcept {
   thread_epoch_change_barrier();
@@ -498,8 +498,8 @@ void qsbr::epoch_change_barrier_and_handle_orphans(
   }
 }
 
-detail::qsbr_epoch qsbr::change_epoch(detail::qsbr_epoch current_global_epoch,
-                                      bool single_thread_mode) noexcept {
+qsbr_epoch qsbr::change_epoch(qsbr_epoch current_global_epoch,
+                              bool single_thread_mode) noexcept {
   epoch_change_barrier_and_handle_orphans(single_thread_mode);
 
   auto old_state = state.load(std::memory_order_acquire);

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -33,19 +33,20 @@ class QSBRTestBase : public ::testing::Test {
 
   // QSBR operation wrappers
  private:
-  [[nodiscard]] static auto get_qsbr_state() noexcept {
+  [[nodiscard]] static qsbr_state::type get_qsbr_state() noexcept {
     return must_not_allocate(
         []() noexcept { return unodb::qsbr::instance().get_state(); });
   }
 
  protected:
-  [[nodiscard]] static auto get_qsbr_thread_count() noexcept {
+  [[nodiscard]] static qsbr_thread_count_type get_qsbr_thread_count() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr_state::get_thread_count(get_qsbr_state());
     });
   }
 
-  [[nodiscard]] static auto get_qsbr_threads_in_previous_epoch() noexcept {
+  [[nodiscard]] static qsbr_thread_count_type
+  get_qsbr_threads_in_previous_epoch() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr_state::get_threads_in_previous_epoch(get_qsbr_state());
     });
@@ -75,31 +76,33 @@ class QSBRTestBase : public ::testing::Test {
         [] { unodb::qsbr::instance().reset_stats(); });
   }
 
-  [[nodiscard]] static auto qsbr_get_max_backlog_bytes() noexcept {
+  [[nodiscard]] static std::uint64_t qsbr_get_max_backlog_bytes() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance().get_max_backlog_bytes();
     });
   }
 
-  [[nodiscard]] static auto qsbr_get_mean_backlog_bytes() noexcept {
+  [[nodiscard]] static double qsbr_get_mean_backlog_bytes() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance().get_mean_backlog_bytes();
     });
   }
 
-  [[nodiscard]] static auto qsbr_get_epoch_callback_count_max() noexcept {
+  [[nodiscard]] static std::size_t
+  qsbr_get_epoch_callback_count_max() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance().get_epoch_callback_count_max();
     });
   }
 
-  [[nodiscard]] static auto qsbr_get_epoch_callback_count_variance() noexcept {
+  [[nodiscard]] static double
+  qsbr_get_epoch_callback_count_variance() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance().get_epoch_callback_count_variance();
     });
   }
 
-  [[nodiscard]] static auto
+  [[nodiscard]] static double
   qsbr_get_mean_quiescent_states_per_thread_between_epoch_changes() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance()
@@ -107,7 +110,7 @@ class QSBRTestBase : public ::testing::Test {
     });
   }
 
-  [[nodiscard]] static auto qsbr_get_epoch_change_count() noexcept {
+  [[nodiscard]] static std::uint64_t qsbr_get_epoch_change_count() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance().get_epoch_change_count();
     });
@@ -115,7 +118,7 @@ class QSBRTestBase : public ::testing::Test {
 
 #endif  // UNODB_DETAIL_WITH_STATS
 
-  [[nodiscard]] static auto
+  [[nodiscard]] static bool
   qsbr_previous_interval_orphaned_requests_empty() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance()
@@ -123,7 +126,7 @@ class QSBRTestBase : public ::testing::Test {
     });
   }
 
-  [[nodiscard]] static auto
+  [[nodiscard]] static bool
   qsbr_current_interval_orphaned_requests_empty() noexcept {
     return must_not_allocate([]() noexcept {
       return unodb::qsbr::instance().current_interval_orphaned_requests_empty();
@@ -260,7 +263,7 @@ class QSBRTestBase : public ::testing::Test {
   QSBRTestBase &operator=(QSBRTestBase &&) = delete;
 
  private:
-  unodb::detail::qsbr_epoch last_epoch{0};
+  unodb::qsbr_epoch last_epoch{0};
 };
 
 }  // namespace unodb::test


### PR DESCRIPTION
Improve code readability by replacing auto return type deduction with
explicit return types across the codebase. This makes function signatures
self-documenting and eliminates the need to inspect implementation details
to understand return types.

Changes span core library headers (art.hpp, olc_art.hpp, mutex_art.hpp,
art_internal.hpp, heap.hpp), benchmark utilities, test utilities, and
fuzz test files. Variadic template forwarding methods are intentionally
excluded as they require auto for perfect forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced inferred return types with explicit concrete return types across public APIs, benchmarks, fuzzing helpers, and test utilities.
  * Unified and exposed consistent QSBR epoch/thread types in the public API surface.
  * Updated several test-only utilities and diagnostics to return concrete types for clearer, stricter interfaces while preserving behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->