### PR TITLE
Add constexpr annotations to ART and utility functions

### DIFF
--- a/art_common.hpp
+++ b/art_common.hpp
@@ -229,7 +229,8 @@ class key_encoder {
   static constexpr std::uint64_t msb64 = 1ULL << 63;
 
   template <typename T>
-  [[nodiscard]] static T make_binary_comparable_integral(T v) noexcept {
+  [[nodiscard]] static constexpr T make_binary_comparable_integral(
+      T v) noexcept {
     static_assert(std::endian::native == std::endian::little,
                   "Big-endian support needs implementing");
     return unodb::detail::bswap(v);
@@ -490,7 +491,8 @@ class key_decoder {
   static constexpr std::uint64_t msb64 = 1ULL << 63U;
 
   template <typename T>
-  [[nodiscard]] static T decode_binary_comparable_integral(T u) noexcept {
+  [[nodiscard]] static constexpr T decode_binary_comparable_integral(
+      T u) noexcept {
     static_assert(std::endian::native == std::endian::little,
                   "Big-endian support needs implementing");
     return unodb::detail::bswap(u);

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -567,7 +567,7 @@ union [[nodiscard]] key_prefix_snapshot {
   constexpr explicit key_prefix_snapshot(std::uint64_t v) noexcept : u64(v) {}
 
   /// Return a view onto the snapshot of the key prefix.
-  [[nodiscard]] key_view get_key_view() const noexcept {
+  [[nodiscard]] constexpr key_view get_key_view() const noexcept {
     return key_view(f.key_prefix.data(), f.key_prefix_length);
   }
 

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -42,7 +42,7 @@ class [[nodiscard]] fake_read_critical_section final {
   /// construction, always succeeds.
   // cppcheck-suppress functionStatic
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-  [[nodiscard]] bool must_restart() const noexcept { return false; }
+  [[nodiscard]] constexpr bool must_restart() const noexcept { return false; }
 
   /// Check whether this fake read critical section is still valid, always
   /// succeeds.
@@ -54,7 +54,7 @@ class [[nodiscard]] fake_read_critical_section final {
 
   /// Compare with another read fake read critical section for equality, always
   /// returning true.
-  [[nodiscard]] bool operator==(
+  [[nodiscard]] constexpr bool operator==(
       const fake_read_critical_section &) const noexcept {
     return true;
   }
@@ -62,7 +62,7 @@ class [[nodiscard]] fake_read_critical_section final {
   /// Try to read unlock this read fake critical section, always succeeds.
   // cppcheck-suppress functionStatic
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-  [[nodiscard]] bool try_read_unlock() const noexcept { return true; }
+  [[nodiscard]] constexpr bool try_read_unlock() const noexcept { return true; }
 
   fake_read_critical_section(const fake_read_critical_section &) = delete;
   fake_read_critical_section(fake_read_critical_section &&) = delete;

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -22,7 +22,7 @@ namespace unodb::detail {
 
 /// Reverse the order of bytes in \a x.
 template <typename T>
-[[nodiscard, gnu::const]] T bswap(T x) noexcept {
+[[nodiscard, gnu::const]] constexpr T bswap(T x) noexcept {
 #ifdef UNODB_DETAIL_MSVC
   static_assert(sizeof(std::uint32_t) ==
                 sizeof(unsigned long));               // NOLINT(runtime/int)


### PR DESCRIPTION
- Make bswap() constexpr in portability_builtins.hpp (builtin byte-swap
  functions are constexpr in MSVC, GCC, and Clang)
- Make binary comparable integral conversion functions constexpr in
  art_common.hpp: make_binary_comparable_integral() and
  decode_binary_comparable_integral()
- Make key_prefix_snapshot::get_key_view() constexpr (simple member access)
- Make fake_read_critical_section member functions constexpr in
  in_fake_critical_section.hpp: must_restart(), try_read_unlock(), and
  operator==()

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted multiple internal utilities and lightweight accessors to be constexpr-qualified, enabling additional compile-time evaluation opportunities without changing runtime behavior or public interfaces.
  * Changes affect byte-swapping, key encoding/decoding helpers, snapshot accessors, and no-op critical-section accessors to improve constant-evaluability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->