### PR TITLE
Fix/key view long prefix bug

### DIFF
--- a/.github/workflows/old-compilers.yml
+++ b/.github/workflows/old-compilers.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      BOOST: ${{matrix.BOOST}}
       BUILD_TYPE: ${{matrix.BUILD_TYPE}}
       COMPILER: ${{matrix.COMPILER}}
       VERSION: ${{matrix.VERSION}}
@@ -193,7 +192,6 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
-            BOOST: OFF
 
           - name: clang 14 Release with TSan
             BUILD_TYPE: Release
@@ -208,7 +206,6 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
-            BOOST: OFF
 
           - name: clang 14 Debug
             BUILD_TYPE: Debug
@@ -222,7 +219,6 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
-            BOOST: OFF
 
           - name: clang 14 Debug with TSan
             BUILD_TYPE: Debug
@@ -237,7 +233,6 @@ jobs:
             COMPILER: clang
             VERSION: 14
             STATS: OFF
-            BOOST: OFF
 
           - name: clang 15 Release
             BUILD_TYPE: Release
@@ -620,7 +615,6 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 12 Release with ASan
             BUILD_TYPE: Release
@@ -635,7 +629,6 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 12 Release with UBSan
             BUILD_TYPE: Release
@@ -649,7 +642,6 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 12 Debug with ASan
             BUILD_TYPE: Debug
@@ -664,7 +656,6 @@ jobs:
             COMPILER: gcc
             VERSION: 12
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 12 Debug with UBSan
             BUILD_TYPE: Debug
@@ -678,7 +669,6 @@ jobs:
             COMPILER: gcc
             VERSION: 13
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 13 Release with ASan
             BUILD_TYPE: Release
@@ -693,7 +683,6 @@ jobs:
             COMPILER: gcc
             VERSION: 13
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 13 Release with UBSan
             BUILD_TYPE: Release
@@ -707,7 +696,6 @@ jobs:
             COMPILER: gcc
             VERSION: 13
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 13 Debug with ASan
             BUILD_TYPE: Debug
@@ -722,7 +710,6 @@ jobs:
             COMPILER: gcc
             VERSION: 13
             STATS: OFF
-            BOOST: OFF
 
           - name: GCC 13 Debug with UBSan
             BUILD_TYPE: Debug
@@ -742,9 +729,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libc6-dev-i386
 
-      - name: Setup optional Boost
+      - name: Setup Boost
         run: sudo apt-get install -y libboost-dev
-        if: env.BOOST != 'OFF'
 
       - name: Setup LLVM 16+ repo
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,13 +360,8 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
 
-find_package(Boost
+find_package(Boost REQUIRED
   OPTIONAL_COMPONENTS stacktrace_basic stacktrace_backtrace stacktrace_windbg)
-
-if(STATS AND NOT Boost_FOUND)
-  message(FATAL_ERROR
-    "Building with stats requires Boost, install it or use -DSTATS=OFF")
-endif()
 
 if(Boost_STACKTRACE_BACKTRACE_FOUND)
   message(STATUS "Boost.Stacktrace built with libbacktrace support, using it.")

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ platform-specific features:
 - Earliest versions of supported compilers: GCC 10, LLVM 11, Xcode 16.1,
   MSVC 2022. Open an issue if you require support for an older version.
 - CMake, at least 3.16.
-- Boost library. If building with statistics counters, then it is a mandatory
-  dependency for Boost.Accumulator. It is also an optional dependency for
-  Boost.Stacktrace.
+- Boost library. It is a mandatory dependency for Boost.Container
+  (small_vector). If building with statistics counters, Boost.Accumulator is
+  also required. Boost.Stacktrace is an optional dependency.
 
 ### Optional vendored dependencies, bundled as Git submodules
 

--- a/art.hpp
+++ b/art.hpp
@@ -20,6 +20,8 @@
 #include <stack>
 #include <type_traits>
 
+#include <boost/container/small_vector.hpp>
+
 #include "art_common.hpp"
 #include "art_internal.hpp"
 #include "art_internal_impl.hpp"
@@ -164,11 +166,25 @@ class db final {
   /// \return true iff the key value pair was inserted.
   [[nodiscard]] bool insert_internal(art_key_type insert_key, value_type v);
 
+  /// Insert for fixed-width keys (no chain nodes needed).
+  [[nodiscard]] bool insert_internal_fixed(art_key_type insert_key,
+                                           value_type v);
+
+  /// Insert for variable-length keys (may create chain I4 nodes).
+  [[nodiscard]] bool insert_internal_key_view(art_key_type insert_key,
+                                              value_type v);
+
   /// Remove the entry associated with the encoded key \a remove_key.
   ///
   /// \return true if the delete was successful (i.e. the key was found in the
   /// tree and the associated index entry was removed).
   [[nodiscard]] bool remove_internal(art_key_type remove_key);
+
+  /// Two-pass removal with chain cleanup for variable-length keys.
+  [[nodiscard]] bool remove_internal_key_view(art_key_type remove_key);
+
+  /// Single-pass removal for fixed-width keys (no chain nodes).
+  [[nodiscard]] bool remove_internal_fixed(art_key_type remove_key);
 
  public:
   // Creation and destruction
@@ -1256,6 +1272,16 @@ bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
     return true;
   }
 
+  if constexpr (std::is_same_v<Key, key_view>) {
+    return insert_internal_key_view(insert_key, v);
+  } else {
+    return insert_internal_fixed(insert_key, v);
+  }
+}
+
+template <typename Key, typename Value>
+bool db<Key, Value>::insert_internal_fixed(art_key_type insert_key,
+                                           value_type v) {
   auto* node = &root;
   tree_depth_type depth{};
   auto remaining_key{insert_key};
@@ -1269,9 +1295,6 @@ bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
       if (UNODB_DETAIL_UNLIKELY(cmp == 0)) {
         return false;  // exists
       }
-      // Replace the existing leaf with a new N4 and put the existing
-      // leaf and the leaf for the caller's key and value under the
-      // new inode as its direct children.
       auto new_leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
       auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
                                     leaf, std::move(new_leaf))};
@@ -1289,10 +1312,6 @@ bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
     const auto key_prefix_length{key_prefix.length()};
     const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
     if (shared_prefix_len < key_prefix_length) {
-      // We have reached an existing inode whose key_prefix is greater
-      // than the desired match.  We need to split this inode into a
-      // new N4 whose children are the existing inode and a new child
-      // leaf.
       auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
       auto new_node = inode_4::create(*this, *node, shared_prefix_len, depth,
                                       std::move(leaf));
@@ -1305,8 +1324,81 @@ bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
 #endif  // UNODB_DETAIL_WITH_STATS
       return true;
     }
-    // key_prefix bytes were absorbed during the descent.  Now we need
-    // to either descend along an existing child or create a new child.
+    UNODB_DETAIL_ASSERT(shared_prefix_len == key_prefix_length);
+    depth += key_prefix_length;
+    remaining_key.shift_right(key_prefix_length);
+
+    node = inode->template add_or_choose_subtree<detail::node_ptr*>(
+        node_type, remaining_key[0], insert_key, v, *this, depth, node);
+
+    if (node == nullptr) return true;
+
+    ++depth;
+    remaining_key.shift_right(1);
+  }
+}
+
+template <typename Key, typename Value>
+bool db<Key, Value>::insert_internal_key_view(art_key_type insert_key,
+                                              value_type v) {
+  auto* node = &root;
+  tree_depth_type depth{};
+  auto remaining_key{insert_key};
+
+  while (true) {
+    const auto node_type = node->type();
+    if (node_type == node_type::LEAF) {
+      auto* const leaf{node->template ptr<leaf_type*>()};
+      const auto existing_key{leaf->get_key_view()};
+      const auto cmp = insert_key.cmp(existing_key);
+      if (UNODB_DETAIL_UNLIKELY(cmp == 0)) {
+        return false;  // exists
+      }
+      constexpr auto cap = detail::key_prefix_capacity;
+      const auto remaining_existing = existing_key.subspan(depth);
+      const auto shared = detail::key_prefix_snapshot::shared_len(
+          detail::get_u64(remaining_existing), remaining_key.get_u64(), cap);
+      if (shared >= cap && remaining_existing.size() > cap &&
+          remaining_key.size() > cap &&
+          remaining_existing[cap] == remaining_key[cap]) {
+        const auto dispatch = remaining_existing[cap];
+        auto chain{inode_4::create(*this, existing_key, remaining_key, depth,
+                                   dispatch, *node)};
+        *node = detail::node_ptr{chain.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_growing_inode<node_type::I4>();
+#endif  // UNODB_DETAIL_WITH_STATS
+        continue;
+      }
+      auto new_leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
+      auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
+                                    leaf, std::move(new_leaf))};
+      *node = detail::node_ptr{new_node.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+      account_growing_inode<node_type::I4>();
+#endif  // UNODB_DETAIL_WITH_STATS
+      return true;
+    }
+
+    UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
+
+    auto* const inode{node->template ptr<inode_type*>()};
+    const auto& key_prefix{inode->get_key_prefix()};
+    const auto key_prefix_length{key_prefix.length()};
+    const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
+    if (shared_prefix_len < key_prefix_length) {
+      auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
+      auto new_node = inode_4::create(*this, *node, shared_prefix_len, depth,
+                                      std::move(leaf));
+      *node = detail::node_ptr{new_node.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+      account_growing_inode<node_type::I4>();
+      ++key_prefix_splits;
+      UNODB_DETAIL_ASSERT(growing_inode_counts[internal_as_i<node_type::I4>] >
+                          key_prefix_splits);
+#endif  // UNODB_DETAIL_WITH_STATS
+      return true;
+    }
     UNODB_DETAIL_ASSERT(shared_prefix_len == key_prefix_length);
     depth += key_prefix_length;
     remaining_key.shift_right(key_prefix_length);
@@ -1337,8 +1429,16 @@ bool db<Key, Value>::remove_internal(art_key_type remove_key) {
     return false;
   }
 
+  if constexpr (std::is_same_v<Key, key_view>) {
+    return remove_internal_key_view(remove_key);
+  } else {
+    return remove_internal_fixed(remove_key);
+  }
+}
+
+template <typename Key, typename Value>
+bool db<Key, Value>::remove_internal_fixed(art_key_type remove_key) {
   auto* node = &root;
-  tree_depth_type depth{};
   auto remaining_key{remove_key};
 
   while (true) {
@@ -1352,7 +1452,6 @@ bool db<Key, Value>::remove_internal(art_key_type remove_key) {
     if (shared_prefix_len < key_prefix_length) return false;
 
     UNODB_DETAIL_ASSERT(shared_prefix_len == key_prefix_length);
-    depth += key_prefix_length;
     remaining_key.shift_right(key_prefix_length);
 
     const auto remove_result{inode->template remove_or_choose_subtree<
@@ -1364,10 +1463,159 @@ bool db<Key, Value>::remove_internal(art_key_type remove_key) {
     if (child_ptr == nullptr) return true;
 
     node = child_ptr;
-    ++depth;
     remaining_key.shift_right(1);
   }
 }
+
+template <typename Key, typename Value>
+// MSVC C26815 false positive: ptr<>() on local node_ptr values
+UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
+    Key, Value>::remove_internal_key_view(art_key_type remove_key) {
+  struct stack_entry {
+    detail::node_ptr* slot;
+    std::uint8_t child_i;
+  };
+
+  boost::container::small_vector<stack_entry, 32> stack;
+  auto* slot = &root;
+  auto remaining_key{remove_key};
+
+  // --- Downward pass: find the leaf ---
+  while (true) {
+    const auto node_val = *slot;
+    const auto ntype = node_val.type();
+    UNODB_DETAIL_ASSERT(ntype != node_type::LEAF);
+
+    auto* const inode{node_val.template ptr<inode_type*>()};
+    const auto& kp{inode->get_key_prefix()};
+    const auto kp_len{kp.length()};
+    if (kp.get_shared_length(remaining_key) < kp_len) return false;
+    remaining_key.shift_right(kp_len);
+
+    const auto [child_i, child_ptr]{inode->find_child(ntype, remaining_key[0])};
+    if (child_ptr == nullptr) return false;
+
+    const auto child_val{child_ptr->load()};
+    if (child_val.type() != node_type::LEAF) {
+      stack.push_back({slot, child_i});
+      slot = detail::unwrap_fake_critical_section(child_ptr);
+      remaining_key.shift_right(1);
+      continue;
+    }
+
+    // Found a leaf — verify it matches.
+    auto* const leaf{child_val.template ptr<leaf_type*>()};
+    if (!leaf->matches(remove_key)) return false;
+
+    // --- Upward pass ---
+    const auto count = inode->get_children_count();
+
+    if (count > 1 || ntype != node_type::I4) {
+      const auto remove_result
+          UNODB_DETAIL_USED_IN_DEBUG{inode->template remove_or_choose_subtree<
+              std::optional<detail::node_ptr*>>(ntype, remaining_key[0],
+                                                remove_key, *this, slot)};
+      UNODB_DETAIL_ASSERT(remove_result.has_value());
+      UNODB_DETAIL_ASSERT(*remove_result == nullptr);
+      return true;
+    }
+
+    // Single-child inode (chain node).  Reclaim leaf and chain,
+    // then walk up cleaning any further empty chains.
+    {
+      const auto rl{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
+    }
+    {
+      const auto ri{art_policy::make_db_inode_unique_ptr(
+          node_val.template ptr<inode_4*>(), *this)};
+    }
+#ifdef UNODB_DETAIL_WITH_STATS
+    account_shrinking_inode<node_type::I4>();
+#endif
+
+    while (!stack.empty()) {
+      const auto entry = stack.back();
+      stack.pop_back();
+      const auto parent_val = *entry.slot;
+      const auto ptype = parent_val.type();
+      auto* const pinode{parent_val.template ptr<inode_type*>()};
+      const auto pcount = pinode->get_children_count();
+
+      if (pcount == 1 && ptype == node_type::I4) {
+        {
+          const auto ri{art_policy::make_db_inode_unique_ptr(
+              parent_val.template ptr<inode_4*>(), *this)};
+        }
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_shrinking_inode<node_type::I4>();
+#endif
+        continue;
+      }
+
+      if (ptype == node_type::I4 &&
+          pcount == detail::basic_inode_4<art_policy>::min_size) {
+        pinode->remove_child_entry(ptype, entry.child_i);
+        auto* const pi4{parent_val.template ptr<inode_4*>()};
+        const auto remaining_iter = pi4->begin();
+        const auto remaining = pi4->get_child(0);
+        if (remaining.type() != node_type::LEAF) {
+          auto* const remaining_inode{remaining.template ptr<inode_type*>()};
+          const auto child_prefix_len =
+              remaining_inode->get_key_prefix().length();
+          const auto parent_prefix_len = pi4->get_key_prefix().length();
+          if (child_prefix_len + parent_prefix_len + 1 >=
+              detail::key_prefix_capacity) {
+            return true;
+          }
+          remaining_inode->get_key_prefix().prepend(pi4->get_key_prefix(),
+                                                    remaining_iter.key_byte);
+        }
+        *entry.slot = remaining;
+        {
+          const auto ri{art_policy::make_db_inode_unique_ptr(pi4, *this)};
+        }
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_shrinking_inode<node_type::I4>();
+#endif
+      } else if (ptype == node_type::I16 &&
+                 pcount == detail::basic_inode_16<art_policy>::min_size) {
+        auto new_node{inode_4::create(
+            *this, *parent_val.template ptr<detail::inode_16<Key, Value>*>(),
+            entry.child_i)};
+        *entry.slot = detail::node_ptr{new_node.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_shrinking_inode<node_type::I16>();
+#endif
+      } else if (ptype == node_type::I48 &&
+                 pcount == detail::basic_inode_48<art_policy>::min_size) {
+        auto new_node{detail::inode_16<Key, Value>::create(
+            *this, *parent_val.template ptr<detail::inode_48<Key, Value>*>(),
+            entry.child_i)};
+        *entry.slot = detail::node_ptr{new_node.release(), node_type::I16};
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_shrinking_inode<node_type::I48>();
+#endif
+      } else if (ptype == node_type::I256 &&
+                 pcount == detail::basic_inode_256<art_policy>::min_size) {
+        auto new_node{detail::inode_48<Key, Value>::create(
+            *this, *parent_val.template ptr<detail::inode_256<Key, Value>*>(),
+            entry.child_i)};
+        *entry.slot = detail::node_ptr{new_node.release(), node_type::I48};
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_shrinking_inode<node_type::I256>();
+#endif
+      } else {
+        pinode->remove_child_entry(ptype, entry.child_i);
+      }
+      return true;
+    }
+
+    // Stack empty — chain was the root.
+    root = nullptr;
+    return true;
+  }
+}
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 //
 // ART Iterator Implementation

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -236,8 +236,8 @@ class [[nodiscard]] basic_leaf final : public Header {
   /// Dump leaf contents to stream for debugging.
   ///
   /// \param os Output stream
-  [[gnu::cold]]
-  UNODB_DETAIL_NOINLINE void dump(std::ostream& os, bool /*recursive*/) const {
+  [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
+                                                bool /*recursive*/) const {
     os << ", ";
     ::unodb::detail::dump_key(os, get_key_view());
     os << ", ";
@@ -528,6 +528,26 @@ struct basic_art_policy final {
       leaf_type* leaf UNODB_DETAIL_LIFETIMEBOUND,
       db_type& db_instance UNODB_DETAIL_LIFETIMEBOUND) noexcept {
     return leaf_reclaimable_ptr{leaf, LeafReclamator<db_type>{db_instance}};
+  }
+
+  /// Reclaim a child node if it is a leaf; ignore if it is an inode.
+  ///
+  /// Used by shrink constructors where the deleted child may be a
+  /// dead chain inode (already freed) rather than a leaf.  The type
+  /// tag is embedded in the pointer value, so checking type() is safe
+  /// even if the pointed-to memory has been freed.
+  ///
+  /// \param child Tagged node pointer to conditionally reclaim
+  /// \param db_instance Database for memory reclamation
+  /// \return Reclaimable pointer (no-op if child is not a leaf)
+  [[nodiscard]] static auto reclaim_if_leaf(
+      node_ptr child,
+      db_type& db_instance UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+    if (child.type() == node_type::LEAF) {
+      return leaf_reclaimable_ptr{child.template ptr<leaf_type*>(),
+                                  LeafReclamator<db_type>{db_instance}};
+    }
+    return leaf_reclaimable_ptr{nullptr, LeafReclamator<db_type>{db_instance}};
   }
 
   /// Create new internal node.
@@ -830,8 +850,12 @@ union [[nodiscard]] key_prefix_snapshot {
     return f.key_prefix[i];
   }
 
- private:
-  /// Compute shared prefix length between two 64-bit values.
+  /// Compute shared prefix length between two 64-bit key values.
+  ///
+  /// \param k1 First key as u64 (from get_u64)
+  /// \param k2 Second key as u64 (from get_u64)
+  /// \param clamp_byte_pos Maximum prefix length to consider
+  /// \return Number of leading bytes in common (at most \a clamp_byte_pos)
   [[nodiscard, gnu::const]] static constexpr unsigned shared_len(
       std::uint64_t k1, std::uint64_t k2, unsigned clamp_byte_pos) noexcept {
     UNODB_DETAIL_ASSERT(clamp_byte_pos < 8);
@@ -1297,6 +1321,33 @@ class basic_inode_impl : public ArtPolicy::header_type {
     // LCOV_EXCL_STOP
   }
 
+  /// Remove child entry without reclaiming the child, dispatching by type.
+  ///
+  /// \param type Current node type
+  /// \param child_index Child index to remove
+  constexpr void remove_child_entry(node_type type,
+                                    std::uint8_t child_index) noexcept {
+    switch (type) {
+      case node_type::I4:
+        static_cast<inode4_type*>(this)->remove_child_entry(child_index);
+        return;
+      case node_type::I16:
+        static_cast<inode16_type*>(this)->remove_child_entry(child_index);
+        return;
+      case node_type::I48:
+        static_cast<inode48_type*>(this)->remove_child_entry(child_index);
+        return;
+      case node_type::I256:
+        static_cast<inode256_type*>(this)->remove_child_entry(child_index);
+        return;
+        // LCOV_EXCL_START
+      case node_type::LEAF:
+        UNODB_DETAIL_CANNOT_HAPPEN();
+    }
+    UNODB_DETAIL_CANNOT_HAPPEN();
+    // LCOV_EXCL_STOP
+  }
+
   /// Return child node at specified child index.
   ///
   /// \param type Current node type
@@ -1678,6 +1729,23 @@ class [[nodiscard]] basic_inode : public basic_inode_impl<ArtPolicy> {
     // node optimistically in the case of OLC.
     UNODB_DETAIL_ASSERT(is_full_for_add());
   }
+
+  /// Tag type to select the single-child chain constructor.
+  struct single_child_tag {};
+
+  /// Construct single-child node with prefix from two identical keys.
+  ///
+  /// Used to create chain nodes when keys share more than
+  /// key_prefix_capacity bytes. The prefix is computed from the keys
+  /// at the given depth, and children_count is set to 1.
+  ///
+  /// \param k1 First key for prefix computation
+  /// \param shifted_k2 Second key shifted to current depth
+  /// \param depth Current tree depth
+  constexpr basic_inode(unodb::key_view k1, art_key_type shifted_k2,
+                        tree_depth<art_key_type> depth,
+                        single_child_tag) noexcept
+      : parent{1, k1, shifted_k2, depth} {}
 };
 
 /// Type alias for basic_inode_4 parent class.
@@ -1787,6 +1855,27 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     init(db_instance, source_node, child_to_delete);
   }
 
+  /// Construct single-child chain node for long shared prefixes.
+  ///
+  /// Creates an inode_4 with one child, used when two keys share more
+  /// than key_prefix_capacity bytes. The prefix is the first 7 bytes
+  /// of the key at \a depth, and the single child is placed under
+  /// \a key_byte.
+  ///
+  /// \param k1 Key for prefix computation
+  /// \param remaining_key Same key shifted to current depth
+  /// \param depth Current tree depth
+  /// \param key_byte Dispatch byte for the single child
+  /// \param child The single child node
+  constexpr basic_inode_4(db_type&, key_view k1, art_key_type remaining_key,
+                          // cppcheck-suppress passedByValue
+                          tree_depth_type depth, std::byte key_byte,
+                          node_ptr child) noexcept
+      : parent_class{k1, remaining_key, depth,
+                     typename parent_class::single_child_tag{}} {
+    init(key_byte, child);
+  }
+
   /// \}
 
   /// \name Initialization methods
@@ -1836,8 +1925,8 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
       *children_itr++ = *source_children_itr++;
     }
 
-    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        source_children_itr->load().template ptr<leaf_type*>(), db_instance)};
+    const auto r{
+        ArtPolicy::reclaim_if_leaf(source_children_itr->load(), db_instance)};
 
     ++source_keys_itr;
     ++source_children_itr;
@@ -1870,6 +1959,22 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     const auto k1_next_byte_depth = k2_next_byte_depth + depth;
     add_two_to_empty(k1[k1_next_byte_depth], node_ptr{child1, node_type::LEAF},
                      shifted_k2[k2_next_byte_depth], std::move(child2));
+  }
+
+  /// Initialize single-child node.
+  ///
+  /// \param key_byte Dispatch byte for the child
+  /// \param child The single child node
+  constexpr void init(std::byte key_byte, node_ptr child) noexcept {
+    UNODB_DETAIL_ASSERT(this->children_count == 1);
+
+    keys.byte_array[0] = key_byte;
+    children[0] = child;
+#ifndef UNODB_DETAIL_X86_64
+    keys.byte_array[1] = unused_key_byte;
+    keys.byte_array[2] = unused_key_byte;
+    keys.byte_array[3] = unused_key_byte;
+#endif
   }
 
   /// \}
@@ -1930,14 +2035,26 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
   constexpr void remove(std::uint8_t child_index,
                         db_type& db_instance) noexcept {
+    UNODB_DETAIL_ASSERT(child_index < this->children_count.load());
+
+    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
+        children[child_index].load().template ptr<leaf_type*>(), db_instance)};
+
+    remove_child_entry(child_index);
+  }
+
+  /// Remove child entry without reclaiming the child.
+  ///
+  /// Used during upward walk to remove empty chain inodes from their
+  /// parent.  The caller is responsible for reclaiming the child.
+  ///
+  /// \param child_index Index of child to remove
+  constexpr void remove_child_entry(std::uint8_t child_index) noexcept {
     auto children_count_ = this->children_count.load();
 
     UNODB_DETAIL_ASSERT(child_index < children_count_);
     UNODB_DETAIL_ASSERT(std::is_sorted(
         keys.byte_array.cbegin(), keys.byte_array.cbegin() + children_count_));
-
-    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        children[child_index].load().template ptr<leaf_type*>(), db_instance)};
 
     typename decltype(keys.byte_array)::size_type i = child_index;
     for (; i < static_cast<unsigned>(children_count_ - 1); ++i) {
@@ -2484,13 +2601,22 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
   constexpr void remove(std::uint8_t child_index,
                         db_type& db_instance) noexcept {
+    UNODB_DETAIL_ASSERT(child_index < this->children_count.load());
+
+    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
+        children[child_index].load().template ptr<leaf_type*>(), db_instance)};
+
+    remove_child_entry(child_index);
+  }
+
+  /// Remove child entry without reclaiming the child.
+  ///
+  /// \param child_index Index of child to remove
+  constexpr void remove_child_entry(std::uint8_t child_index) noexcept {
     auto children_count_ = this->children_count.load();
     UNODB_DETAIL_ASSERT(child_index < children_count_);
     UNODB_DETAIL_ASSERT(std::is_sorted(
         keys.byte_array.cbegin(), keys.byte_array.cbegin() + children_count_));
-
-    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        children[child_index].load().template ptr<leaf_type*>(), db_instance)};
 
     for (unsigned i = child_index + 1U; i < children_count_; ++i) {
       keys.byte_array[i - 1] = keys.byte_array[i];
@@ -2883,9 +3009,8 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
     const auto reclaim_source_node{
         ArtPolicy::template make_db_inode_reclaimable_ptr<inode256_type>(
             &source_node, db_instance)};
-    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        source_node.children[child_to_delete].load().template ptr<leaf_type*>(),
-        db_instance)};
+    const auto r{ArtPolicy::reclaim_if_leaf(
+        source_node.children[child_to_delete].load(), db_instance)};
 
     source_node.children[child_to_delete] = node_ptr{nullptr};
 
@@ -3043,6 +3168,13 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   constexpr void remove(std::uint8_t child_index,
                         db_type& db_instance) noexcept {
     remove_child_pointer(child_index, db_instance);
+    remove_child_entry(child_index);
+  }
+
+  /// Remove child entry without reclaiming the child.
+  ///
+  /// \param child_index Key byte of child to remove
+  constexpr void remove_child_entry(std::uint8_t child_index) noexcept {
     children.pointer_array[child_indexes[child_index]] = node_ptr{nullptr};
     child_indexes[child_index] = empty_child;
     --this->children_count;
@@ -3286,9 +3418,8 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
                                              db_type& db_instance) noexcept {
     UNODB_DETAIL_ASSERT(children_i != empty_child);
 
-    const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
-        children.pointer_array[children_i].load().template ptr<leaf_type*>(),
-        db_instance)};
+    const auto r{ArtPolicy::reclaim_if_leaf(
+        children.pointer_array[children_i].load(), db_instance)};
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
@@ -3515,6 +3646,13 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
     const auto r{ArtPolicy::reclaim_leaf_on_scope_exit(
         children[child_index].load().template ptr<leaf_type*>(), db_instance)};
 
+    remove_child_entry(child_index);
+  }
+
+  /// Remove child entry without reclaiming the child.
+  ///
+  /// \param child_index Key byte of child to remove
+  constexpr void remove_child_entry(std::uint8_t child_index) noexcept {
     children[child_index] = node_ptr{nullptr};
     --this->children_count;
   }

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -108,7 +108,8 @@ template <unsigned NodeCapacity>
     return 5;
   } else if constexpr (NodeCapacity == 48) {
     return 17;
-  } else if constexpr (NodeCapacity == 256) {
+  } else {
+    static_assert(NodeCapacity == 256);
     return 49;
   }
 }

--- a/fuzz_deepstate/test_art_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_art_fuzz_deepstate.cpp
@@ -36,7 +36,6 @@ using dynamic_value = std::vector<std::byte>;
 using values_type = std::vector<dynamic_value>;
 
 using oracle_type = std::unordered_map<std::uint64_t, unodb::value_view>;
-
 [[nodiscard]] dynamic_value make_random_value(dynamic_value::size_type length) {
   dynamic_value result{length};
   for (dynamic_value::size_type i = 0; i < length; i++) {
@@ -85,7 +84,6 @@ void dump_tree(const unodb::db<std::uint64_t, unodb::value_view>& tree) {
   std::stringstream dump_sink;
   tree.dump(dump_sink);
 }
-
 #ifdef UNODB_DETAIL_WITH_STATS
 
 void assert_unchanged_tree_after_failed_op(
@@ -201,7 +199,8 @@ void op_with_oom_test(oracle_type& oracle, std::vector<std::uint64_t>& keys,
 
 UNODB_START_DEEPSTATE_TESTS()
 
-// NOLINTBEGIN(clang-analyzer-security.ArrayBound)
+// NOLINTBEGIN(clang-analyzer-security.ArrayBound): false positive in
+// DeepState OneOf() template (DeepState.hpp:360), clang-21+.
 TEST(ART, DeepStateFuzz) {
   const auto limit_max_key = DeepState_Bool();
   const auto max_key_value =

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -18,6 +18,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include <boost/container/small_vector.hpp>
+
 #include "art_common.hpp"
 #include "art_internal.hpp"
 #include "art_internal_impl.hpp"
@@ -27,6 +29,7 @@
 #include "portability_arch.hpp"
 #include "qsbr.hpp"
 #include "qsbr_ptr.hpp"
+#include "sync.hpp"
 
 namespace unodb {
 
@@ -34,6 +37,12 @@ template <typename Key, typename Value>
 class olc_db;
 
 namespace detail {
+
+/// Sync point: fires after chain locked, before acquiring cut_point_parent.
+inline sync_point sync_after_chain_locked;
+
+/// Sync point: fires inside Step 2 loop between chain node locks.
+inline sync_point sync_between_chain_locks;
 
 /// OLC ART node header contains an unodb::optimistic_lock object for this node.
 ///
@@ -768,6 +777,9 @@ class olc_db final {
   using header_type = typename art_policy::header_type;
   using inode_type = detail::olc_inode<Key, Value>;
   using inode_4 = detail::olc_inode_4<Key, Value>;
+  using inode_16 = detail::olc_inode_16<Key, Value>;
+  using inode_48 = detail::olc_inode_48<Key, Value>;
+  using inode_256 = detail::olc_inode_256<Key, Value>;
   using tree_depth_type = detail::tree_depth<art_key_type>;
   using visitor_type = visitor<db_type::iterator>;
   using olc_db_leaf_unique_ptr_type =
@@ -781,10 +793,70 @@ class olc_db final {
 
   [[nodiscard]] try_get_result_type try_get(art_key_type k) const noexcept;
 
+  /// Single-attempt insert.
+  ///
+  /// For variable-length keys (key_view) only, two keys may share more than
+  /// key_prefix_capacity (7) bytes at a given depth, causing their dispatch
+  /// bytes to collide.  When this happens, a single-child "chain" I4 node is
+  /// created that consumes 7 prefix bytes + 1 dispatch byte, advancing depth
+  /// by 8.  The insert then restarts from the root.  Subsequent attempts
+  /// descend through the chain and either extend it (if keys still collide)
+  /// or complete a normal two-child split.
   [[nodiscard]] try_update_result_type try_insert(
       art_key_type k, value_type v, olc_db_leaf_unique_ptr_type& cached_leaf);
 
   [[nodiscard]] try_update_result_type try_remove(art_key_type k);
+
+  /// Stack entry for key_view remove traversal.
+  struct remove_entry {
+    detail::olc_node_ptr node;
+    std::uint8_t child_i;  // child index within this node we descended through
+    std::byte key_byte;    // dispatch byte used to descend FROM this node
+    version_tag_type version;
+    in_critical_section<detail::olc_node_ptr>* slot;
+  };
+  using remove_stack_type = boost::container::small_vector<remove_entry, 32>;
+
+  /// Two-pass removal with chain cleanup for variable-length keys.
+  ///
+  /// Pass 1 (downward): traverses from root to the target leaf, building
+  /// a stack of inode entries with cached versions.  Single-child I4
+  /// nodes are identified as chain members.
+  ///
+  /// Pass 2 (upward / chain cut): if the leaf is under a chain, delegates
+  /// to try_chain_cut for atomic disconnection.  Otherwise, uses the
+  /// standard remove_or_choose_subtree path.
+  [[nodiscard]] try_update_result_type try_remove_key_view(art_key_type k);
+
+  /// Atomic chain cut: remove a leaf under a chain of single-child I4 nodes.
+  ///
+  /// Locks the chain bottom-up, then atomically disconnects the entire chain
+  /// from its parent (the "cut point") in a single child-pointer update.
+  /// If a concurrent modification invalidates a chain node during locking,
+  /// the cut point is adjusted downward.  If the cut-point parent's version
+  /// has changed, the operation restarts without modifying the tree.
+  /// After the cut, the cut-point parent is shrunk or collapsed as needed
+  /// to maintain well-formedness (no single-child I4 except during chain
+  /// insert).  Disconnected nodes are reclaimed via QSBR.
+  [[nodiscard]] try_update_result_type try_chain_cut(
+      detail::olc_node_ptr chain_bottom, detail::olc_node_ptr leaf_ptr,
+      optimistic_lock::write_guard parent_guard,
+      optimistic_lock::write_guard chain_bottom_guard,
+      optimistic_lock::write_guard leaf_guard, remove_stack_type& stk,
+      std::size_t stk_n);
+
+  /// Collapse an I4 after removing one of its two children.
+  /// Removes del_ci, checks prefix overflow, and if the merge fits,
+  /// promotes the remaining child into *slot (or root if slot==nullptr).
+  /// Returns true if the I4 was collapsed and reclaimed.
+  [[nodiscard]] bool try_collapse_i4(
+      detail::olc_node_ptr i4_node, std::uint8_t del_ci,
+      in_critical_section<detail::olc_node_ptr>* slot,
+      optimistic_lock::write_guard& guard);
+
+  /// Single-pass removal for fixed-width keys (no chain nodes).
+  [[nodiscard]] try_update_result_type try_remove_fixed_width_key(
+      art_key_type k);
 
   void delete_root_subtree() noexcept;
 
@@ -1567,6 +1639,25 @@ template <typename Key, typename Value, class INode>
         std::move(*child_critical_section)};
     if (UNODB_DETAIL_UNLIKELY(child_guard.must_restart())) return {};
 
+    // For variable-length keys, check leave_last_child precondition:
+    // prefix merge must not overflow key_prefix_capacity.
+    if constexpr (std::is_same_v<Key, key_view>) {
+      const std::uint8_t child_to_leave = (child_i == 0) ? 1U : 0U;
+      const auto remaining = inode.get_child(child_to_leave);
+      if (remaining.type() != node_type::LEAF) {
+        const auto* const ri{
+            remaining
+                .template ptr<detail::olc_inode_base<Key, Value> const*>()};
+        if (ri->get_key_prefix().length() + inode.get_key_prefix().length() +
+                1 >
+            detail::key_prefix_capacity) {
+          child_guard.unlock_and_obsolete();
+          inode.remove(child_i, db_instance);
+          *child_in_parent = nullptr;
+          return true;
+        }
+      }
+    }
     auto current_node{olc_art_policy<Key, Value>::make_db_inode_reclaimable_ptr(
         &inode, db_instance)};
     node_guard.unlock_and_obsolete();
@@ -1837,6 +1928,39 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
         return false;  // exists
       }
 
+      // When the keys share more than key_prefix_capacity bytes at
+      // this depth, the dispatch bytes collide and we cannot create a
+      // two-child inode_4 directly.  Instead, create a single-child
+      // chain inode_4 and restart — the next attempt will descend
+      // through the chain and repeat until the keys diverge.
+      constexpr auto cap = detail::key_prefix_capacity;
+      const auto remaining_existing = existing_key.subspan(depth);
+      const auto shared = detail::key_prefix_snapshot::shared_len(
+          detail::get_u64(remaining_existing), remaining_key.get_u64(), cap);
+      if (shared >= cap && remaining_existing.size() > cap &&
+          remaining_key.size() > cap &&
+          remaining_existing[cap] == remaining_key[cap]) {
+        const auto dispatch = remaining_existing[cap];
+        auto chain{inode_4::create(*this, existing_key, remaining_key, depth,
+                                   dispatch, node)};
+        {
+          const optimistic_lock::write_guard parent_guard{
+              std::move(parent_critical_section)};
+          if (UNODB_DETAIL_UNLIKELY(parent_guard.must_restart())) return {};
+
+          const optimistic_lock::write_guard node_guard{
+              std::move(node_critical_section)};
+          if (UNODB_DETAIL_UNLIKELY(node_guard.must_restart())) return {};
+
+          *node_in_parent =
+              detail::olc_node_ptr{chain.release(), node_type::I4};
+        }
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_growing_inode<node_type::I4>();
+#endif              // UNODB_DETAIL_WITH_STATS
+        return {};  // restart to descend through the new chain node
+      }
+
       create_leaf_if_needed(cached_leaf, k, v, *this);
       auto new_node{inode_4::create(*this, existing_key, remaining_key, depth)};
 
@@ -1939,6 +2063,210 @@ bool olc_db<Key, Value>::remove_internal(art_key_type remove_key) {
 template <typename Key, typename Value>
 typename olc_db<Key, Value>::try_update_result_type
 olc_db<Key, Value>::try_remove(art_key_type k) {
+  if constexpr (std::is_same_v<Key, key_view>) {
+    return try_remove_key_view(k);
+  } else {
+    return try_remove_fixed_width_key(k);
+  }
+}
+
+template <typename Key, typename Value>
+typename olc_db<Key, Value>::try_update_result_type
+olc_db<Key, Value>::try_remove_key_view(art_key_type k) {
+  auto parent_critical_section = root_pointer_lock.try_read_lock();
+  if (UNODB_DETAIL_UNLIKELY(parent_critical_section.must_restart())) {
+    // LCOV_EXCL_START
+    spin_wait_loop_body();
+    return {};
+    // LCOV_EXCL_STOP
+  }
+
+  auto node{root.load()};
+
+  if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.check())) {
+    // LCOV_EXCL_START
+    spin_wait_loop_body();
+    return {};
+    // LCOV_EXCL_STOP
+  }
+
+  if (UNODB_DETAIL_UNLIKELY(node == nullptr)) return false;
+
+  auto node_critical_section = node_ptr_lock(node).try_read_lock();
+  if (UNODB_DETAIL_UNLIKELY(node_critical_section.must_restart())) {
+    // LCOV_EXCL_START
+    spin_wait_loop_body();
+    return {};
+    // LCOV_EXCL_STOP
+  }
+
+  auto node_type = node.type();
+
+  if (node_type == node_type::LEAF) {
+    auto* const leaf{node.template ptr<leaf_type*>()};
+    if (leaf->matches(k)) {
+      const optimistic_lock::write_guard parent_guard{
+          std::move(parent_critical_section)};
+      // Do not call spin_wait_loop_body from this point on - assume
+      // the above took enough time.
+      if (UNODB_DETAIL_UNLIKELY(parent_guard.must_restart())) return {};
+
+      optimistic_lock::write_guard node_guard{std::move(node_critical_section)};
+      if (UNODB_DETAIL_UNLIKELY(node_guard.must_restart())) return {};
+
+      node_guard.unlock_and_obsolete();
+
+      const auto r{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
+      root = detail::olc_node_ptr{nullptr};
+      return true;
+    }
+
+    if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
+      return {};  // LCOV_EXCL_LINE
+
+    return false;
+  }
+
+  auto* node_in_parent{&root};
+  tree_depth_type depth{};
+  auto remaining_key{k};
+
+  remove_stack_type stk;
+  std::size_t stk_n = 0;
+
+  while (true) {
+    UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
+
+    auto* const inode{node.template ptr<inode_type*>()};
+    const auto& key_prefix{inode->get_key_prefix()};
+    const auto key_prefix_length{key_prefix.length()};
+    const auto shared_prefix_length{
+        key_prefix.get_shared_length(remaining_key)};
+
+    if (shared_prefix_length < key_prefix_length) {
+      if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
+        return {};  // LCOV_EXCL_LINE
+      if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
+        return {};  // LCOV_EXCL_LINE
+      return false;
+    }
+
+    UNODB_DETAIL_ASSERT(shared_prefix_length == key_prefix_length);
+    depth += key_prefix_length;
+    remaining_key.shift_right(key_prefix_length);
+
+    // --- Chain I4 detection ---
+    if (node_type == node_type::I4 && inode->get_children_count() == 1) {
+      const auto [ci, cp]{inode->find_child(node_type, remaining_key[0])};
+      if (cp == nullptr) {
+        // LCOV_EXCL_START — single-child I4: if the prefix matched,
+        // the dispatch byte is determined by the shared key bytes, so
+        // find_child always succeeds.  nullptr only via concurrent race.
+        if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
+          return {};
+        if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
+          return {};
+        return false;
+        // LCOV_EXCL_STOP
+      }
+      const auto cv{cp->load()};
+      if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check())) return {};
+
+      if (cv.type() == node_type::LEAF) {
+        // Leaf under chain I4.  Verify match.
+        UNODB_DETAIL_DISABLE_MSVC_WARNING(26462)
+        const auto* const leaf{cv.template ptr<leaf_type*>()};
+        UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+        if (!leaf->matches(k)) {
+          if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
+            return {};  // LCOV_EXCL_LINE
+          if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
+            return {};  // LCOV_EXCL_LINE
+          return false;
+        }
+
+        // Write-lock parent, chain, and leaf.
+        optimistic_lock::write_guard pg{std::move(parent_critical_section)};
+        if (UNODB_DETAIL_UNLIKELY(pg.must_restart())) return {};
+        optimistic_lock::write_guard ng{std::move(node_critical_section)};
+        if (UNODB_DETAIL_UNLIKELY(ng.must_restart())) return {};
+        auto lcs = node_ptr_lock(cv).try_read_lock();
+        if (UNODB_DETAIL_UNLIKELY(lcs.must_restart())) return {};
+        optimistic_lock::write_guard lg{std::move(lcs)};
+        if (UNODB_DETAIL_UNLIKELY(lg.must_restart())) return {};
+
+        // ============================================================
+        return try_chain_cut(node, cv, std::move(pg), std::move(ng),
+                             std::move(lg), stk, stk_n);
+      }
+
+      // Chain child is not a leaf — push and descend.
+      stk.push_back({node, ci, remaining_key[0], node_critical_section.get(),
+                     node_in_parent});
+      ++stk_n;
+
+      auto ccs = node_ptr_lock(cv).try_read_lock();
+      if (UNODB_DETAIL_UNLIKELY(ccs.must_restart())) return {};
+
+      parent_critical_section = std::move(node_critical_section);
+      node = cv;
+      node_in_parent = cp;
+      node_critical_section = std::move(ccs);
+      node_type = cv.type();
+      ++depth;
+      remaining_key.shift_right(1);
+      if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.check())) return {};
+      continue;
+    }
+
+    // --- Non-chain: delegate to existing remove_or_choose_subtree ---
+    // Capture stack entry BEFORE remove_or_choose_subtree consumes
+    // the critical sections (it may move them into write guards).
+    const auto pre_version = node_critical_section.get();
+    const auto pre_key_byte = remaining_key[0];
+    const auto [pre_ci, pre_cp]{inode->find_child(node_type, remaining_key[0])};
+
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26494)
+    in_critical_section<detail::olc_node_ptr>* child_in_parent;
+    enum node_type child_type;
+    detail::olc_node_ptr child;
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+    optimistic_lock::read_critical_section child_critical_section;
+
+    const auto opt_remove_result{
+        inode->template remove_or_choose_subtree<std::optional<bool>>(
+            node_type, remaining_key[0], k, *this, parent_critical_section,
+            node_critical_section, node_in_parent, &child_in_parent,
+            &child_critical_section, &child_type, &child)};
+
+    if (UNODB_DETAIL_UNLIKELY(!opt_remove_result)) return {};
+
+    if (const auto remove_result{*opt_remove_result}; !remove_result)
+      return false;
+
+    if (child_in_parent == nullptr) return true;
+
+    // Push stack entry for the non-chain node we just traversed.
+    if (pre_cp != nullptr) {
+      stk.push_back({node, pre_ci, pre_key_byte, pre_version, node_in_parent});
+      ++stk_n;
+    }
+
+    parent_critical_section = std::move(node_critical_section);
+    node = child;
+    node_in_parent = child_in_parent;
+    node_critical_section = std::move(child_critical_section);
+    node_type = child_type;
+
+    ++depth;
+    remaining_key.shift_right(1);
+  }
+}
+
+template <typename Key, typename Value>
+typename olc_db<Key, Value>::try_update_result_type
+olc_db<Key, Value>::try_remove_fixed_width_key(art_key_type k) {
   auto parent_critical_section = root_pointer_lock.try_read_lock();
   if (UNODB_DETAIL_UNLIKELY(parent_critical_section.must_restart())) {
     // LCOV_EXCL_START
@@ -2019,12 +2347,9 @@ olc_db<Key, Value>::try_remove(art_key_type k) {
     depth += key_prefix_length;
     remaining_key.shift_right(key_prefix_length);
 
-    UNODB_DETAIL_DISABLE_MSVC_WARNING(26494)
-    in_critical_section<detail::olc_node_ptr>* child_in_parent;
-    enum node_type child_type;
-    detail::olc_node_ptr child;
-    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
-
+    in_critical_section<detail::olc_node_ptr>* child_in_parent{nullptr};
+    enum node_type child_type {};
+    detail::olc_node_ptr child{nullptr};
     optimistic_lock::read_critical_section child_critical_section;
 
     const auto opt_remove_result{
@@ -2759,6 +3084,279 @@ void olc_db<Key, Value>::dump() const {
 }
 // LCOV_EXCL_STOP
 
+template <typename Key, typename Value>
+UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
+bool olc_db<Key, Value>::try_collapse_i4(
+    detail::olc_node_ptr i4_node, std::uint8_t del_ci,
+    in_critical_section<detail::olc_node_ptr>* slot,
+    optimistic_lock::write_guard& guard) {
+  auto* const i4{i4_node.template ptr<inode_4*>()};
+  i4->remove_child_entry(del_ci);
+  const auto rem_iter = i4->begin();
+  const auto rem = i4->get_child(0);
+  if (rem.type() != node_type::LEAF) {
+    auto* const ri{rem.template ptr<inode_type*>()};
+    if (ri->get_key_prefix().length() + i4->get_key_prefix().length() + 1 >
+        detail::key_prefix_capacity) {
+      return false;  // prefix overflow — leave as single-child I4
+    }
+    ri->get_key_prefix().prepend(i4->get_key_prefix(), rem_iter.key_byte);
+  }
+  if (slot != nullptr)
+    *slot = rem;
+  else
+    root = rem;
+  guard.unlock_and_obsolete();
+  {
+    const auto r{
+        art_policy::template make_db_inode_reclaimable_ptr<inode_4>(i4, *this)};
+  }
+#ifdef UNODB_DETAIL_WITH_STATS
+  account_shrinking_inode<node_type::I4>();
+#endif
+  return true;
+}
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+template <typename Key, typename Value>
+typename olc_db<Key, Value>::try_update_result_type
+olc_db<Key, Value>::try_chain_cut(
+    detail::olc_node_ptr chain_bottom, detail::olc_node_ptr leaf_ptr,
+    optimistic_lock::write_guard parent_guard,
+    optimistic_lock::write_guard chain_bottom_guard,
+    optimistic_lock::write_guard leaf_guard, remove_stack_type& stk,
+    std::size_t stk_n) {
+  auto* const leaf{leaf_ptr.template ptr<detail::olc_leaf_type<Key, Value>*>()};
+  // Atomic Chain Cut — remove leaf under a single-child chain I4.
+  // Parameters are self-documenting; chain_bottom is NOT on the stack.
+  //
+  // Stack entry semantics (same as iterator):
+  //   stk[i].child_i  = child index within stk[i] for descent
+  //   stk[i].key_byte = dispatch byte used FROM stk[i] to stk[i+1]
+  // ============================================================
+
+  // --- Identify chain_top ---
+  std::size_t chain_top = stk_n;  // = no chain on stack
+  if (stk_n > 0) {
+    const auto& top_e = stk[stk_n - 1];
+    if (top_e.node.type() == node_type::I4 &&
+        top_e.node.template ptr<inode_type*>()->get_children_count() == 1) {
+      chain_top = stk_n - 1;
+      while (chain_top > 0) {
+        const auto& e = stk[chain_top - 1];
+        if (e.node.type() != node_type::I4) break;
+        if (e.node.template ptr<inode_type*>()->get_children_count() != 1)
+          break;
+        --chain_top;
+      }
+    }
+  }
+
+  // --- Step 2: Lock the chain bottom-up ---
+  boost::container::small_vector<optimistic_lock::write_guard, 16> chain_guards;
+  std::size_t cut_level = stk_n;
+
+  if (stk_n > 0 && chain_top < stk_n) {
+    chain_guards.push_back(std::move(parent_guard));
+    cut_level = stk_n - 1;
+    detail::sync(detail::sync_between_chain_locks);
+
+    for (std::size_t i = stk_n - 2; i + 1 > chain_top && i < stk_n; --i) {
+      const auto& entry = stk[i];
+      auto rcs = node_ptr_lock(entry.node).rehydrate_read_lock(entry.version);
+      if (UNODB_DETAIL_UNLIKELY(!rcs.check())) {
+        rcs = node_ptr_lock(entry.node).try_read_lock();
+        if (UNODB_DETAIL_UNLIKELY(rcs.must_restart())) break;
+        const auto etype = entry.node.type();
+        const auto ecount =
+            entry.node.template ptr<inode_type*>()->get_children_count();
+        if (UNODB_DETAIL_UNLIKELY(!rcs.check())) break;
+        if (!(etype == node_type::I4 && ecount == 1)) break;
+      }
+      optimistic_lock::write_guard wg{std::move(rcs)};
+      if (UNODB_DETAIL_UNLIKELY(wg.must_restart())) break;
+      chain_guards.push_back(std::move(wg));
+      cut_level = i;
+    }
+  }
+
+  detail::sync(detail::sync_after_chain_locked);
+
+  // --- Step 3: Acquire the cut_point_parent ---
+  optimistic_lock::write_guard cpp_guard;
+
+  if (chain_top >= stk_n) {
+    cpp_guard = std::move(parent_guard);
+  } else {
+    for (;;) {
+      if (cut_level == 0) {
+        auto rcs = root_pointer_lock.try_read_lock();
+        if (UNODB_DETAIL_UNLIKELY(rcs.must_restart())) return {};
+        cpp_guard = optimistic_lock::write_guard{std::move(rcs)};
+        if (UNODB_DETAIL_UNLIKELY(cpp_guard.must_restart())) return {};
+        break;
+      }
+      const auto& pe = stk[cut_level - 1];
+      auto rcs = node_ptr_lock(pe.node).rehydrate_read_lock(pe.version);
+      if (!rcs.check()) {
+        rcs = node_ptr_lock(pe.node).try_read_lock();
+        if (UNODB_DETAIL_UNLIKELY(rcs.must_restart())) return {};
+      }
+      auto* const pi{pe.node.template ptr<inode_type*>()};
+      const auto ptype = pe.node.type();
+      const auto pcount = pi->get_children_count();
+      const auto [pci, pcp]{pi->find_child(ptype, stk[cut_level - 1].key_byte)};
+      if (UNODB_DETAIL_UNLIKELY(!rcs.check())) continue;
+      if (pcp == nullptr || pcp->load() != stk[cut_level].node)
+        return {};  // Child gone, restart.
+
+      // LCOV_EXCL_START — Case B: a chain_bottom that was multi-child during
+      // the downward pass became single-child due to a concurrent
+      // remove.  Extend the chain by locking it.
+      if (ptype == node_type::I4 && pcount == 1) {
+        optimistic_lock::write_guard wg{std::move(rcs)};
+        if (UNODB_DETAIL_UNLIKELY(wg.must_restart())) continue;
+        chain_guards.push_back(std::move(wg));
+        --cut_level;
+        continue;
+      }
+      // LCOV_EXCL_STOP
+      cpp_guard = optimistic_lock::write_guard{std::move(rcs)};
+      if (UNODB_DETAIL_UNLIKELY(cpp_guard.must_restart())) continue;
+      break;
+    }
+  }
+
+  // --- Step 4.1: Pre-acquire grandparent if shrinkage needed ---
+  const bool cpp_is_root =
+      (cut_level == 0) || (chain_top >= stk_n && stk_n == 0);
+  const std::size_t cpp_idx = cpp_is_root ? 0 : (cut_level - 1);
+
+  bool needs_shrink = false;
+  optimistic_lock::write_guard gp_guard;
+
+  if (!cpp_is_root) {
+    const auto& cpe = stk[cpp_idx];
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26462)
+    auto* const cpi{cpe.node.template ptr<inode_type*>()};
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+    const auto cpt = cpe.node.type();
+    const auto cpc = cpi->get_children_count();
+
+    needs_shrink = (cpt == node_type::I4 && cpc <= 2) ||
+                   (cpt == node_type::I16 &&
+                    cpc == detail::basic_inode_16<art_policy>::min_size) ||
+                   (cpt == node_type::I48 &&
+                    cpc == detail::basic_inode_48<art_policy>::min_size) ||
+                   (cpt == node_type::I256 &&
+                    cpc == detail::basic_inode_256<art_policy>::min_size);
+
+    if (needs_shrink) {
+      if (cpp_idx >= 1) {
+        const auto& gpe = stk[cpp_idx - 1];
+        auto gp_rcs = node_ptr_lock(gpe.node).rehydrate_read_lock(gpe.version);
+        if (UNODB_DETAIL_UNLIKELY(!gp_rcs.check())) return {};
+        gp_guard = optimistic_lock::write_guard{std::move(gp_rcs)};
+        if (UNODB_DETAIL_UNLIKELY(gp_guard.must_restart())) return {};
+      } else {
+        auto rcs = root_pointer_lock.try_read_lock();
+        if (UNODB_DETAIL_UNLIKELY(rcs.must_restart())) return {};
+        gp_guard = optimistic_lock::write_guard{std::move(rcs)};
+        if (UNODB_DETAIL_UNLIKELY(gp_guard.must_restart())) return {};
+      }
+    }
+  }
+
+  // --- Step 4.2: Point of no return — cut and shrink ---
+  if (cpp_is_root) {
+    root = detail::olc_node_ptr{nullptr};
+  } else {
+    const auto& cpe = stk[cpp_idx];
+    auto* const cpi{cpe.node.template ptr<inode_type*>()};
+    const auto cpt = cpe.node.type();
+
+    const std::uint8_t del_ci = (chain_top >= stk_n)
+                                    ? stk[cpp_idx].child_i
+                                    : stk[cut_level - 1].child_i;
+
+    if (!needs_shrink) {
+      cpi->remove_child_entry(cpt, del_ci);
+    } else if (cpt == node_type::I4) {
+      // I4 collapse: remove entry, promote remaining child if
+      // prefix merge fits.
+      auto* slot = (cpp_idx >= 1) ? cpe.slot : nullptr;
+      std::ignore = try_collapse_i4(cpe.node, del_ci, slot, cpp_guard);
+    } else {
+      // I16/I48/I256 shrink via shrink constructors.
+      UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+      detail::olc_node_ptr replacement{};
+      if (cpt == node_type::I16) {
+        auto* const src = cpe.node.template ptr<inode_16*>();
+        auto s{inode_4::create(*this, *src)};
+        s->init(*this, *src, cpp_guard, del_ci, chain_bottom_guard);
+        replacement = detail::olc_node_ptr{s.release(), node_type::I4};
+      } else if (cpt == node_type::I48) {
+        auto* const src = cpe.node.template ptr<inode_48*>();
+        auto s{inode_16::create(*this, *src)};
+        s->init(*this, *src, cpp_guard, del_ci, chain_bottom_guard);
+        replacement = detail::olc_node_ptr{s.release(), node_type::I16};
+      } else {
+        UNODB_DETAIL_ASSERT(cpt == node_type::I256);
+        auto* const src = cpe.node.template ptr<inode_256*>();
+        auto s{inode_48::create(*this, *src)};
+        s->init(*this, *src, cpp_guard, del_ci, chain_bottom_guard);
+        replacement = detail::olc_node_ptr{s.release(), node_type::I48};
+      }
+      UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+      if (cpp_idx >= 1)
+        *cpe.slot = replacement;
+      else
+        root = replacement;
+#ifdef UNODB_DETAIL_WITH_STATS
+      if (cpt == node_type::I16)
+        account_shrinking_inode<node_type::I16>();
+      else if (cpt == node_type::I48)
+        account_shrinking_inode<node_type::I48>();
+      else
+        account_shrinking_inode<node_type::I256>();
+#endif
+    }
+  }
+
+  // --- Step 4.4: Reclaim leaf and chain nodes ---
+  leaf_guard.unlock_and_obsolete();
+  {
+    const auto r{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
+  }
+
+  // chain_bottom_guard may have been consumed by init() in the shrink path.
+  // must_restart() returns true when the guard is inactive (no lock).
+  if (!chain_bottom_guard.must_restart()) {
+    chain_bottom_guard.unlock_and_obsolete();
+  }
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) {
+    const auto r{art_policy::template make_db_inode_reclaimable_ptr<inode_4>(
+        chain_bottom.template ptr<inode_4*>(), *this)};
+  }
+#ifdef UNODB_DETAIL_WITH_STATS
+  account_shrinking_inode<node_type::I4>();
+#endif
+
+  for (std::size_t gi = 0; gi < chain_guards.size(); ++gi) {
+    const std::size_t si = (stk_n - 1) - gi;
+    chain_guards[gi].unlock_and_obsolete();
+    {
+      const auto r{art_policy::template make_db_inode_reclaimable_ptr<inode_4>(
+          stk[si].node.template ptr<inode_4*>(), *this)};
+    }
+#ifdef UNODB_DETAIL_WITH_STATS
+    account_shrinking_inode<node_type::I4>();
+#endif
+  }
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+  return true;
+}
 }  // namespace unodb
 
 #endif  // UNODB_DETAIL_OLC_ART_HPP

--- a/optimistic_lock.hpp
+++ b/optimistic_lock.hpp
@@ -475,6 +475,10 @@ class [[nodiscard]] optimistic_lock final {
 
     /// Move \a other RCS into this one.
     read_critical_section& operator=(read_critical_section&& other) noexcept {
+#ifndef NDEBUG
+      // Release the old RCS if it was still valid.
+      if (lock != nullptr) std::ignore = lock->try_read_unlock(version);
+#endif
       lock = other.lock;
       // The current implementation does not need lock == nullptr in the
       // destructor, thus only reset other.lock in debug builds
@@ -598,6 +602,9 @@ class [[nodiscard]] optimistic_lock final {
     explicit write_guard(read_critical_section&& critical_section) noexcept
         : lock{try_lock_upgrade(std::move(critical_section))} {}
 
+    /// Create an inactive write guard (no lock held).
+    write_guard() noexcept : lock{nullptr} {}
+
     /// Unlock if needed and destruct the write guard.
     ~write_guard() noexcept {
       if (lock == nullptr) return;
@@ -640,9 +647,18 @@ class [[nodiscard]] optimistic_lock final {
 #endif
 
     write_guard(const write_guard&) = delete;
-    write_guard(write_guard&&) = delete;
+    write_guard(write_guard&& other) noexcept : lock{other.lock} {
+      other.lock = nullptr;
+    }
     write_guard& operator=(const write_guard&) = delete;
-    write_guard& operator=(write_guard&&) = delete;
+    write_guard& operator=(write_guard&& other) noexcept {
+      if (this != &other) {
+        if (lock != nullptr) lock->write_unlock();
+        lock = other.lock;
+        other.lock = nullptr;
+      }
+      return *this;
+    }
 
    private:
     /// Attempt to upgrade the underlying lock of \a critical_section to

--- a/sync.hpp
+++ b/sync.hpp
@@ -1,0 +1,48 @@
+// Copyright 2026 UnoDB contributors
+#ifndef UNODB_DETAIL_SYNC_HPP
+#define UNODB_DETAIL_SYNC_HPP
+
+/// \file
+/// Debug-only synchronization points for concurrent algorithm testing.
+///
+/// In Debug builds, sync points allow tests to pause a thread at a
+/// specific point in an algorithm and let another thread act before
+/// continuing.  In Release builds, everything compiles away.
+
+#include "global.hpp"
+
+#ifndef NDEBUG
+#include <functional>
+#endif
+
+namespace unodb::detail {
+
+#ifndef NDEBUG
+
+/// A named synchronization point that tests can arm with a callback.
+/// Tests call arm() before the parallel phase and disarm() after.
+struct sync_point {
+  std::function<void()> hook_;
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
+  void arm(std::function<void()> fn) { hook_ = std::move(fn); }
+  void disarm() noexcept { hook_ = nullptr; }
+  void hit() {
+    if (hook_) hook_();
+  }
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+};
+
+/// Fire a sync point (calls hook if armed).
+inline void sync(sync_point& pt) { pt.hit(); }
+
+#else  // NDEBUG
+
+struct sync_point {};
+
+inline void sync(sync_point&) noexcept {}
+
+#endif  // NDEBUG
+
+}  // namespace unodb::detail
+
+#endif  // UNODB_DETAIL_SYNC_HPP

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -11,7 +11,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <random>
+#include <thread>
 #include <tuple>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -19,8 +21,14 @@
 #include "assert.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
+#include "olc_art.hpp"
 #include "qsbr.hpp"
 #include "qsbr_test_utils.hpp"
+
+#ifndef NDEBUG
+#include "sync.hpp"
+#include "thread_sync.hpp"
+#endif
 
 namespace {
 
@@ -333,5 +341,796 @@ UNODB_TYPED_TEST(ARTConcurrencyTest,
       TestFixture::random_op_thread);
 }
 // LCOV_EXCL_STOP
+
+// ===================================================================
+// Chain concurrency tests for key_view types.
+//
+// These tests exercise the OLC chain insert (single-child inode4
+// creation + restart) and two-pass remove (stack-based upward walk)
+// under concurrent contention.  The existing tests above only use u64
+// keys which cannot trigger chains.
+//
+// Key encoding: encode(uint8_t tag).encode(uint64_t v) = 9 bytes.
+// Keys with the same tag share 8 prefix bytes, triggering chain
+// creation.  Different tags diverge at byte 0 (no chain).
+// ===================================================================
+
+// Helper: encode a 9-byte chain-triggering key into a caller-owned buffer.
+// The returned key_view is valid for the lifetime of `buf`.
+inline unodb::key_view make_chain_key(unodb::key_encoder& enc, std::uint8_t tag,
+                                      std::uint64_t v,
+                                      std::array<std::byte, 9>& buf) {
+  auto kv = enc.reset().encode(tag).encode(v).get_key_view();
+  std::ranges::copy(kv, buf.begin());
+  return {buf.data(), buf.size()};
+}
+
+// Chain concurrency tests reuse ARTConcurrencyTest for QSBR setup and
+// parallel_test.  Thread functions access the db via verifier->get_db().
+template <class Db>
+class ARTChainConcurrencyTest : public ARTConcurrencyTest<Db> {
+ protected:
+  // Thread function: insert/remove chain keys with a fixed tag.
+  static void chain_insert_remove_thread(unodb::test::tree_verifier<Db>* tv,
+                                         std::size_t thread_i,
+                                         std::size_t ops_per_thread) {
+    auto& db = tv->get_db();
+    unodb::key_encoder enc;
+    std::array<std::byte, 9> buf{};
+    constexpr auto tag = static_cast<std::uint8_t>(0x42);
+    const auto val =
+        unodb::test::test_values[thread_i % unodb::test::test_values.size()];
+    for (std::size_t i = 0; i < ops_per_thread; ++i) {
+      const auto v = i;
+      const auto key = make_chain_key(enc, tag, v, buf);
+      if (i % 2 == 0) {
+        std::ignore = db.insert(key, val);
+      } else {
+        if constexpr (unodb::test::is_olc_db<Db>) {
+          const unodb::quiescent_state_on_scope_exit qsbr{};
+          std::ignore = db.remove(key);
+        } else {
+          std::ignore = db.remove(key);
+        }
+      }
+    }
+    if constexpr (unodb::test::is_olc_db<Db>) unodb::this_thread().quiescent();
+  }
+
+  // Thread function: random insert/remove/get on chain keys.
+  static void chain_random_ops_thread(unodb::test::tree_verifier<Db>* tv,
+                                      std::size_t thread_i,
+                                      std::size_t ops_per_thread) {
+    auto& db = tv->get_db();
+    std::random_device rd;
+    std::mt19937 gen{rd()};
+    std::geometric_distribution<std::uint64_t> key_gen{0.05};
+    unodb::key_encoder enc;
+    std::array<std::byte, 9> buf{};
+    constexpr auto tag = static_cast<std::uint8_t>(0x42);
+    constexpr auto ntasks = 3;  // insert / remove / get
+    for (std::size_t i = 0; i < ops_per_thread; ++i) {
+      const auto v = key_gen(gen);
+      const auto key = make_chain_key(enc, tag, v, buf);
+      const auto val =
+          unodb::test::test_values[v % unodb::test::test_values.size()];
+      switch (thread_i % ntasks) {
+        case 0:
+          std::ignore = db.insert(key, val);
+          break;
+        case 1:
+          if constexpr (unodb::test::is_olc_db<Db>) {
+            const unodb::quiescent_state_on_scope_exit qsbr{};
+            std::ignore = db.remove(key);
+          } else {
+            std::ignore = db.remove(key);
+          }
+          break;
+        case 2:
+          if constexpr (unodb::test::is_olc_db<Db>) {
+            const unodb::quiescent_state_on_scope_exit qsbr{};
+            std::ignore = db.get(key);
+          } else {
+            std::ignore = db.get(key);
+          }
+          break;
+          // LCOV_EXCL_START
+        default:
+          UNODB_DETAIL_CANNOT_HAPPEN();
+          // LCOV_EXCL_STOP
+      }
+    }
+    if constexpr (unodb::test::is_olc_db<Db>) unodb::this_thread().quiescent();
+  }
+
+  // Thread function: multi-tag random ops.
+  static void chain_multi_tag_thread(unodb::test::tree_verifier<Db>* tv,
+                                     std::size_t thread_i,
+                                     std::size_t ops_per_thread) {
+    auto& db = tv->get_db();
+    std::random_device rd;
+    std::mt19937 gen{rd()};
+    std::geometric_distribution<std::uint64_t> key_gen{0.1};
+    unodb::key_encoder enc;
+    std::array<std::byte, 9> buf{};
+    const auto tag = static_cast<std::uint8_t>(1 + (thread_i % 4));
+    for (std::size_t i = 0; i < ops_per_thread; ++i) {
+      const auto v = key_gen(gen);
+      const auto key = make_chain_key(enc, tag, v, buf);
+      const auto val =
+          unodb::test::test_values[v % unodb::test::test_values.size()];
+      switch (i % 3) {
+        case 0:
+          std::ignore = db.insert(key, val);
+          break;
+        case 1:
+          if constexpr (unodb::test::is_olc_db<Db>) {
+            const unodb::quiescent_state_on_scope_exit qsbr{};
+            std::ignore = db.remove(key);
+          } else {
+            std::ignore = db.remove(key);
+          }
+          break;
+        case 2:
+          if constexpr (unodb::test::is_olc_db<Db>) {
+            const unodb::quiescent_state_on_scope_exit qsbr{};
+            std::ignore = db.get(key);
+          } else {
+            std::ignore = db.get(key);
+          }
+          break;
+          // LCOV_EXCL_START
+        default:
+          UNODB_DETAIL_CANNOT_HAPPEN();
+          // LCOV_EXCL_STOP
+      }
+    }
+    if constexpr (unodb::test::is_olc_db<Db>) unodb::this_thread().quiescent();
+  }
+};
+
+using ChainConcurrentTypes = ::testing::Types<unodb::test::key_view_mutex_db,
+                                              unodb::test::key_view_olc_db>;
+
+UNODB_TYPED_TEST_SUITE(ARTChainConcurrencyTest, ChainConcurrentTypes)
+
+/// Concurrent insert/remove on chain keys — exercises chain creation
+/// and two-pass removal under contention.
+UNODB_TYPED_TEST(ARTChainConcurrencyTest, ChainInsertRemove) {
+  this->template parallel_test<8, 200>(TestFixture::chain_insert_remove_thread);
+  UNODB_ASSERT_TRUE(this->verifier.get_db().empty() ||
+                    !this->verifier.get_db().empty());  // no crash
+}
+
+/// Concurrent random insert/remove/get on chain keys with geometric
+/// key distribution — hot-spot contention on small v values.
+UNODB_TYPED_TEST(ARTChainConcurrencyTest, ChainRandomOps) {
+  this->template parallel_test<6, 500>(TestFixture::chain_random_ops_thread);
+}
+
+/// Multi-tag concurrent ops — independent chain subtrees with some
+/// cross-tag contention at the root inode.
+UNODB_TYPED_TEST(ARTChainConcurrencyTest, ChainMultiTagOps) {
+  this->template parallel_test<8, 500>(TestFixture::chain_multi_tag_thread);
+}
+
+/// Higher contention stress test (DISABLED for CI, enable manually).
+// LCOV_EXCL_START
+UNODB_TYPED_TEST(ARTChainConcurrencyTest, DISABLED_ChainStressTest) {
+  this->template parallel_test<12, 10'000>(
+      TestFixture::chain_random_ops_thread);
+}
+// LCOV_EXCL_STOP
+
+// ===================================================================
+// Dangling chain bug test.
+//
+// Tests that the two-pass remove correctly handles the case where
+// chain nodes are reclaimed during the upward walk but a concurrent
+// modification to a higher ancestor causes a version mismatch.
+//
+// Setup: Parent-I4 with a 2-level chain subtree + a sibling leaf.
+//   Parent-I4 → [tag1: Chain-head → Chain-tail → Leaf(target),
+//                 tag2: Leaf(sibling)]
+//
+// The test uses sync_point to pause T1 after it has obsoleted
+// the chain head but before it processes the parent.  T2 then
+// modifies the parent (inserts a new sibling), causing T1's version
+// check to fail on restart.
+//
+// Bug: T1 loops forever because Parent-I4 still points to the
+// obsoleted chain head.
+// Fix: T1 must handle the dangling chain correctly.
+// ===================================================================
+
+#ifndef NDEBUG
+
+// ===================================================================
+// Concurrent chain cut tests with explicit interleavings.
+// Uses thread_syncs (condition variables) for coordination.
+//
+// Key constraint: T2 must only access nodes that T1 does NOT hold
+// write guards on at the sync point.
+//
+// At SP1 (sync_after_chain_locked): T1 holds chain_bottom (ng),
+//   all chain nodes on stack (chain_guards), and leaf (lg).
+//   The cut_point_parent is NOT locked.
+//
+// At SP2 (sync_between_chain_locks): T1 holds chain_bottom (ng),
+//   stk[stk_n-1] (chain_guards[0]), and leaf (lg).
+//   All other stack entries are NOT locked.
+//
+// Tree setup uses 26-byte keys (CT1/CT3, 3 chain levels) or 34-byte
+// keys (CT2/CT4, 4 chain levels) to ensure enough chain depth that
+// pg locks a deep chain node, not the cut_point_parent.
+// ===================================================================
+
+struct sync_point_guard {
+  unodb::detail::sync_point* pt_;
+  explicit sync_point_guard(unodb::detail::sync_point& pt) noexcept
+      : pt_{&pt} {}
+  ~sync_point_guard() { pt_->disarm(); }
+  sync_point_guard(const sync_point_guard&) = delete;
+  sync_point_guard& operator=(const sync_point_guard&) = delete;
+  sync_point_guard(sync_point_guard&&) = delete;
+  sync_point_guard& operator=(sync_point_guard&&) = delete;
+};
+
+// CT1: T1 removes A (chain cut).  T2 inserts a sibling into the
+// cut_point_parent (Root-I4) between Step 2 and Step 3.
+UNODB_TEST(OLCChainCutInterleaved, ConcurrentInsertIntoCutPointParent) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  // 26-byte keys: tag(1) + 3×uint64(24) + bottom(1).
+  // A,B share 25 bytes → 3 chain levels after removing B.
+  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0})
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  std::array<std::byte, 26> buf_a{};
+  std::array<std::byte, 26> buf_b{};
+  std::array<std::byte, 26> buf_sib{};
+  std::array<std::byte, 26> buf_new{};
+  auto copy_key = [](const unodb::key_view kv, auto& buf) {
+    std::ranges::copy(kv, buf.begin());
+    return unodb::key_view{buf.data(), buf.size()};
+  };
+  const auto key_a = copy_key(make26(0x10, 0x01), buf_a);
+  const auto key_b = copy_key(make26(0x10, 0x02), buf_b);
+  const auto sib = copy_key(make26(0x20, 0x01), buf_sib);
+  const auto new_key = copy_key(make26(0x30, 0x01), buf_new);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val));
+  UNODB_ASSERT_TRUE(db.insert(sib, val));
+  {
+    const unodb::quiescent_state_on_scope_exit q{};
+    UNODB_ASSERT_TRUE(db.remove(key_b));
+  }
+
+  // Arm SP1 AFTER setup remove.
+  const sync_point_guard guard{unodb::detail::sync_after_chain_locked};
+  unodb::detail::sync_after_chain_locked.arm([&]() {
+    unodb::detail::thread_syncs[0].notify();
+    unodb::detail::thread_syncs[1].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  // Spawn T2 first so it's registered with QSBR before T1 starts.
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[0].wait();
+    const unodb::quiescent_state_on_scope_exit q{};
+    // Insert at root level — Root-I4 is NOT locked by T1 at SP1.
+    std::ignore = db.insert(new_key, val);
+    unodb::detail::thread_syncs[1].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  const unodb::quiescent_state_on_scope_exit q{};
+  UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+  UNODB_ASSERT_TRUE(db.get(sib).has_value());
+  UNODB_ASSERT_TRUE(db.get(new_key).has_value());
+}
+
+// CT2: T1 removes A (chain cut).  T2 inserts a key that modifies
+// chain[0] (splits its prefix) between the first and second chain
+// lock in Step 2.
+UNODB_TEST(OLCChainCutInterleaved, ConcurrentInsertIntoMidChain) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  // 34-byte keys: tag(1) + 4×uint64(32) + bottom(1).
+  // A,B share 33 bytes → 4 chain levels after removing B.
+  // At SP2: T1 holds chain[2] (stk[3]) + chain_bottom + leaf.
+  // chain[0], chain[1], Root-I4 are all unlocked.
+  // T2 targets chain[0] (different v1) — only needs Root-I4 + chain[0].
+  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
+  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
+
+  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(v1)
+        .encode(X)
+        .encode(X)
+        .encode(X)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  std::array<std::byte, 34> buf_a{};
+  std::array<std::byte, 34> buf_b{};
+  std::array<std::byte, 34> buf_sib{};
+  std::array<std::byte, 34> buf_t2{};
+  auto copy_key = [](const unodb::key_view kv, auto& buf) {
+    std::ranges::copy(kv, buf.begin());
+    return unodb::key_view{buf.data(), buf.size()};
+  };
+  const auto key_a = copy_key(make34(0x10, X, 0x01), buf_a);
+  const auto key_b = copy_key(make34(0x10, X, 0x02), buf_b);
+  const auto sib = copy_key(make34(0x20, X, 0x01), buf_sib);
+  const auto t2_key = copy_key(make34(0x10, Z, 0x01), buf_t2);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val));
+  UNODB_ASSERT_TRUE(db.insert(sib, val));
+  {
+    const unodb::quiescent_state_on_scope_exit q{};
+    UNODB_ASSERT_TRUE(db.remove(key_b));
+  }
+
+  // Arm SP2 AFTER setup remove.
+  const sync_point_guard guard{unodb::detail::sync_between_chain_locks};
+  unodb::detail::sync_between_chain_locks.arm([&]() {
+    unodb::detail::sync_between_chain_locks.disarm();  // fire only once
+    unodb::detail::thread_syncs[2].notify();
+    unodb::detail::thread_syncs[3].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[2].wait();
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.insert(t2_key, val);
+    unodb::detail::thread_syncs[3].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  const unodb::quiescent_state_on_scope_exit q{};
+  UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+  UNODB_ASSERT_TRUE(db.get(sib).has_value());
+  UNODB_ASSERT_TRUE(db.get(t2_key).has_value());
+}
+
+// CT3: T1 removes A (chain cut).  T2 removes the sibling.
+UNODB_TEST(OLCChainCutInterleaved, ConcurrentRemoveOfSibling) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0})
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  std::array<std::byte, 26> buf_a{};
+  std::array<std::byte, 26> buf_b{};
+  auto copy_key = [](const unodb::key_view kv, auto& buf) {
+    std::ranges::copy(kv, buf.begin());
+    return unodb::key_view{buf.data(), buf.size()};
+  };
+  const auto key_a = copy_key(make26(0x10, 0x01), buf_a);
+  const auto key_b = copy_key(make26(0x10, 0x02), buf_b);
+  // Use a short (1-byte) sibling so that when T2 removes it, the
+  // Root-I4 goes to 1 child but prefix merge overflows (0+1+7 > 7),
+  // preventing collapse.  Root-I4 stays alive with a new version.
+  std::array<std::byte, 1> buf_sib{};
+  const auto sib =
+      copy_key(enc.reset().encode(std::uint8_t{0x20}).get_key_view(), buf_sib);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val));
+  UNODB_ASSERT_TRUE(db.insert(sib, val));
+  {
+    const unodb::quiescent_state_on_scope_exit q{};
+    UNODB_ASSERT_TRUE(db.remove(key_b));
+  }
+
+  const sync_point_guard guard{unodb::detail::sync_after_chain_locked};
+  unodb::detail::sync_after_chain_locked.arm([&]() {
+    unodb::detail::sync_after_chain_locked.disarm();  // one-shot
+    unodb::detail::thread_syncs[0].notify();
+    unodb::detail::thread_syncs[1].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[0].wait();
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(sib);
+    unodb::detail::thread_syncs[1].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  const unodb::quiescent_state_on_scope_exit q{};
+  UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+  UNODB_ASSERT_FALSE(db.get(sib).has_value());
+  UNODB_ASSERT_TRUE(db.empty());
+}
+
+// CT4: ABA on chain node.  T2 inserts then removes a key that
+// modifies chain[0]'s version but restores it to single-child.
+UNODB_TEST(OLCChainCutInterleaved, ABAOnChainNode) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
+  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
+
+  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(v1)
+        .encode(X)
+        .encode(X)
+        .encode(X)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  std::array<std::byte, 34> buf_a{};
+  std::array<std::byte, 34> buf_b{};
+  std::array<std::byte, 34> buf_sib{};
+  std::array<std::byte, 34> buf_t2{};
+  auto copy_key = [](const unodb::key_view kv, auto& buf) {
+    std::ranges::copy(kv, buf.begin());
+    return unodb::key_view{buf.data(), buf.size()};
+  };
+  const auto key_a = copy_key(make34(0x10, X, 0x01), buf_a);
+  const auto key_b = copy_key(make34(0x10, X, 0x02), buf_b);
+  const auto sib = copy_key(make34(0x20, X, 0x01), buf_sib);
+  const auto t2_key = copy_key(make34(0x10, Z, 0x01), buf_t2);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val));
+  UNODB_ASSERT_TRUE(db.insert(sib, val));
+  {
+    const unodb::quiescent_state_on_scope_exit q{};
+    UNODB_ASSERT_TRUE(db.remove(key_b));
+  }
+
+  const sync_point_guard guard{unodb::detail::sync_between_chain_locks};
+  unodb::detail::sync_between_chain_locks.arm([&]() {
+    unodb::detail::sync_between_chain_locks.disarm();  // fire only once
+    unodb::detail::thread_syncs[4].notify();
+    unodb::detail::thread_syncs[5].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[4].wait();
+    {
+      const unodb::quiescent_state_on_scope_exit q{};
+      std::ignore = db.insert(t2_key, val);
+    }
+    {
+      const unodb::quiescent_state_on_scope_exit q{};
+      std::ignore = db.remove(t2_key);
+    }
+    unodb::detail::thread_syncs[5].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  const unodb::quiescent_state_on_scope_exit q{};
+  UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+  UNODB_ASSERT_TRUE(db.get(sib).has_value());
+  UNODB_ASSERT_FALSE(db.get(t2_key).has_value());
+}
+
+#endif  // NDEBUG
+
+// ===================================================================
+// Concurrent chain cut stress tests (no sync points).
+// ===================================================================
+
+// CT5: Two threads removing last two keys under same chain.
+UNODB_TEST(OLCChainCutStress, TwoRemoversFromChain) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  for (int iter = 0; iter < 200; ++iter) {
+    db_type db;
+    unodb::key_encoder enc;
+    std::array<std::byte, 9> buf_a{};
+    std::array<std::byte, 9> buf_b{};
+    std::array<std::byte, 9> buf_sib{};
+
+    const auto key_a = make_chain_key(enc, 0x10, 1, buf_a);
+    const auto key_b = make_chain_key(enc, 0x10, 2, buf_b);
+    const auto sibling = make_chain_key(enc, 0x20, 1, buf_sib);
+
+    UNODB_ASSERT_TRUE(db.insert(key_a, val));
+    UNODB_ASSERT_TRUE(db.insert(key_b, val));
+    UNODB_ASSERT_TRUE(db.insert(sibling, val));
+
+    unodb::this_thread().qsbr_pause();
+
+    auto t1 = unodb::qsbr_thread([&] {
+      const unodb::quiescent_state_on_scope_exit q{};
+      std::ignore = db.remove(key_a);
+    });
+    auto t2 = unodb::qsbr_thread([&] {
+      const unodb::quiescent_state_on_scope_exit q{};
+      std::ignore = db.remove(key_b);
+    });
+    t1.join();
+    t2.join();
+    unodb::this_thread().qsbr_resume();
+    unodb::this_thread().quiescent();
+
+    const unodb::quiescent_state_on_scope_exit q{};
+    UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+    UNODB_ASSERT_FALSE(db.get(key_b).has_value());
+    UNODB_ASSERT_TRUE(db.get(sibling).has_value());
+  }
+}
+
+// CT6: Multiple threads doing insert/remove on chain-triggering keys.
+UNODB_TEST(OLCChainCutStress, InsertRemoveMix) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  for (int iter = 0; iter < 100; ++iter) {
+    db_type db;
+
+    // Pre-insert some keys so the tree has chain structure.
+    {
+      unodb::key_encoder enc;
+      UNODB_DETAIL_DISABLE_MSVC_WARNING(26496)
+      std::array<std::byte, 9> buf{};
+      UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+      for (std::uint64_t i = 1; i <= 4; ++i) {
+        UNODB_ASSERT_TRUE(db.insert(make_chain_key(enc, 0x10, i, buf), val));
+        UNODB_ASSERT_TRUE(db.insert(make_chain_key(enc, 0x20, i, buf), val));
+      }
+    }
+
+    unodb::this_thread().qsbr_pause();
+
+    // T1: remove keys from tag=0x10.
+    auto t1 = unodb::qsbr_thread([&] {
+      unodb::key_encoder enc;
+      std::array<std::byte, 9> buf{};
+      for (std::uint64_t i = 1; i <= 4; ++i) {
+        const unodb::quiescent_state_on_scope_exit q{};
+        std::ignore = db.remove(make_chain_key(enc, 0x10, i, buf));
+      }
+    });
+    // T2: remove keys from tag=0x20.
+    auto t2 = unodb::qsbr_thread([&] {
+      unodb::key_encoder enc;
+      std::array<std::byte, 9> buf{};
+      for (std::uint64_t i = 1; i <= 4; ++i) {
+        const unodb::quiescent_state_on_scope_exit q{};
+        std::ignore = db.remove(make_chain_key(enc, 0x20, i, buf));
+      }
+    });
+    // T3: insert new keys concurrently.
+    auto t3 = unodb::qsbr_thread([&] {
+      unodb::key_encoder enc;
+      std::array<std::byte, 9> buf{};
+      for (std::uint64_t i = 1; i <= 4; ++i) {
+        const unodb::quiescent_state_on_scope_exit q{};
+        std::ignore = db.insert(make_chain_key(enc, 0x30, i, buf), val);
+      }
+    });
+
+    t1.join();
+    t2.join();
+    t3.join();
+    unodb::this_thread().qsbr_resume();
+    unodb::this_thread().quiescent();
+
+    // All tag=0x10 and tag=0x20 keys removed. tag=0x30 keys inserted.
+    const unodb::quiescent_state_on_scope_exit q{};
+    unodb::key_encoder enc;
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26496)
+    std::array<std::byte, 9> buf{};
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+    for (std::uint64_t i = 1; i <= 4; ++i) {
+      UNODB_ASSERT_FALSE(db.get(make_chain_key(enc, 0x10, i, buf)).has_value());
+      UNODB_ASSERT_FALSE(db.get(make_chain_key(enc, 0x20, i, buf)).has_value());
+      UNODB_ASSERT_TRUE(db.get(make_chain_key(enc, 0x30, i, buf)).has_value());
+    }
+  }
+}
+
+// ===================================================================
+// CT6: Deep chain stress test — 8 chain levels, N threads.
+// ===================================================================
+
+void deep_chain_stress(int n_threads, int ops_per_thread, int iterations) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  constexpr int chain_depth = 8;
+  constexpr int chain_variants = 32;
+  constexpr int short_count = 8;
+  constexpr std::size_t chain_key_len = 1 + (chain_depth * 8) + 1;
+  constexpr std::size_t short_key_len = 1;
+
+  auto make_deep_key = [](unodb::key_encoder& enc, std::uint8_t variant,
+                          std::array<std::byte, chain_key_len>& buf) {
+    enc.reset().encode(std::uint8_t{0x42});
+    for (int d = 0; d < chain_depth; ++d) enc.encode(std::uint64_t{0});
+    enc.encode(variant);
+    auto kv = enc.get_key_view();
+    std::ranges::copy(kv, buf.begin());
+    return unodb::key_view{buf.data(), buf.size()};
+  };
+
+  auto make_short = [](unodb::key_encoder& enc, std::uint8_t tag,
+                       std::array<std::byte, short_key_len>& buf) {
+    auto kv = enc.reset().encode(tag).get_key_view();
+    std::ranges::copy(kv, buf.begin());
+    return unodb::key_view{buf.data(), buf.size()};
+  };
+
+  for (int iter = 0; iter < iterations; ++iter) {
+    db_type db;
+    unodb::key_encoder enc;
+
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26496)
+    std::array<std::array<std::byte, chain_key_len>, 4> ck_bufs{};
+    for (std::size_t v = 1; v <= 4; ++v)
+      UNODB_ASSERT_TRUE(db.insert(
+          make_deep_key(enc, static_cast<std::uint8_t>(v), ck_bufs[v - 1]),
+          val));
+    std::array<std::array<std::byte, short_key_len>, short_count> sk_bufs{};
+    for (std::size_t t = 1; t <= short_count; ++t)
+      UNODB_ASSERT_TRUE(db.insert(
+          make_short(enc, static_cast<std::uint8_t>(t), sk_bufs[t - 1]), val));
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+    unodb::this_thread().qsbr_pause();
+
+    std::vector<unodb::qsbr_thread> threads;
+    threads.reserve(static_cast<std::size_t>(n_threads));
+    for (int ti = 0; ti < n_threads; ++ti) {
+      threads.emplace_back([&, ti] {
+        unodb::key_encoder e;
+        std::minstd_rand rng{static_cast<unsigned>((ti * 1000) + iter)};
+        for (int op = 0; op < ops_per_thread; ++op) {
+          const unodb::quiescent_state_on_scope_exit q{};
+          const auto r = rng() % 6;
+          if (r < 2) {
+            const auto v =
+                static_cast<std::uint8_t>(1 + (rng() % chain_variants));
+            std::array<std::byte, chain_key_len> buf{};
+            std::ignore = db.insert(make_deep_key(e, v, buf), val);
+          } else if (r < 4) {
+            const auto v =
+                static_cast<std::uint8_t>(1 + (rng() % chain_variants));
+            std::array<std::byte, chain_key_len> buf{};
+            std::ignore = db.remove(make_deep_key(e, v, buf));
+          } else if (r == 4) {
+            if (rng() % 2 == 0) {
+              const auto v =
+                  static_cast<std::uint8_t>(1 + (rng() % chain_variants));
+              std::array<std::byte, chain_key_len> buf{};
+              std::ignore = db.get(make_deep_key(e, v, buf));
+            } else {
+              const auto t =
+                  static_cast<std::uint8_t>(1 + (rng() % short_count));
+              std::array<std::byte, short_key_len> buf{};
+              std::ignore = db.get(make_short(e, t, buf));
+            }
+          } else {
+            const auto t = static_cast<std::uint8_t>(1 + (rng() % short_count));
+            std::array<std::byte, short_key_len> buf{};
+            if (rng() % 2 == 0)
+              std::ignore = db.insert(make_short(e, t, buf), val);
+            else
+              std::ignore = db.remove(make_short(e, t, buf));
+          }
+        }
+      });
+    }
+    for (auto& t : threads) t.join();
+
+    unodb::this_thread().qsbr_resume();
+    unodb::this_thread().quiescent();
+
+    const unodb::quiescent_state_on_scope_exit q{};
+    for (std::uint8_t v = 1; v <= chain_variants; ++v) {
+      std::array<std::byte, chain_key_len> buf{};
+      std::ignore = db.remove(make_deep_key(enc, v, buf));
+    }
+    for (std::uint8_t t = 1; t <= short_count; ++t) {
+      std::array<std::byte, short_key_len> buf{};
+      std::ignore = db.remove(make_short(enc, t, buf));
+    }
+    UNODB_ASSERT_TRUE(db.empty());
+  }
+}
+
+// Default: 4 threads, 1000 ops, 10 iterations.
+UNODB_TEST(OLCChainCut, DeepChainStress) { deep_chain_stress(4, 1000, 10); }
+
+// Heavy: all cores, 100k ops, 10 iterations.  DISABLED by default.
+UNODB_TEST(OLCChainCut, DISABLED_DeepChainStressHeavy) {
+  const int cores = static_cast<int>(std::thread::hardware_concurrency());
+  deep_chain_stress(cores, 100000, 10);
+}
 
 }  // namespace

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -73,4 +73,1532 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, EncodedTextKeys) {
   verifier.check_present_values();  // checks keys and key ordering.
 }
 
+// ===================================================================
+// key_view tests for the dispatch byte collision bug.
+//
+// key_prefix_capacity is 7 bytes.  When two key_view keys share more
+// than 7 bytes of common prefix, the leaf-to-inode4 split must create
+// a chain of internal nodes rather than a single inode4, because the
+// dispatch byte (the byte immediately after the stored prefix) is the
+// same for both keys.
+//
+// Keys are 9 bytes: (uint8_t tag, uint64_t value).  Same tag + small
+// values → 8 shared bytes, triggering the bug.  10-byte keys
+// (uint8_t tag, uint64_t value, uint8_t suffix) are used for
+// mixed-length tests.  Both lengths exceed key_prefix_capacity + 1.
+//
+// Test plan groups:
+//   0. Bug reproduction — minimal cases
+//   1. Prefix boundary cases — validate various shared-prefix lengths
+//   2. Node growth — inode4 -> inode16 -> inode48 -> inode256
+//   3. Removal & shrinkage — chained inodes collapse correctly
+//   4. Mixed key lengths — different-length keys with long shared prefix
+//   5. Duplicate & edge cases — duplicate insert, get-missing
+//   6. Stats verification — node counts at intermediate states
+//     6a. Insert stats — verify chain structure after insert
+//     6b. Partial remove — bottom inode shrinks, chain preserved
+//         I16→I4, I48→I16, I256→I48
+//     6c. Full remove — remove all keys through each bottom inode size
+//         I4, I16, I48, I256
+//     6d. Cascade — chain under parent at min_size, removing chain
+//         triggers parent shrinkage: I4→leaf, I16→I4, I48→I16, I256→I48
+//     6e. Multi-level chain — 17-byte keys, 2 chain levels
+// ===================================================================
+
+// Helper: encode a 9-byte key (uint8 + uint64).
+// Same tag byte → 8 shared bytes when uint64 values are small.
+inline unodb::key_view make_key(unodb::key_encoder& enc, std::uint8_t tag,
+                                std::uint64_t v) {
+  return enc.reset().encode(tag).encode(v).get_key_view();
+}
+
+// Helper: encode a 1-byte key (uint8 only).
+// Diverges at byte 0 from any key with a different first byte.
+// Used in cascade tests where we need direct-leaf children of the root
+// alongside a chain subtree.
+[[maybe_unused]] inline unodb::key_view make_short_key(unodb::key_encoder& enc,
+                                                       std::uint8_t tag) {
+  return enc.reset().encode(tag).get_key_view();
+}
+
+// Helper: encode a 10-byte key (uint8 + uint64 + uint8).
+// When used with the same tag and v as make_key, the 9-byte key is a
+// prefix of this 10-byte key — which ART does not support.  Use
+// different v values to avoid prefix relationships.
+// Both lengths (9 and 10) exceed key_prefix_capacity + 1 = 8.
+inline unodb::key_view make_long_key(unodb::key_encoder& enc, std::uint8_t tag,
+                                     std::uint64_t v, std::uint8_t suffix) {
+  return enc.reset().encode(tag).encode(v).encode(suffix).get_key_view();
+}
+
+// -------------------------------------------------------------------
+// Group 0: Original bug reproduction tests
+// -------------------------------------------------------------------
+
+/// Two 9-byte keys sharing 8 bytes — dispatch byte collision.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysLongSharedPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 (prefix=7, 1 child) + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Three keys with the same tag byte and small uint64 values.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ThreeCompoundKeysLongSharedPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + bottom I4 (3 children) + 3 leaves
+  verifier.assert_node_counts({3, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// 9-byte keys sharing 8 bytes — minimal collision case.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, NineByteCompoundKeysLongPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 1: Prefix boundary cases
+// -------------------------------------------------------------------
+
+/// Keys identical except last byte — maximum chaining depth for 9-byte keys.
+/// 9-byte keys sharing 8 bytes, differing only at byte 8.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
+                 CompoundKeysIdenticalExceptLastByte) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.insert(make_key(enc, 0x42, 4), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + bottom I4 (4 children, at capacity) + 4 leaves
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Two 17-byte keys sharing 16 bytes — forces two consecutive chain
+/// nodes (depth 0→8 and depth 8→16) before the normal 2-child split.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // 17 bytes: 0xAA × 16, then 0x01 vs 0x02.
+  auto make17 = [&](std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+  verifier.insert(make17(0x01), val);
+  verifier.insert(make17(0x02), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // 2 chain I4s (depth 0→8, 8→16) + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 3, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Three 17-byte keys: A and B share 16 bytes, C diverges at byte 10.
+/// After inserting A and B (two chain levels), inserting C splits the
+/// second chain node mid-prefix.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
+                 InsertDivergingAtIntermediateChainDepth) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make17 = [&](std::uint8_t byte10, std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 10; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(byte10);
+    for (unsigned i = 11; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+  // A and B share 16 bytes (byte10=0xAA), differ at byte 16.
+  verifier.insert(make17(0xAA, 0x01), val);
+  verifier.insert(make17(0xAA, 0x02), val);
+  // C diverges at byte 10 — splits the second chain node.
+  verifier.insert(make17(0xBB, 0x03), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 (bytes 0-7) + split I4 (at byte 10) + chain I4 (bytes 11-15)
+  // + bottom I4 (A,B) + 3 leaves
+  verifier.assert_node_counts({3, 4, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 2: Node growth (inode4 -> inode16 -> inode48 -> inode256)
+// -------------------------------------------------------------------
+
+/// 5 keys with same 8-byte prefix — forces inode4 -> inode16 growth.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysFiveChildren) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + I16 (5 children) + 5 leaves
+  verifier.assert_node_counts({5, 1, 1, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// 17 keys — forces inode16 -> inode48 growth.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysSeventeenChildren) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 17; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + I48 (17 children) + 17 leaves
+  verifier.assert_node_counts({17, 1, 0, 1, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// 50 keys — forces inode48 -> inode256 growth.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysFiftyChildren) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 50; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + I256 (50 children) + 50 leaves
+  verifier.assert_node_counts({50, 1, 0, 0, 1});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 3: Removal & shrinkage
+// -------------------------------------------------------------------
+
+// Group 3a: Chain collapse scenarios
+
+/// Insert 2 colliding keys, remove one, verify the other is still found.
+/// The chain of inode_4s should collapse to a single leaf.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysInsertThenRemove) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Bottom I4 collapsed via leave_last_child.  Chain I4 remains with
+  // 1 child (the surviving leaf).
+  verifier.assert_node_counts({1, 1, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 3 keys: two sharing 8 bytes, one diverging earlier.
+/// Remove one of the 8-byte-shared pair.  The surviving structure
+/// should be an inode with 2 children (the remaining keys).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveFromChainLeavesInode) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Keys 1 and 2 share 8 bytes; key 3 diverges at byte 5.
+  // key3 uint64 = 0x0000000100000000 differs at byte 5 (overall).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 0x0000000100000000ULL), val);
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Root I4 (2 children: key3 leaf + chain) + chain I4 + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 3 colliding keys, remove in reverse order, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveAllFromChainReverseOrder) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.remove(make_key(enc, 0x42, 3));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.assert_empty();
+}
+
+/// Insert 3 colliding keys, remove in forward order, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveAllFromChainForwardOrder) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.remove(make_key(enc, 0x42, 3));
+  verifier.assert_empty();
+}
+
+// Group 3b: Shrinkage at chain terminal
+
+/// Insert 5 keys (-> inode16 at chain terminal), remove 3 (-> inode4).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkInode16InChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.remove(make_key(enc, 0x42, 3));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // I16(5) shrinks to I4(4) on first remove, then 2 more removes → I4(2).
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 17 keys (-> inode48), remove 13 (-> shrink to inode4).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkInode48InChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 17; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  for (std::uint64_t i = 1; i <= 13; ++i) {
+    verifier.remove(make_key(enc, 0x42, i));
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // I48(17) shrinks to I16(16) on first remove, then I16(5) shrinks
+  // to I4(4) on 13th remove.
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 5 keys (-> inode16), remove all 5, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkToEmptyFromInode16InChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.remove(make_key(enc, 0x42, i));
+  }
+  verifier.assert_empty();
+}
+
+// Group 3c: Mixed-depth removal
+
+/// Insert a 10-byte and 9-byte key sharing 8 bytes (same tag, different
+/// uint64 values).  Remove the 10-byte key, verify 9-byte key.  Then
+/// remove it too, assert empty.
+///
+/// Note: the two keys must NOT be in a prefix relationship — ART does
+/// not support one key being a prefix of another.  Using different
+/// uint64 values ensures they diverge within the shared bytes.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveMixedLengthFromChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_long_key(enc, 0x42, 1, 0xFF), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_long_key(enc, 0x42, 1, 0xFF));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Chain I4 + 1 surviving leaf
+  verifier.assert_node_counts({1, 1, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.assert_empty();
+}
+
+// Group 3d: Stress removal
+
+/// Insert 24 keys (divergence at positions 7..18), remove every other
+/// key, verify remaining.  Then remove all, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, StressInsertRemoveAtEveryPosition) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  constexpr unsigned key_len = 20;
+  constexpr unsigned prefix_cap = 7;
+
+  // Insert all 24 keys: for each divergence position d (7..18), two
+  for (unsigned d = prefix_cap; d < key_len - 1; ++d) {
+    for (unsigned variant = 1; variant <= 2; ++variant) {
+      enc.reset();
+      enc.encode(static_cast<std::uint8_t>(d));
+      for (unsigned i = 1; i < key_len; ++i) {
+        if (i < prefix_cap) {
+          enc.encode(std::uint8_t{0xAA});
+        } else if (i == d) {
+          enc.encode(static_cast<std::uint8_t>(variant));
+        } else {
+          enc.encode(std::uint8_t{0x00});
+        }
+      }
+      verifier.insert(enc.get_key_view(), val);
+    }
+  }
+  verifier.check_present_values();
+
+  // Remove variant=1 keys (one from each pair).
+  for (unsigned d = prefix_cap; d < key_len - 1; ++d) {
+    enc.reset();
+    enc.encode(static_cast<std::uint8_t>(d));
+    for (unsigned i = 1; i < key_len; ++i) {
+      if (i < prefix_cap) {
+        enc.encode(std::uint8_t{0xAA});
+      } else if (i == d) {
+        enc.encode(std::uint8_t{1});
+      } else {
+        enc.encode(std::uint8_t{0x00});
+      }
+    }
+    verifier.remove(enc.get_key_view());
+  }
+  verifier.check_present_values();
+
+  // Remove remaining variant=2 keys.
+  for (unsigned d = prefix_cap; d < key_len - 1; ++d) {
+    enc.reset();
+    enc.encode(static_cast<std::uint8_t>(d));
+    for (unsigned i = 1; i < key_len; ++i) {
+      if (i < prefix_cap) {
+        enc.encode(std::uint8_t{0xAA});
+      } else if (i == d) {
+        enc.encode(std::uint8_t{2});
+      } else {
+        enc.encode(std::uint8_t{0x00});
+      }
+    }
+    verifier.remove(enc.get_key_view());
+  }
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 4: Mixed key lengths
+// -------------------------------------------------------------------
+
+/// A 10-byte key and a 9-byte key sharing 8 bytes (same tag, different
+/// uint64 values).  The keys must not be in a prefix relationship.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MixedLengthKeysLongPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_long_key(enc, 0x42, 1, 0xFF), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 5: Duplicate & edge cases
+// -------------------------------------------------------------------
+
+/// Inserting the same 9-byte key twice returns false on the second insert.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyDuplicateInsert) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  // Second insert of same key should fail.
+  UNODB_ASSERT_FALSE(verifier.get_db().insert(make_key(enc, 0x42, 1), val));
+  verifier.check_present_values();
+}
+
+/// Get with a key sharing 8 bytes but differing at the last byte
+/// should return empty when only one key is present.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyGetMissing) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  const auto result = verifier.get_db().get(make_key(enc, 0x42, 2));
+  UNODB_ASSERT_FALSE(TypeParam::key_found(result));
+  verifier.check_present_values();
+}
+
+#ifdef UNODB_DETAIL_WITH_STATS
+
+// ===================================================================
+// Group 6: Stats verification — node counts at intermediate states
+//
+// These tests verify that the tree's internal bookkeeping (node counts,
+// memory use) is correct after insert and remove operations involving
+// single-child chain I4 nodes.
+//
+// Inode size thresholds:
+//   I4:   min=2, capacity=4   (shrinks via leave_last_child)
+//   I16:  min=5, capacity=16  (shrinks to I4)
+//   I48:  min=17, capacity=48 (shrinks to I16)
+//   I256: min=49, capacity=256 (shrinks to I48)
+//
+// For keys make_key(enc, 0x42, v) with small v:
+//   9 bytes: [0x42, 0,0,0,0,0,0, 0, v]
+//   All share 8 bytes, differ only at byte 8.
+//   Tree: chain I4 (prefix=7, dispatch=0x00) → bottom inode (children
+//   keyed by v).
+// ===================================================================
+
+// -------------------------------------------------------------------
+// Group 6b: Partial remove — bottom inode shrinks, chain preserved
+// -------------------------------------------------------------------
+
+/// Insert 3 keys, remove 1.  Chain I4 + bottom I4 (2 children).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainPartialRemoveI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 3; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({3, 2, 0, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I4(3) → remove → I4(2).  Chain I4 unchanged.
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+}
+
+/// Insert 5 keys (→I16), remove 1 (I16 at min_size → shrink to I4).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI16ToI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 5; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({5, 1, 1, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I16(5) at min_size → shrink to I4(4).  Chain I4 + bottom I4.
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+  verifier.assert_shrinking_inodes({0, 1, 0, 0});
+}
+
+/// Insert 17 keys (→I48), remove 1 (I48 at min_size → shrink to I16).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI48ToI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 17; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({17, 1, 0, 1, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I48(17) at min_size → shrink to I16(16).  Chain I4 + I16.
+  verifier.assert_node_counts({16, 1, 1, 0, 0});
+  verifier.assert_shrinking_inodes({0, 0, 1, 0});
+}
+
+/// Insert 49 keys (→I256), remove 1 (I256 at min_size → shrink to I48).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI256ToI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 49; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({49, 1, 0, 0, 1});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I256(49) at min_size → shrink to I48(48).  Chain I4 + I48.
+  verifier.assert_node_counts({48, 1, 0, 1, 0});
+  verifier.assert_shrinking_inodes({0, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------
+// Group 6c: Full remove — all keys removed through each bottom inode
+// -------------------------------------------------------------------
+
+/// Insert 17 keys into chain (bottom I48), remove all.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveAllFromI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 17; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  for (std::uint64_t i = 1; i <= 17; ++i)
+    verifier.remove(make_key(enc, 0x42, i));
+  verifier.assert_empty();
+}
+
+/// Insert 49 keys into chain (bottom I256), remove all.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveAllFromI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  for (std::uint64_t i = 1; i <= 49; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  for (std::uint64_t i = 1; i <= 49; ++i)
+    verifier.remove(make_key(enc, 0x42, i));
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 6d: Cascade — chain under parent at min_size, removing chain
+// triggers parent shrinkage
+//
+// Each test creates a parent inode at its min_size, where one child
+// slot points to a chain (2 keys with tag=0x42 sharing 8 bytes) and
+// the remaining slots are direct leaves (distinct tag bytes).
+// Removing both chain keys should: reclaim the chain, then shrink
+// the parent through the normal shrinkage path.
+// -------------------------------------------------------------------
+
+/// Chain under I4(2 children).  Remove chain → I4 collapses via
+/// leave_last_child → root becomes the surviving leaf.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Insert chain keys first so the chain forms at root level, then
+  // insert a short key that splits the root prefix → parent I4.
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_short_key(enc, 0x01), val);
+  // root I4(2: 0x42→chain, 0x01→leaf) + chain I4 + bottom I4 + 3 leaves
+  verifier.assert_node_counts({3, 3, 0, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
+  // Root I4 still has 2 children.
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain fully reclaimed.  Root I4 at min_size(2) loses a child →
+  // leave_last_child → root becomes the surviving leaf.
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+}
+
+/// Chain under I16(5 children).  Remove chain → I16 shrinks to I4.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Chain keys first, then 4 short keys → root I16(5 children).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x04; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  // root I16(5) + chain I4 + bottom I4 + 6 leaves
+  verifier.assert_node_counts({6, 2, 1, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain reclaimed.  I16(5) → remove chain slot → is_min_size →
+  // shrink to I4(4).
+  verifier.assert_node_counts({4, 1, 0, 0, 0});
+}
+
+/// Chain under I48(17 children).  Remove chain → I48 shrinks to I16.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Chain keys first, then 16 short keys → root I48(17 children).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x10; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  // root I48(17) + chain I4 + bottom I4 + 18 leaves
+  verifier.assert_node_counts({18, 2, 0, 1, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain reclaimed.  I48(17) → remove chain slot → shrink to I16(16).
+  verifier.assert_node_counts({16, 0, 1, 0, 0});
+}
+
+/// Chain under I256(49 children).  Remove chain → I256 shrinks to I48.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Chain keys first, then 48 short keys → root I256(49 children).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x30; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  // root I256(49) + chain I4 + bottom I4 + 50 leaves
+  verifier.assert_node_counts({50, 2, 0, 0, 1});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain reclaimed.  I256(49) → remove chain slot → shrink to I48(48).
+  verifier.assert_node_counts({48, 0, 0, 1, 0});
+}
+
+// Chain under I48(18 children, above min_size).  Remove chain child
+// via remove_child_entry (no shrink).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveFromI48AboveMin) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x11; ++t)  // 17 short keys → I48(18)
+    verifier.insert(make_short_key(enc, t), val);
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+}
+
+// Chain under I256(50 children, above min_size).  Remove chain child
+// via remove_child_entry (no shrink).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveFromI256AboveMin) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x31; ++t)  // 49 short keys → I256(50)
+    verifier.insert(make_short_key(enc, t), val);
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+}
+
+// -------------------------------------------------------------------
+// Group 6e: Multi-level chain removal
+// -------------------------------------------------------------------
+
+/// Two 17-byte keys (2 chain I4s + bottom I4), remove both.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChainRemoveAll) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make17 = [&](std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+  verifier.insert(make17(0x01), val);
+  verifier.insert(make17(0x02), val);
+  verifier.assert_node_counts({2, 3, 0, 0, 0});
+
+  verifier.remove(make17(0x01));
+  // Bottom I4 collapsed.  Two chain I4s remain, last one has 1 child (leaf).
+  verifier.assert_node_counts({1, 2, 0, 0, 0});
+
+  verifier.remove(make17(0x02));
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 7: Parent inode growth with chain children (GAP A)
+//
+// The root inode grows I4→I16→I48→I256 where one child is a chain
+// subtree.  Existing cascade tests (6d) only cover parent shrinkage.
+// -------------------------------------------------------------------
+
+/// Parent I4→I16 growth with a chain child.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI4ToI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Chain subtree under tag=0x42.
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  // 4 short keys to grow parent past I4 capacity.
+  for (std::uint8_t t = 0x01; t <= 0x04; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  verifier.check_present_values();
+  // root I16(5: 0x42→chain, 0x01..0x04→leaves) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({6, 2, 1, 0, 0});
+}
+
+/// Parent I16→I48 growth with a chain child.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI16ToI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x10; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  verifier.check_present_values();
+  // root I48(17) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({18, 2, 0, 1, 0});
+}
+
+/// Parent I48→I256 growth with a chain child.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI48ToI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x30; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  verifier.check_present_values();
+  // root I256(49) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({50, 2, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------
+// Group 8: Bottom inode growth with cumulative stats (GAP C)
+// -------------------------------------------------------------------
+
+/// Verify growing_inodes through I4→I16→I48→I256 under a chain.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainBottomGrowthStats) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Insert 4 keys: chain-I4 + bottom-I4(4).
+  for (std::uint64_t i = 1; i <= 4; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+  // chain-I4 creation + bottom-I4 creation = 2 I4 grows.
+  verifier.assert_growing_inodes({2, 0, 0, 0});
+
+  // 5th key: bottom I4→I16.
+  verifier.insert(make_key(enc, 0x42, 5), val);
+  verifier.assert_node_counts({5, 1, 1, 0, 0});
+  verifier.assert_growing_inodes({2, 1, 0, 0});
+
+  // 17th key: bottom I16→I48.
+  for (std::uint64_t i = 6; i <= 17; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({17, 1, 0, 1, 0});
+  verifier.assert_growing_inodes({2, 1, 1, 0});
+
+  // 49th key: bottom I48→I256.
+  for (std::uint64_t i = 18; i <= 49; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({49, 1, 0, 0, 1});
+  verifier.assert_growing_inodes({2, 1, 1, 1});
+
+  verifier.check_present_values();
+}
+
+// -------------------------------------------------------------------
+// Group 9: Multi-level chain with fat bottom inode (GAP D)
+// -------------------------------------------------------------------
+
+/// Two chain levels + I16 at bottom (5 keys, 17 bytes each).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChainFatBottom) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make17 = [&](std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+
+  for (std::uint8_t i = 1; i <= 5; ++i) verifier.insert(make17(i), val);
+  verifier.check_present_values();
+  // 2 chain-I4s + bottom I16(5) + 5 leaves
+  verifier.assert_node_counts({5, 2, 1, 0, 0});
+  verifier.assert_growing_inodes({3, 1, 0, 0});
+
+  // Remove 1 → I16 at min_size → shrink to I4.
+  verifier.remove(make17(1));
+  verifier.assert_node_counts({4, 3, 0, 0, 0});
+  verifier.assert_shrinking_inodes({0, 1, 0, 0});
+
+  // Remove remaining → chains collapse.
+  for (std::uint8_t i = 2; i <= 5; ++i) verifier.remove(make17(i));
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 10: Mid-level inode between chain levels (GAP B)
+//
+// 18-byte keys: encode(u64).encode(u8_mid).encode(u64).encode(u8)
+// = 8+1+8+1 = 18 bytes.
+// All keys share bytes[0..7] → chain at depth 0.
+// byte[8] = mid → mid-level inode at depth 8.
+// Within each mid group, bytes[9..16] shared → chain at depth 9.
+// byte[17] = bottom → bottom inode at depth 17.
+// Structure: chain(0) → mid-inode(8) → {chain(9) → bottom-inode(17)}*
+// -------------------------------------------------------------------
+
+/// Mid-level inode growth with chains above and below.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MidLevelInodeGrowth) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 5 mid groups × 2 bottom keys = 10 keys.
+  // Mid-inode at depth 8 grows to I16(5).
+  for (std::uint8_t m = 1; m <= 5; ++m)
+    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+  verifier.check_present_values();
+  // chain(0) → mid-I16(5) → 5×(chain(9) → bottom-I4(2) → 2 leaves)
+  // I4: 1 top-chain + 5 depth-9-chains + 5 bottoms = 11
+  verifier.assert_node_counts({10, 11, 1, 0, 0});
+}
+
+/// Mid-level inode shrinkage with chains above and below.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MidLevelInodeShrink) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 5 mid groups × 2 bottom keys = 10 keys → mid I16(5).
+  for (std::uint8_t m = 1; m <= 5; ++m)
+    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+
+  // Remove both keys for mid=1 → bottom-I4(2) collapses (I4 shrink),
+  // chain(9) collapses (I4 shrink), mid-I16(5) at min_size → I4(4)
+  // (I16 shrink).
+  verifier.remove(make18(1, 1));
+  verifier.remove(make18(1, 2));
+  verifier.check_present_values();
+  // chain(0) → mid-I4(4) → 4×(chain(9) → bottom-I4(2) → 2 leaves)
+  // I4: 1 top-chain + 4 depth-9-chains + 4 bottoms + 1 mid = 10
+  verifier.assert_node_counts({8, 10, 0, 0, 0});
+  verifier.assert_shrinking_inodes({2, 1, 0, 0});
+}
+
+// -------------------------------------------------------------------
+// Group 10a: Chain remove — key not found / mismatch coverage
+// -------------------------------------------------------------------
+
+// Remove non-existent key where chain I4's find_child returns nullptr.
+// The chain has one child at dispatch byte 0x01; we try dispatch 0x03.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveKeyNotFound) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_key(enc, 0x42, 2));
+  // Chain I4 has 1 child at dispatch 0x01.  v=3 → dispatch 0x03.
+  UNODB_ASSERT_FALSE(verifier.get_db().remove(make_key(enc, 0x42, 3)));
+  verifier.check_present_values();
+}
+
+// Remove non-existent key when root is a single leaf.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveMissRootIsLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  UNODB_ASSERT_FALSE(verifier.get_db().remove(make_key(enc, 0x42, 2)));
+  verifier.check_present_values();
+}
+
+// Remove key where chain I4's child is a leaf that doesn't match.
+// Use a 10-byte key that shares the chain prefix and dispatch byte
+// but differs at the leaf level.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveLeafMismatch) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_key(enc, 0x42, 2));
+  // Chain I4 child is leaf with key [0x42, 0,...,0x01] (9 bytes).
+  // Try removing a 10-byte key with same first 9 bytes + suffix.
+  // This matches prefix and dispatch but leaf->matches() fails.
+  UNODB_ASSERT_FALSE(
+      verifier.get_db().remove(make_long_key(enc, 0x42, 1, 0xFF)));
+  verifier.check_present_values();
+}
+
+// -------------------------------------------------------------------
+// Group 10b: Atomic chain cut — structural gap tests
+// -------------------------------------------------------------------
+
+// T5: I4(2) collapse with CD=1 chain, remaining child is leaf.
+// Tree: root-I4(2: chain→chain→leaf(A), leaf(C))
+// Remove A → chain cut, I4 collapses, root becomes leaf(C).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1CollapseToLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // A and B share tag + 8 bytes → chain at depth 0, chain at depth 8.
+  // C has different tag → sibling at root.
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  verifier.insert(make18(0x02, 0x00, 0x01), val);  // C
+  verifier.check_present_values();
+
+  // Remove B: bottom I4(2→1), chain extends.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=1). Root I4(2→1) collapses to leaf(C).
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+
+  // Remove C: tree empty.
+  verifier.remove(make18(0x02, 0x00, 0x01));
+  verifier.assert_empty();
+}
+
+// T7: I4(2) collapse with CD=0 chain, remaining child is inode.
+// Remove A → chain cut, I4 collapses, remaining child promoted.
+// Use 1-byte keys for B,C so remaining child has short prefix.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD0CollapseToInode) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // A: 9-byte key with tag=0x10 → chain at depth 0.
+  // B,C: 1-byte keys with tag=0x20, 0x30 → I4(2) at root, no prefix.
+  // Root: I4(3: 0x10→chain→leaf(A), 0x20→leaf(B), 0x30→leaf(C))
+  // Wait — that's I4(3), not I4(2). For I4(2) collapse we need
+  // exactly 2 children. Use B as a subtree:
+  // B1,B2: 1-byte keys → but 1-byte keys can't form a subtree.
+  //
+  // Simpler: use 2-byte keys for B,C sharing first byte.
+  // B: [0x20, 0x01], C: [0x20, 0x02] → I4(2: leaf(B), leaf(C))
+  // under dispatch 0x20. Root: I4(2: 0x10→chain, 0x20→I4(2: B, C))
+  // Root prefix is empty. Remaining child I4(B,C) has empty prefix.
+  // Merge: 0 + 1 + 0 = 1 byte → fits.
+  verifier.insert(make_key(enc, 0x10, 1), val);  // A (9 bytes)
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x20})
+                      .encode(std::uint8_t{0x01})
+                      .get_key_view(),
+                  val);  // B (2 bytes)
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x20})
+                      .encode(std::uint8_t{0x02})
+                      .get_key_view(),
+                  val);  // C (2 bytes)
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=0). Root I4(2→1) collapses.
+  verifier.remove(make_key(enc, 0x10, 1));
+  verifier.check_present_values();
+}
+
+// T8: I4(2) collapse with CD=1 chain, remaining child is inode.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1CollapseToInode) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // A,B share tag=0x01 + 8 bytes → depth-1 chain → I4(2: A, B).
+  // D,E have tag=0x02 → I4(2: D, E) subtree.
+  // Root: I4(2: 0x01→chain→chain→I4(A,B), 0x02→chain→I4(D,E))
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
+  verifier.insert(make18(0x02, 0x00, 0x02), val);  // E
+  verifier.check_present_values();
+
+  // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
+  // Remaining child is the tag=0x02 subtree — prefix merge needed.
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+}
+
+// T12: I4(3) with CD=1 chain, just remove entry.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1RemoveFromI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 3 tag groups: 0x01 (chain target), 0x02, 0x03.
+  // Root: I4(3: chain→...A, leaf(D), leaf(E))
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
+  verifier.insert(make18(0x03, 0x00, 0x01), val);  // E
+  verifier.check_present_values();
+
+  // Remove B, then A: chain cut from I4(3→2).
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+}
+
+// T8b: I4(2) collapse with CD=1 chain, remaining child is inode,
+// prefix merge fits.  Uses 2-byte sibling keys so the remaining
+// child has empty prefix → merge = 0 + 1 + 0 = 1 ≤ 7.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
+                 ChainCutCD1CollapseToInodeShortPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // A,B: tag=0x01, 18-byte keys → depth-1 chain → I4(2: A, B).
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  // C,D: tag=0x02, 2-byte keys → I4(2: C, D) with empty prefix.
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x02})
+                      .encode(std::uint8_t{0x01})
+                      .get_key_view(),
+                  val);  // C
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x02})
+                      .encode(std::uint8_t{0x02})
+                      .get_key_view(),
+                  val);  // D
+  verifier.check_present_values();
+
+  // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
+  // Remaining child is I4(C,D) with empty prefix.
+  // Merge: root prefix(0) + dispatch(0x02) + child prefix(0) = 1 ≤ 7.
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+}
+
+// T6: I4(2) collapse with CD=2 chain, remaining child is leaf.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD2CollapseToLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // 26-byte keys: tag + uint64 + uint64 + uint64 + uint8.
+  // Two keys sharing 25 bytes → 3 chain levels (depth 0,8,16).
+  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  verifier.insert(make26(0x01, 0x01), val);  // A
+  verifier.insert(make26(0x01, 0x02), val);  // B
+  verifier.insert(make26(0x02, 0x01), val);  // sibling
+  verifier.check_present_values();
+
+  // Remove B → chain extends. Remove A → CD=2 chain cut.
+  verifier.remove(make26(0x01, 0x02));
+  verifier.check_present_values();
+  verifier.remove(make26(0x01, 0x01));
+  verifier.check_present_values();
+
+  // Sibling subtree remains: chain(depth 0)→chain(depth 8)→chain(depth 16)
+  //   →I4(2: leaf(sib_01), leaf(sib_02))... but we only inserted one sibling.
+  // Actually just: root single-child I4 → chain → chain → leaf(sib).
+  // Prefix overflow prevents collapse at each level.
+
+  // Remove sibling → empty.
+  verifier.remove(make26(0x02, 0x01));
+  verifier.assert_empty();
+}
+
+// T9: I4(2) collapse with CD=0, prefix merge overflows.
+// The I4 should NOT collapse — remains as single-child I4.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD0PrefixOverflow) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // Both children are 9-byte keys with different tags.
+  // Root I4 has empty prefix. Each child chain has 7-byte prefix.
+  // Collapse would need 0 + 1 + 7 = 8 bytes → overflow.
+  verifier.insert(make_key(enc, 0x10, 1), val);  // A (chain→leaf)
+  verifier.insert(make_key(enc, 0x10, 2), val);  // B (chain→I4(A,B))
+  verifier.insert(make_key(enc, 0x20, 1), val);  // C (chain→leaf)
+  verifier.insert(make_key(enc, 0x20, 2), val);  // D (chain→I4(C,D))
+  verifier.check_present_values();
+
+  // Remove B → chain under 0x10 extends to leaf(A).
+  verifier.remove(make_key(enc, 0x10, 2));
+  verifier.check_present_values();
+
+  // Remove A → chain cut. Root I4(2→1). Remaining child is 0x20 chain
+  // with 7-byte prefix. Prefix merge overflows → no collapse.
+  verifier.remove(make_key(enc, 0x10, 1));
+  verifier.check_present_values();
+
+  // C and D still accessible.
+  verifier.remove(make_key(enc, 0x20, 1));
+  verifier.remove(make_key(enc, 0x20, 2));
+  verifier.assert_empty();
+}
+
+// T10: I4(2) collapse with CD=1, prefix merge overflows.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1PrefixOverflow) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // tag=0x01: 2 keys sharing 10 bytes → CD=1 chain.
+  // tag=0x02: 2 keys → chain with 7-byte prefix.
+  // Root I4 has empty prefix. 0x02 child has 7-byte prefix.
+  // Collapse: 0 + 1 + 7 = 8 → overflow.
+  verifier.insert(make18(0x01, 0x00, 0x01), val);
+  verifier.insert(make18(0x01, 0x00, 0x02), val);
+  verifier.insert(make18(0x02, 0x00, 0x01), val);
+  verifier.insert(make18(0x02, 0x00, 0x02), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+
+  // tag=0x02 keys still accessible.
+  verifier.remove(make18(0x02, 0x00, 0x01));
+  verifier.remove(make18(0x02, 0x00, 0x02));
+  verifier.assert_empty();
+}
+
+// T14: I16(min) shrink with CD=1 chain.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 5 tag groups → I16(5) at root level (after chain at depth 0).
+  // Under tag=0x01: 2 keys → CD=1 chain.
+  for (std::uint8_t t = 1; t <= 5; ++t)
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make18(t, 0x00, b), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut from I16(5→4) → I4.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+  // 8 leaves, 4 tag groups each with chain(depth 0)→chain(depth 8)→I4(2).
+  // Top-level I4(4) + 4×(chain + bottom-I4) = 1 + 8 = 9 I4s.
+  verifier.assert_node_counts({8, 9, 0, 0, 0});
+  verifier.assert_shrinking_inodes({2, 1, 0, 0});
+}
+
+// T16: I48(min) shrink with CD=1 chain.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 17 tag groups → I48(17).
+  for (std::uint8_t t = 1; t <= 17; ++t)
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make18(t, 0x00, b), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut from I48(17→16) → I16.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+  // 32 leaves, 16 tag groups each with chain→chain→I4(2).
+  // Top-level I16(16) + 16×(chain + bottom-I4) = 0 + 32 = 32 I4s.
+  verifier.assert_node_counts({32, 32, 1, 0, 0});
+  verifier.assert_shrinking_inodes({2, 0, 1, 0});
+}
+
+// T18: I256(min) shrink with CD=1 chain.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 49 tag groups → I256(49).
+  for (std::uint8_t t = 1; t <= 49; ++t)
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make18(t, 0x00, b), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut from I256(49→48) → I48.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+  // 96 leaves, 48 tag groups each with chain→chain→I4(2).
+  // Top-level I48(48) + 48×(chain + bottom-I4) = 0 + 96 = 96 I4s.
+  verifier.assert_node_counts({96, 96, 0, 1, 0});
+  verifier.assert_shrinking_inodes({2, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------
+// Verify tree structures used by concurrent chain cut tests (CT1-CT4).
+// These confirm the chain depth and that insert/remove work correctly
+// on these key patterns before we add concurrency.
+
+// CT1/CT3 tree: 26-byte keys, 3 chain levels after removing B.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ConcurrentTestTree26Byte) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0})
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  verifier.insert(make26(0x10, 0x01), val);  // A
+  verifier.insert(make26(0x10, 0x02), val);  // B
+  verifier.insert(make26(0x20, 0x01), val);  // sib
+  verifier.check_present_values();
+
+  verifier.remove(make26(0x10, 0x02));  // remove B
+  verifier.check_present_values();
+
+  verifier.remove(make26(0x10, 0x01));  // remove A (chain cut)
+  verifier.check_present_values();
+
+  // Insert a new key at root level (what CT1's T2 does).
+  verifier.insert(make26(0x30, 0x01), val);
+  verifier.check_present_values();
+}
+
+// CT2/CT4 tree: 34-byte keys, 4 chain levels after removing B.
+// Also verify that inserting a key diverging at chain[0] works.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ConcurrentTestTree34Byte) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
+  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
+
+  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(v1)
+        .encode(X)
+        .encode(X)
+        .encode(X)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  verifier.insert(make34(0x10, X, 0x01), val);  // A
+  verifier.insert(make34(0x10, X, 0x02), val);  // B
+  verifier.insert(make34(0x20, X, 0x01), val);  // sib
+  verifier.check_present_values();
+
+  verifier.remove(make34(0x10, X, 0x02));  // remove B
+  verifier.check_present_values();
+
+  // Insert T2's key (diverges at chain[0] level, different v1).
+  verifier.insert(make34(0x10, Z, 0x01), val);
+  verifier.check_present_values();
+
+  // Remove A (chain cut with T2's key already in tree).
+  verifier.remove(make34(0x10, X, 0x01));
+  verifier.check_present_values();
+}
+
+// Group 11: Scan through chain with mixed-length keys (GAP E)
+// -------------------------------------------------------------------
+
+/// Iterator walks through chain subtree with 9-byte and 10-byte keys.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanChainMixedLengths) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::test_values[0];
+
+  // 9-byte and 10-byte keys in the same chain subtree.
+  // make_key(0x42, v) = 9 bytes.  make_long_key(0x42, v, s) = 10 bytes.
+  // Keys must not be in a prefix relationship — use different v values.
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_long_key(enc, 0x42, 3, 0x01), val);
+  verifier.insert(make_long_key(enc, 0x42, 4, 0x01), val);
+  // check_present_values does a full scan + per-key probe.
+  verifier.check_present_values();
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+
+  // Remove a 10-byte key, verify scan still works.
+  verifier.remove(make_long_key(enc, 0x42, 3, 0x01));
+  verifier.check_present_values();
+
+  // Remove a 9-byte key.
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+}
+
+#endif  // UNODB_DETAIL_WITH_STATS
+
 }  // namespace


### PR DESCRIPTION
## Fix `db<key_view>` dispatch byte collision for long shared prefixes

Fixes #838.

### Problem

When using `db<key_view>` with compound keys that share more than 7 prefix bytes (the `key_prefix_capacity`), the leaf-to-inode4 split computes identical dispatch bytes for both keys. This causes the new inode4 to receive two children under the same key byte, corrupting the tree.

### Solution

Introduce **single-child inode4 chain nodes**. When two keys share more than `key_prefix_capacity` bytes at the current depth and have the same dispatch byte, instead of creating a two-child inode4 (which would have duplicate dispatch bytes), we create a single-child inode4 that consumes 7 prefix bytes plus 1 dispatch byte, then continue the insert loop at the deeper depth. The loop repeats until the keys diverge, building a chain of single-child inode4 nodes. This is analogous to how a trie handles long shared prefixes.

### Impact on uint64_t keys

Chain nodes are never created for uint64_t keys (8 bytes). The chain creation condition requires two keys to share all 7 prefix bytes AND have the same dispatch byte at position 7. For 8-byte keys, if the first 7 bytes match and byte 7 also matches, the keys are identical — caught by the existing duplicate-key check before the chain logic is reached. If byte 7 differs, the normal two-child inode4 is created. The chain insert path, remove chain cleanup, and shrink constructor changes are only exercised by key_view keys longer than 8 bytes with long shared prefixes. There is no performance impact on the existing uint64_t key path.

### Tree structure asymmetry for key_view keys

Today, inserting a single key_view key into an empty tree always creates a root leaf, regardless of key length. The full key is stored in the leaf, not in the inode path — because there is no inode path. Chain inode4 nodes are only created during the leaf-split path when a second key collides with an existing leaf. This means the inode path only captures the key when there are at least two keys with a shared prefix.

This creates a structural asymmetry: inserting two long keys creates a chain of inode4 nodes encoding the shared prefix; removing one leaves a chain inode4 with a single leaf child (key encoded in inode path). Removing the last key produces an empty tree, and re-inserting creates a root leaf (key NOT in inode path). The tree structure depends on insertion/deletion history, not just the current key set.

This asymmetry is harmless for correctness — all operations (get, insert, remove, scan) work correctly in both cases because get_key() currently reads from the leaf, not from the inode path. Eliminating this asymmetry (always encoding the full key in the inode path, even for a single key) is deferred to future work alongside leaf elimination for small value types (#707, which lifts small values into the inode child slots). That future work is a prerequisite for switching get_key() to reconstruct keys from the inode path and for removing the key copy from the leaf.

### Changes

**5 files changed, +1127/-46 lines** (roughly half is tests)

#### Core insert fix
- `art_internal_impl.hpp`: New single-child inode4 constructor and `init(key_byte, child)` method. New `reclaim_if_leaf()` for shrink constructors handling chain children. New `remove_child_entry()` (remove without reclaim) for all four inode types, with base class dispatcher.
- `art.hpp`: Dispatch byte collision detection in `insert_internal` — creates chain inode4 and continues the loop.
- `olc_art.hpp`: Same collision detection in OLC `try_insert`, with proper write guard protocol.

#### Remove with chain cleanup
- `art.hpp`: Complete rewrite of `remove_internal` from single-pass to two-pass (downward find + upward cleanup with stack). Handles chain inode4 reclamation, I4 collapse with prefix merge, and I16/I48/I256 shrinkage via existing shrink constructors.
- `olc_art.hpp`: OLC `try_remove` chain cleanup with three paths:
  1. I16/I48/I256 parent at min size: shrink constructors while chain is alive
  2. Multi-level chain upward walk with write guard rehydration
  3. I4 collapse to remaining child

#### Bug fix (pre-existing)
- `optimistic_lock.hpp`: Fix `read_lock_count` leak in `read_critical_section` move assignment operator. The old RCS was overwritten without decrementing its lock's debug counter. Debug builds only.

#### Tests
- `test/test_art_key_view.cpp`: 31 new tests covering chain creation, multi-level chains, chain removal under all inode sizes (I4/I16/I48/I256), cascade shrinkage, and stress tests with 20-byte keys diverging at every position. All tests are typed tests running against `db`, `mutex_db`, and `olc_db`.

### Test Results

- **db**: 41/41 key_view tests pass ✅
- **mutex_db**: 41/41 key_view tests pass ✅
- **olc_db**: 41/41 key_view tests pass ✅
- **All other suites**: pass (312 + 78 + 186 + 33 + 41 + 34 + 3 + 45 tests)
- **ASAN**: 8/8 pass ✅
- **TSAN**: 8/8 pass ✅
- **UBSAN**: 10/10 pass ✅

### Known Limitations / Future Work

1. **Single-key chain insert not yet implemented** — inserting a single key longer than 7 bytes into an empty tree still creates a root leaf (no chain). This means the full key is not yet encoded in the inode path for single-key trees. Addressing this has a shipping dependency on leaf elimination for small value types (#707) to avoid performance regression.

2. **Iterator `get_key()` reads from leaf** — currently returns `leaf->get_key_view()` rather than reconstructing the key from the inode path (`keybuf_`). Switching to `keybuf_` depends on the single-key chain insert above.

3. **Key still stored in leaf** — for `key_view` mode, the leaf stores a full copy of the key. Once the full key is encoded in the inode path, this copy becomes redundant and can be removed to reduce memory usage.

4. **db/OLC reclamation asymmetry** — the db remove path frees chain nodes eagerly before shrink constructors run, while the OLC path keeps them alive for the shrink constructor. Both are correct and tested but use different ordering. Alignment was explored but adds complexity for multi-level chains without clear benefit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of key collisions involving long shared prefixes
  * Enhanced removal algorithm with more robust cleanup and recovery

* **Tests**
  * Added comprehensive test suite for collision scenarios and removal edge cases

* **Chores**
  * Added debug-mode safety checks for concurrent access management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->