### PR TITLE
Add constinit to debug atomic instance counter

### DIFF
--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -127,7 +127,7 @@ UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 namespace detail {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::atomic<std::uint64_t> deallocation_request::instance_count{0};
+constinit std::atomic<std::uint64_t> deallocation_request::instance_count{0};
 
 }  // namespace detail
 


### PR DESCRIPTION
std::atomic<T> has constexpr constructor for trivial types since C++20,
ensuring compile-time initialization for deallocation_request::instance_count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal initialization behavior of a core component for improved compile-time efficiency with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->