### PR TITLE
feat(benchmark): add key_view micro-benchmarks (#841)

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -1199,9 +1199,16 @@ std::optional<detail::node_ptr*> impl_helpers::remove_or_choose_subtree(
 
   if (UNODB_DETAIL_UNLIKELY(inode.is_min_size())) {
     if constexpr (std::is_same_v<INode, inode_4<Key, Value>>) {
-      auto current_node{art_policy<Key, Value>::make_db_inode_unique_ptr(
-          &inode, db_instance)};
-      *node_in_parent = current_node->leave_last_child(child_i, db_instance);
+      if (UNODB_DETAIL_LIKELY(inode.can_collapse(child_i))) {
+        auto current_node{art_policy<Key, Value>::make_db_inode_unique_ptr(
+            &inode, db_instance)};
+        *node_in_parent =
+            current_node->leave_last_child(child_i, db_instance);
+      } else {
+        // Prefix overflow — cannot collapse.  Just remove the child.
+        inode.remove(child_i, db_instance);
+        return nullptr;
+      }
     } else {
       auto new_node{
           INode::smaller_derived_type::create(db_instance, inode, child_i)};

--- a/art.hpp
+++ b/art.hpp
@@ -1202,8 +1202,7 @@ std::optional<detail::node_ptr*> impl_helpers::remove_or_choose_subtree(
       if (UNODB_DETAIL_LIKELY(inode.can_collapse(child_i))) {
         auto current_node{art_policy<Key, Value>::make_db_inode_unique_ptr(
             &inode, db_instance)};
-        *node_in_parent =
-            current_node->leave_last_child(child_i, db_instance);
+        *node_in_parent = current_node->leave_last_child(child_i, db_instance);
       } else {
         // Prefix overflow — cannot collapse.  Just remove the child.
         inode.remove(child_i, db_instance);
@@ -1518,8 +1517,8 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
     const auto count = inode->get_children_count();
 
     if (count > 1 || ntype != node_type::I4) {
-      const auto remove_result
-          UNODB_DETAIL_USED_IN_DEBUG{inode->template remove_or_choose_subtree<
+      const auto remove_result UNODB_DETAIL_USED_IN_DEBUG{
+          inode->template remove_or_choose_subtree<
               std::optional<detail::node_ptr*>>(ntype, remaining_key[0],
                                                 remove_key, *this, slot)};
       UNODB_DETAIL_ASSERT(remove_result.has_value());
@@ -1529,9 +1528,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
 
     // Single-child inode (chain node).  Reclaim leaf and chain,
     // then walk up cleaning any further empty chains.
-    {
-      const auto rl{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
-    }
+    { const auto rl{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)}; }
     {
       const auto ri{art_policy::make_db_inode_unique_ptr(
           node_val.template ptr<inode_4*>(), *this)};
@@ -1578,9 +1575,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
                                                     remaining_iter.key_byte);
         }
         *entry.slot = remaining;
-        {
-          const auto ri{art_policy::make_db_inode_unique_ptr(pi4, *this)};
-        }
+        { const auto ri{art_policy::make_db_inode_unique_ptr(pi4, *this)}; }
 #ifdef UNODB_DETAIL_WITH_STATS
         account_shrinking_inode<node_type::I4>();
 #endif

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -331,8 +331,8 @@ class basic_db_leaf_deleter {
   static_assert(std::is_trivially_destructible_v<leaf_type>);
 
   /// Construct leaf deleter for database \a db_
-  constexpr explicit basic_db_leaf_deleter(Db& db_
-                                           UNODB_DETAIL_LIFETIMEBOUND) noexcept
+  constexpr explicit basic_db_leaf_deleter(
+      Db& db_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
       : db{db_} {}
 
   /// Delete a leaf node \a to_delete through the database.
@@ -375,8 +375,8 @@ template <class INode, class Db>
 class basic_db_inode_deleter {
  public:
   /// Construct internal node deleter for database \a db_.
-  constexpr explicit basic_db_inode_deleter(Db& db_
-                                            UNODB_DETAIL_LIFETIMEBOUND) noexcept
+  constexpr explicit basic_db_inode_deleter(
+      Db& db_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
       : db{db_} {}
 
   /// Delete an internal node \a inode_ptr through the database.

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -136,7 +136,7 @@ struct [[nodiscard]] basic_art_key final {
   [[nodiscard, gnu::pure]] constexpr int cmp(
       basic_art_key<KeyType> key2) const noexcept {
     if constexpr (std::is_same_v<KeyType, key_view>) {
-      return compare(&key, sizeof(KeyType), &key2.key, sizeof(KeyType));
+      return compare(key, key2.key);
     } else {
       return std::memcmp(&key, &key2.key, sizeof(KeyType));
     }

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -2075,6 +2075,22 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
 
   /// For a node with two children, remove one child and return the other one.
   ///
+  /// Check if collapsing this min-size I4 is safe (prefix merge fits).
+  /// \param child_to_delete Index of child to remove (0 or 1)
+  /// \return true if the remaining child's prefix can absorb this node's
+  ///         prefix + dispatch byte without exceeding key_prefix_capacity.
+  [[nodiscard]] constexpr bool can_collapse(
+      std::uint8_t child_to_delete) const noexcept {
+    UNODB_DETAIL_ASSERT(this->is_min_size());
+    const std::uint8_t child_to_leave = (child_to_delete == 0) ? 1U : 0U;
+    const auto child_ptr = children[child_to_leave].load();
+    if (child_ptr.type() == node_type::LEAF) return true;
+    const auto* const child_inode{child_ptr.template ptr<inode_type*>()};
+    return this->get_key_prefix().length() +
+               child_inode->get_key_prefix().length() <
+           detail::key_prefix_capacity;
+  }
+
   /// \param child_to_delete Index of child to remove (0 or 1)
   /// \param db_instance Database instance
   ///

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -286,9 +286,9 @@ class [[nodiscard]] basic_leaf final : public Header {
 ///
 /// \throws std::length_error if key or value exceeds maximum size
 template <typename Key, typename Value, template <typename, typename> class Db>
-[[nodiscard]] auto make_db_leaf_ptr(basic_art_key<Key> k, value_view v,
-                                    Db<Key, Value>& db
-                                    UNODB_DETAIL_LIFETIMEBOUND) {
+[[nodiscard]] auto make_db_leaf_ptr(
+    basic_art_key<Key> k, value_view v,
+    Db<Key, Value>& db UNODB_DETAIL_LIFETIMEBOUND) {
   using db_type = Db<Key, Value>;
   using header_type = typename db_type::header_type;
   using leaf_type = basic_leaf<Key, header_type>;
@@ -512,9 +512,9 @@ struct basic_art_policy final {
   /// \param db_instance Database for memory tracking
   ///
   /// \return Unique pointer to newly allocated leaf
-  [[nodiscard]] static auto make_db_leaf_ptr(art_key_type k, value_view v,
-                                             db_type& db_instance
-                                             UNODB_DETAIL_LIFETIMEBOUND) {
+  [[nodiscard]] static auto make_db_leaf_ptr(
+      art_key_type k, value_view v,
+      db_type& db_instance UNODB_DETAIL_LIFETIMEBOUND) {
     return ::unodb::detail::make_db_leaf_ptr<Key, Value, Db>(k, v, db_instance);
   }
 
@@ -561,9 +561,8 @@ struct basic_art_policy final {
   /// \return Unique pointer to newly constructed node
   UNODB_DETAIL_DISABLE_GCC_11_WARNING("-Wmismatched-new-delete")
   template <class INode, class... Args>
-  [[nodiscard]] static auto make_db_inode_unique_ptr(db_type& db_instance
-                                                     UNODB_DETAIL_LIFETIMEBOUND,
-                                                     Args&&... args) {
+  [[nodiscard]] static auto make_db_inode_unique_ptr(
+      db_type& db_instance UNODB_DETAIL_LIFETIMEBOUND, Args&&... args) {
     auto* const inode_mem = static_cast<std::byte*>(
         allocate_aligned(sizeof(INode), alignment_for_new<INode>()));
 

--- a/assert.hpp
+++ b/assert.hpp
@@ -85,9 +85,10 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 /// Implementation for marking a source code location as unreachable.
 ///
 /// Should not be called directly - use UNODB_DETAIL_CANNOT_HAPPEN instead.
-[[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_HEADER_NOINLINE void
-cannot_happen(const char* file, int line, const char* func) noexcept {
+[[noreturn,
+  gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1) UNODB_DETAIL_C_STRING_ARG(3)
+    UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char* file, int line,
+                                                    const char* func) noexcept {
   unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
   std::ostringstream buf;
   buf << "Execution reached an unreachable point at " << file << ':' << line
@@ -101,9 +102,9 @@ cannot_happen(const char* file, int line, const char* func) noexcept {
 #define UNODB_DETAIL_DEBUG_CRASH()
 
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3)
-UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char*, int,
-                                                const char*) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3)
+        UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char*, int,
+                                                        const char*) noexcept {
   UNODB_DETAIL_UNREACHABLE();
 }
 
@@ -116,8 +117,9 @@ UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char*, int,
 ///
 /// Should not be called directly - use UNODB_DETAIL_CRASH instead.
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_HEADER_NOINLINE void
-crash(const char* file, int line, const char* func) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3)
+        UNODB_DETAIL_HEADER_NOINLINE void crash(const char* file, int line,
+                                                const char* func) noexcept {
   UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
   buf << "Crash requested at " << file << ':' << line << ", function \"" << func
@@ -145,10 +147,10 @@ crash(const char* file, int line, const char* func) noexcept {
 ///
 /// Should not be called directly - used UNODB_DETAIL_ASSERT instead.
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_C_STRING_ARG(4)
-UNODB_DETAIL_HEADER_NOINLINE void
-assert_failure(const char* file, int line, const char* func,
-               const char* condition) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_C_STRING_ARG(4)
+        UNODB_DETAIL_HEADER_NOINLINE void assert_failure(
+            const char* file, int line, const char* func,
+            const char* condition) noexcept {
   unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
   std::ostringstream buf;
   buf << "Assertion \"" << condition << "\" failed at " << file << ':' << line

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -88,6 +88,7 @@ function(ADD_CONCURRENT_BENCHMARK_TARGET TARGET)
 endfunction()
 
 add_benchmark_target(micro_benchmark_key_prefix)
+add_benchmark_target(micro_benchmark_key_view)
 add_node_benchmark_target(micro_benchmark_n4)
 add_node_benchmark_target(micro_benchmark_n16)
 add_node_benchmark_target(micro_benchmark_n48)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -9,6 +9,8 @@ set(micro_benchmark_quick_arg
   "--benchmark_filter=\".*/100$$|.*/1000/.*:800$$|.*/100/.*:0$$\"")
 set(micro_benchmark_mutex_quick_arg "--benchmark_filter=\"/4/70000/\"")
 set(micro_benchmark_olc_quick_arg "--benchmark_filter=\"/4/70000/\"")
+set(micro_benchmark_key_view_quick_arg
+  "--benchmark_filter=\"compound/1024$$|dense/1024$$\"")
 
 add_custom_target(benchmarks
   env ${SANITIZER_ENV} ./micro_benchmark_key_prefix
@@ -18,7 +20,8 @@ add_custom_target(benchmarks
   COMMAND env ${SANITIZER_ENV} ./micro_benchmark_n256
   COMMAND env ${SANITIZER_ENV} ./micro_benchmark
   COMMAND env ${SANITIZER_ENV} ./micro_benchmark_mutex
-  COMMAND env ${SANITIZER_ENV} ./micro_benchmark_olc)
+  COMMAND env ${SANITIZER_ENV} ./micro_benchmark_olc
+  COMMAND env ${SANITIZER_ENV} ./micro_benchmark_key_view)
 
 add_custom_target(quick_benchmarks
   env ${SANITIZER_ENV}
@@ -36,7 +39,9 @@ add_custom_target(quick_benchmarks
   COMMAND env ${SANITIZER_ENV}
   ./micro_benchmark_mutex ${micro_benchmark_mutex_quick_arg}
   COMMAND env ${SANITIZER_ENV}
-  ./micro_benchmark_olc ${micro_benchmark_olc_quick_arg})
+  ./micro_benchmark_olc ${micro_benchmark_olc_quick_arg}
+  COMMAND env ${SANITIZER_ENV}
+  ./micro_benchmark_key_view ${micro_benchmark_key_view_quick_arg})
 
 add_custom_target(valgrind_benchmarks
   COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_key_prefix
@@ -53,7 +58,9 @@ add_custom_target(valgrind_benchmarks
   COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_mutex
   ${micro_benchmark_mutex_quick_arg}
   COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_olc
-  ${micro_benchmark_olc_quick_arg})
+  ${micro_benchmark_olc_quick_arg}
+  COMMAND ${VALGRIND_COMMAND} ./micro_benchmark_key_view
+  ${micro_benchmark_key_view_quick_arg})
 
 add_library(micro_benchmark_utils STATIC micro_benchmark_utils.cpp
   micro_benchmark_utils.hpp)

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -1,0 +1,332 @@
+// Copyright 2026 UnoDB contributors
+
+// Should be the first include
+#include "global.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+#include <benchmark/benchmark.h>
+
+#include "micro_benchmark_utils.hpp"
+#include "qsbr.hpp"
+
+/// @file
+/// key_view micro-benchmarks for ART tree operations.
+///
+/// Establishes a performance baseline for key_view tree operations
+/// before PR #2 optimizations (remove key from leaf, lift small values
+/// into inodes).  Measures gains against this baseline as optimizations
+/// land.
+///
+/// ## Benchmark groups
+///
+/// **Core chain benchmarks** (8-byte values):
+/// Exercise insert/get/remove/scan across four key generators at
+/// multiple tree sizes (1K, 16K, 262K).
+///
+/// **kv_vs_u64 comparison** (100-byte values):
+/// Direct comparison against the u64 dense_insert benchmark.  Uses
+/// dense sequential 8-byte encoded keys (no chains) and 100-byte
+/// values to match the u64 benchmark's value size.  Timing structure
+/// (PauseTiming/destroy_tree) is identical to the u64 benchmark.
+///
+/// **Key length sweep** (8-byte values, 1024 keys):
+/// Varies key length from 8 to 256 bytes, producing chain depths
+/// from 0 to 31.  Characterizes the per-chain-level cost.
+///
+/// ## Key generators
+///
+/// - **G1 compound** (9 bytes): tag(1) + uint64.  Same tag for all
+///   keys → 1-level chain.  The basic chain workload.
+/// - **G2 deep** (18 bytes): tag(1) + uint64 + mid(1) + uint64.
+///   Same tag + fixed uint64 → 2-level chain.  Exercises multi-level
+///   chain insert/remove and the Step 2 loop in the atomic chain cut.
+/// - **G4 multi_tag** (9 bytes): 8 distinct first bytes, round-robin.
+///   Root inode is I16 with 8 independent chain subtrees.  Simulates
+///   real-world key distribution where keys have diverse prefixes
+///   (e.g., different column values in a secondary index).
+/// - **G5 dense** (8 bytes): encode(uint64) only, no chains.
+///   Baseline for isolating key_view encoding overhead vs u64.
+/// - **G6 chain_depth** (variable length): fixed-length keys with
+///   maximum shared prefix.  Chain depth = (key_len - 2) / 8.
+///   Used in the key length sweep.
+
+UNODB_START_BENCHMARKS()
+
+using unodb::benchmark::key_view_set;
+
+namespace {
+
+constexpr auto val_bytes = std::array<std::byte, 8>{};
+const auto val = unodb::value_view{val_bytes};
+
+constexpr auto val100_bytes = std::array<std::byte, 100>{};
+const auto val100 = unodb::value_view{val100_bytes};
+
+// ===================================================================
+// Core benchmarks — timing matches u64 dense_insert exactly:
+//   PauseTiming → construct → ClobberMemory → ResumeTiming
+//   ... timed work ...
+//   PauseTiming → destroy_tree (clear + ClobberMemory + ResumeTiming)
+// ===================================================================
+
+template <class Db>
+void chain_insert(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.insert(ks[i], val));
+    state.PauseTiming();
+    unodb::benchmark::destroy_tree(db, state);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void chain_get(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  Db db;
+  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.remove(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  Db db;
+  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (auto _ : state) {
+    std::size_t count = 0;
+    db.scan([&count](auto /*visitor*/) {
+      ++count;
+      return false;
+    });
+    benchmark::DoNotOptimize(count);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+// ===================================================================
+// Comparison vs u64: 100-byte values, dense 8B keys.
+// ===================================================================
+
+template <class Db>
+void kv_vs_u64_insert(benchmark::State& state) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = key_view_set::dense_sequential(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.insert(ks[i], val100));
+    state.PauseTiming();
+    unodb::benchmark::destroy_tree(db, state);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void kv_vs_u64_get(benchmark::State& state) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = key_view_set::dense_sequential(n);
+  Db db;
+  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void kv_vs_u64_remove(benchmark::State& state) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = key_view_set::dense_sequential(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.remove(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+// ===================================================================
+// Key generators
+// ===================================================================
+
+key_view_set gen_compound(std::size_t n) {
+  return key_view_set::compound(0x42, n);
+}
+key_view_set gen_deep(std::size_t n) {
+  return key_view_set::deep_compound(0x42, n);
+}
+key_view_set gen_multi_tag(std::size_t n) {
+  return key_view_set::multi_tag(8, n);
+}
+key_view_set gen_dense(std::size_t n) {
+  return key_view_set::dense_sequential(n);
+}
+
+// ===================================================================
+// Sizes
+// ===================================================================
+
+void kv_sizes(benchmark::internal::Benchmark* b) {
+  for (auto n : {1 << 10, 1 << 14, 1 << 18}) b->Arg(n);
+}
+
+void u64_sizes(benchmark::internal::Benchmark* b) {
+  for (auto n : {1 << 12, 1 << 15, 1 << 18}) b->Arg(n);
+}
+
+// ===================================================================
+// Registration: db
+// ===================================================================
+
+using DB = unodb::benchmark::kv_db;
+
+BENCHMARK_CAPTURE(chain_insert<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, deep, gen_deep)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, multi_tag, gen_multi_tag)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_get<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, deep, gen_deep)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, multi_tag, gen_multi_tag)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, deep, gen_deep)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, multi_tag, gen_multi_tag)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_scan<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_scan<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+// ===================================================================
+// Registration: olc_db (same functions — destroy_tree handles OLC)
+// ===================================================================
+
+using OLC = unodb::benchmark::kv_olc_db;
+
+BENCHMARK_CAPTURE(chain_insert<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_get<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_scan<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_scan<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+// ===================================================================
+// Registration: kv vs u64 comparison (100B values)
+// ===================================================================
+
+BENCHMARK(kv_vs_u64_insert<DB>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_get<DB>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_remove<DB>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_insert<OLC>)->Apply(u64_sizes);
+
+// ===================================================================
+// Key length sweep (G6): chain depth = (key_len-2)/8
+// key_len:    8   16   32   64  128  256
+// chain depth: 0    1    3    7   15   31
+// ===================================================================
+
+key_view_set gen_kl8(std::size_t n) { return key_view_set::chain_depth(8, n); }
+key_view_set gen_kl16(std::size_t n) {
+  return key_view_set::chain_depth(16, n);
+}
+key_view_set gen_kl32(std::size_t n) {
+  return key_view_set::chain_depth(32, n);
+}
+key_view_set gen_kl64(std::size_t n) {
+  return key_view_set::chain_depth(64, n);
+}
+key_view_set gen_kl128(std::size_t n) {
+  return key_view_set::chain_depth(128, n);
+}
+key_view_set gen_kl256(std::size_t n) {
+  return key_view_set::chain_depth(256, n);
+}
+
+void kl_sizes(benchmark::internal::Benchmark* b) { b->Arg(1024); }
+
+BENCHMARK_CAPTURE(chain_insert<DB>, kl8, gen_kl8)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl32, gen_kl32)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl128, gen_kl128)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_get<DB>, kl8, gen_kl8)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl32, gen_kl32)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl128, gen_kl128)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<DB>, kl8, gen_kl8)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl32, gen_kl32)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl128, gen_kl128)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_insert<OLC>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<OLC>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<OLC>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_get<OLC>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<OLC>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<OLC>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<OLC>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<OLC>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<OLC>, kl256, gen_kl256)->Apply(kl_sizes);
+
+}  // namespace
+
+UNODB_BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -58,14 +58,6 @@ using unodb::benchmark::key_view_set;
 
 namespace {
 
-/// Call quiescent state for OLC db types, no-op for others.
-template <class Db>
-void maybe_quiescent() {
-  if constexpr (std::is_same_v<
-                    Db, unodb::olc_db<unodb::key_view, unodb::value_view>>)
-    unodb::this_thread().quiescent();
-}
-
 constexpr auto val_bytes = std::array<std::byte, 8>{};
 const auto val = unodb::value_view{val_bytes};
 
@@ -89,11 +81,10 @@ void chain_insert(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     benchmark::ClobberMemory();
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
-      benchmark::DoNotOptimize(db.insert(ks[i], val));
+      unodb::benchmark::kv_insert(db, ks[i], val);
     unodb::benchmark::destroy_tree(db, state);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 template <class Db>
@@ -102,13 +93,10 @@ void chain_get(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   const auto ks = gen(n);
   Db db;
   for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
-  maybe_quiescent<Db>();
   for (auto _ : state) {
-    for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
-    maybe_quiescent<Db>();
+    for (std::size_t i = 0; i < n; ++i) unodb::benchmark::kv_get(db, ks[i]);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 template <class Db>
@@ -121,11 +109,9 @@ void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
     benchmark::ClobberMemory();
     state.ResumeTiming();
-    for (std::size_t i = 0; i < n; ++i)
-      benchmark::DoNotOptimize(db.remove(ks[i]));
+    for (std::size_t i = 0; i < n; ++i) unodb::benchmark::kv_remove(db, ks[i]);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 template <class Db>
@@ -141,10 +127,8 @@ void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
       return false;
     });
     benchmark::DoNotOptimize(count);
-    maybe_quiescent<Db>();
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 // ===================================================================
@@ -161,11 +145,10 @@ void kv_vs_u64_insert(benchmark::State& state) {
     benchmark::ClobberMemory();
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
-      benchmark::DoNotOptimize(db.insert(ks[i], val100));
+      unodb::benchmark::kv_insert(db, ks[i], val100);
     unodb::benchmark::destroy_tree(db, state);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 template <class Db>
@@ -174,13 +157,10 @@ void kv_vs_u64_get(benchmark::State& state) {
   const auto ks = key_view_set::dense_sequential(n);
   Db db;
   for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val100);
-  maybe_quiescent<Db>();
   for (auto _ : state) {
-    for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
-    maybe_quiescent<Db>();
+    for (std::size_t i = 0; i < n; ++i) unodb::benchmark::kv_get(db, ks[i]);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 template <class Db>
@@ -193,11 +173,9 @@ void kv_vs_u64_remove(benchmark::State& state) {
     for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val100);
     benchmark::ClobberMemory();
     state.ResumeTiming();
-    for (std::size_t i = 0; i < n; ++i)
-      benchmark::DoNotOptimize(db.remove(ks[i]));
+    for (std::size_t i = 0; i < n; ++i) unodb::benchmark::kv_remove(db, ks[i]);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
-                          static_cast<std::int64_t>(n));
+  state.SetItemsProcessed(state.iterations() * static_cast<std::int64_t>(n));
 }
 
 // ===================================================================
@@ -279,6 +257,8 @@ BENCHMARK(kv_vs_u64_insert<DB>)->Apply(u64_sizes);
 BENCHMARK(kv_vs_u64_get<DB>)->Apply(u64_sizes);
 BENCHMARK(kv_vs_u64_remove<DB>)->Apply(u64_sizes);
 BENCHMARK(kv_vs_u64_insert<OLC>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_get<OLC>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_remove<OLC>)->Apply(u64_sizes);
 
 // ===================================================================
 // Key length sweep (G6): chain depth = (key_len-2)/8

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -90,8 +90,6 @@ void chain_insert(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.insert(ks[i], val));
-    state.PauseTiming();
-    maybe_quiescent<Db>();
     unodb::benchmark::destroy_tree(db, state);
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
@@ -125,8 +123,6 @@ void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.remove(ks[i]));
-    state.PauseTiming();
-    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));
@@ -166,8 +162,6 @@ void kv_vs_u64_insert(benchmark::State& state) {
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.insert(ks[i], val100));
-    state.PauseTiming();
-    maybe_quiescent<Db>();
     unodb::benchmark::destroy_tree(db, state);
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
@@ -201,8 +195,6 @@ void kv_vs_u64_remove(benchmark::State& state) {
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.remove(ks[i]));
-    state.PauseTiming();
-    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -58,6 +58,14 @@ using unodb::benchmark::key_view_set;
 
 namespace {
 
+/// Call quiescent state for OLC db types, no-op for others.
+template <class Db>
+void maybe_quiescent() {
+  if constexpr (std::is_same_v<
+                    Db, unodb::olc_db<unodb::key_view, unodb::value_view>>)
+    unodb::this_thread().quiescent();
+}
+
 constexpr auto val_bytes = std::array<std::byte, 8>{};
 const auto val = unodb::value_view{val_bytes};
 
@@ -83,6 +91,7 @@ void chain_insert(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.insert(ks[i], val));
     state.PauseTiming();
+    maybe_quiescent<Db>();
     unodb::benchmark::destroy_tree(db, state);
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
@@ -94,9 +103,11 @@ void chain_get(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   const auto n = static_cast<std::size_t>(state.range(0));
   const auto ks = gen(n);
   Db db;
-  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
+  maybe_quiescent<Db>();
   for (auto _ : state) {
     for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
+    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));
@@ -109,11 +120,13 @@ void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   for (auto _ : state) {
     state.PauseTiming();
     Db db;
-    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+    for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
     benchmark::ClobberMemory();
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.remove(ks[i]));
+    state.PauseTiming();
+    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));
@@ -124,7 +137,7 @@ void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   const auto n = static_cast<std::size_t>(state.range(0));
   const auto ks = gen(n);
   Db db;
-  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
   for (auto _ : state) {
     std::size_t count = 0;
     db.scan([&count](auto /*visitor*/) {
@@ -132,6 +145,7 @@ void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
       return false;
     });
     benchmark::DoNotOptimize(count);
+    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));
@@ -153,6 +167,7 @@ void kv_vs_u64_insert(benchmark::State& state) {
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.insert(ks[i], val100));
     state.PauseTiming();
+    maybe_quiescent<Db>();
     unodb::benchmark::destroy_tree(db, state);
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
@@ -164,9 +179,11 @@ void kv_vs_u64_get(benchmark::State& state) {
   const auto n = static_cast<std::size_t>(state.range(0));
   const auto ks = key_view_set::dense_sequential(n);
   Db db;
-  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+  for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val100);
+  maybe_quiescent<Db>();
   for (auto _ : state) {
     for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
+    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));
@@ -179,11 +196,13 @@ void kv_vs_u64_remove(benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     Db db;
-    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+    for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val100);
     benchmark::ClobberMemory();
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.remove(ks[i]));
+    state.PauseTiming();
+    maybe_quiescent<Db>();
   }
   state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
                           static_cast<std::int64_t>(n));
@@ -243,7 +262,7 @@ BENCHMARK_CAPTURE(chain_scan<DB>, compound, gen_compound)->Apply(kv_sizes);
 BENCHMARK_CAPTURE(chain_scan<DB>, dense, gen_dense)->Apply(kv_sizes);
 
 // ===================================================================
-// Registration: olc_db (same functions — destroy_tree handles OLC)
+// Registration: olc_db
 // ===================================================================
 
 using OLC = unodb::benchmark::kv_olc_db;

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -407,8 +407,8 @@ inline void set_size_counter(::benchmark::State& state,
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 template <class Db, node_type DominatingINodeType>
-void assert_dominating_inode_tree(const Db& test_db
-                                  UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+void assert_dominating_inode_tree(
+    const Db& test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
   static_assert(DominatingINodeType != node_type::LEAF);
   const auto node_counts{test_db.get_node_counts()};
@@ -441,9 +441,9 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 template <class Db, unsigned SmallerNodeSize>
-void assert_growing_nodes(const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
-                          std::uint64_t expected_number_of_nodes
-                          UNODB_DETAIL_USED_IN_DEBUG)
+void assert_growing_nodes(
+    const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
+    std::uint64_t expected_number_of_nodes UNODB_DETAIL_USED_IN_DEBUG)
 #ifndef NDEBUG
     noexcept
 #endif
@@ -462,9 +462,9 @@ void assert_growing_nodes(const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
 }
 
 template <class Db, unsigned SmallerNodeSize>
-void assert_shrinking_nodes(const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
-                            std::uint64_t expected_number_of_nodes
-                            UNODB_DETAIL_USED_IN_DEBUG)
+void assert_shrinking_nodes(
+    const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
+    std::uint64_t expected_number_of_nodes UNODB_DETAIL_USED_IN_DEBUG)
 #ifndef NDEBUG
     noexcept
 #endif
@@ -491,8 +491,8 @@ namespace detail {
 template <class Db>
 class [[nodiscard]] tree_shape_snapshot final {
  public:
-  explicit constexpr tree_shape_snapshot(const Db& test_db
-                                         UNODB_DETAIL_USED_IN_DEBUG) noexcept
+  explicit constexpr tree_shape_snapshot(
+      const Db& test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept
 #ifndef NDEBUG
       : db{test_db}
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -30,4 +30,11 @@ template void destroy_tree<unodb::mutex_db<std::uint64_t, unodb::value_view>>(
 template void destroy_tree<unodb::olc_db<std::uint64_t, unodb::value_view>>(
     unodb::olc_db<std::uint64_t, unodb::value_view>&, ::benchmark::State&);
 
+template void destroy_tree<unodb::db<unodb::key_view, unodb::value_view>>(
+    unodb::db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+template void destroy_tree<unodb::mutex_db<unodb::key_view, unodb::value_view>>(
+    unodb::mutex_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+template void destroy_tree<unodb::olc_db<unodb::key_view, unodb::value_view>>(
+    unodb::olc_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+
 }  // namespace unodb::benchmark

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -298,6 +298,11 @@ destroy_tree<unodb::olc_db<unodb::key_view, unodb::value_view>>(
 /// for benchmarking Value=uint64_t (tuple identifier use case).
 class key_view_set {
  public:
+  key_view_set() = default;
+  key_view_set(const key_view_set&) = delete;
+  key_view_set& operator=(const key_view_set&) = delete;
+  key_view_set(key_view_set&&) = default;
+  key_view_set& operator=(key_view_set&&) = default;
   /// G1: 9-byte compound keys (tag + uint64).
   ///
   /// All keys share the same tag byte → 8 shared prefix bytes →
@@ -380,6 +385,7 @@ class key_view_set {
   /// @param n Number of keys (must be <= 256 * 4 = 1024).
   static key_view_set chain_depth(std::size_t key_len, std::size_t n) {
     UNODB_DETAIL_ASSERT(key_len >= 2);
+    UNODB_DETAIL_ASSERT(n <= 1024);
     key_view_set ks;
     ks.key_len_ = key_len;
     ks.buf_.resize(n * key_len);

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -260,6 +260,38 @@ inline void get_existing_key(
   detail::do_get_existing_key(instance, k);
 }
 
+// key_view operation wrappers — per-operation QSBR for OLC.
+
+template <class Db>
+void kv_insert(Db& db, unodb::key_view k, unodb::value_view v) {
+  std::ignore = db.insert(k, v);
+}
+
+inline void kv_insert(kv_olc_db& db, unodb::key_view k, unodb::value_view v) {
+  const quiescent_state_on_scope_exit q{};
+  std::ignore = db.insert(k, v);
+}
+
+template <class Db>
+void kv_get(const Db& db, unodb::key_view k) {
+  ::benchmark::DoNotOptimize(db.get(k));
+}
+
+inline void kv_get(const kv_olc_db& db, unodb::key_view k) {
+  const quiescent_state_on_scope_exit q{};
+  ::benchmark::DoNotOptimize(db.get(k));
+}
+
+template <class Db>
+void kv_remove(Db& db, unodb::key_view k) {
+  ::benchmark::DoNotOptimize(db.remove(k));
+}
+
+inline void kv_remove(kv_olc_db& db, unodb::key_view k) {
+  const quiescent_state_on_scope_exit q{};
+  ::benchmark::DoNotOptimize(db.remove(k));
+}
+
 // Teardown
 
 template <class Db>
@@ -315,10 +347,7 @@ class key_view_set {
     ks.views_.reserve(n);
     unodb::key_encoder enc;
     for (std::size_t i = 0; i < n; ++i) {
-      auto kv = enc.reset()
-                    .encode(tag)
-                    .encode(static_cast<std::uint64_t>(i))
-                    .get_key_view();
+      auto kv = enc.reset().encode(tag).encode(std::uint64_t{i}).get_key_view();
       std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
       ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
     }
@@ -341,7 +370,7 @@ class key_view_set {
                     .encode(tag)
                     .encode(std::uint64_t{0x4242424242424242ULL})
                     .encode(static_cast<std::uint8_t>(i & 0xFF))
-                    .encode(static_cast<std::uint64_t>(i))
+                    .encode(std::uint64_t{i})
                     .get_key_view();
       std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 18);
       ks.views_.emplace_back(ks.buf_.data() + i * 18, 18);
@@ -365,7 +394,7 @@ class key_view_set {
       const auto tag = static_cast<std::uint8_t>(1 + (i % tag_count));
       auto kv = enc.reset()
                     .encode(tag)
-                    .encode(static_cast<std::uint64_t>(i / tag_count))
+                    .encode(std::uint64_t{i / tag_count})
                     .get_key_view();
       std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
       ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
@@ -414,8 +443,7 @@ class key_view_set {
     ks.views_.reserve(n);
     unodb::key_encoder enc;
     for (std::size_t i = 0; i < n; ++i) {
-      auto kv =
-          enc.reset().encode(static_cast<std::uint64_t>(i)).get_key_view();
+      auto kv = enc.reset().encode(std::uint64_t{i}).get_key_view();
       std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 8);
       ks.views_.emplace_back(ks.buf_.data() + i * 8, 8);
     }

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #endif
 #include <random>
+#include <vector>
 
 #include <benchmark/benchmark.h>
 
@@ -40,11 +41,17 @@
 
 namespace unodb::benchmark {
 
-// Benchmarked tree types
+// Benchmarked tree types (u64 keys)
 
 using db = unodb::db<std::uint64_t, unodb::value_view>;
 using mutex_db = unodb ::mutex_db<std::uint64_t, unodb::value_view>;
 using olc_db = unodb::olc_db<std::uint64_t, unodb::value_view>;
+
+// Benchmarked tree types (key_view keys)
+
+using kv_db = unodb::db<unodb::key_view, unodb::value_view>;
+using kv_mutex_db = unodb::mutex_db<unodb::key_view, unodb::value_view>;
+using kv_olc_db = unodb::olc_db<unodb::key_view, unodb::value_view>;
 
 // Values
 
@@ -266,6 +273,180 @@ destroy_tree<unodb::mutex_db<std::uint64_t, unodb::value_view>>(
 extern template void
 destroy_tree<unodb::olc_db<std::uint64_t, unodb::value_view>>(
     unodb::olc_db<std::uint64_t, unodb::value_view>&, ::benchmark::State&);
+
+extern template void
+destroy_tree<unodb::db<unodb::key_view, unodb::value_view>>(
+    unodb::db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+extern template void
+destroy_tree<unodb::mutex_db<unodb::key_view, unodb::value_view>>(
+    unodb::mutex_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+extern template void
+destroy_tree<unodb::olc_db<unodb::key_view, unodb::value_view>>(
+    unodb::olc_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+
+// ===================================================================
+// key_view benchmark utilities
+// ===================================================================
+
+/// Pre-generated key set with stable storage for benchmarking.
+///
+/// Keys are stored in a contiguous byte buffer; key_view instances
+/// point into it.  The buffer lifetime matches the key_view_set
+/// lifetime, so key_views remain valid as long as the set exists.
+///
+/// Designed to be parameterized on value type in the future (PR #2)
+/// for benchmarking Value=uint64_t (tuple identifier use case).
+class key_view_set {
+ public:
+  /// G1: 9-byte compound keys (tag + uint64).
+  ///
+  /// All keys share the same tag byte → 8 shared prefix bytes →
+  /// 1-level chain I4 at the root.  The uint64 component varies
+  /// sequentially (0..n-1), producing unique dispatch bytes.
+  static key_view_set compound(std::uint8_t tag, std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 9;
+    ks.buf_.resize(n * 9);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      auto kv = enc.reset()
+                    .encode(tag)
+                    .encode(static_cast<std::uint64_t>(i))
+                    .get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
+      ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
+    }
+    return ks;
+  }
+
+  /// G2: 18-byte deep compound keys (tag + uint64 + mid + uint64).
+  ///
+  /// All keys share tag + fixed uint64 → 16 shared prefix bytes →
+  /// 2-level chain.  Exercises multi-level chain insert/remove and
+  /// the Step 2 loop in the atomic chain cut algorithm.
+  static key_view_set deep_compound(std::uint8_t tag, std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 18;
+    ks.buf_.resize(n * 18);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      auto kv = enc.reset()
+                    .encode(tag)
+                    .encode(std::uint64_t{0x4242424242424242ULL})
+                    .encode(static_cast<std::uint8_t>(i & 0xFF))
+                    .encode(static_cast<std::uint64_t>(i))
+                    .get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 18);
+      ks.views_.emplace_back(ks.buf_.data() + i * 18, 18);
+    }
+    return ks;
+  }
+
+  /// G4: Multi-tag compound keys — independent chain subtrees.
+  ///
+  /// Uses @p tag_count distinct first bytes, assigned round-robin.
+  /// The root inode fans out to tag_count independent chain subtrees.
+  /// Simulates real-world key distribution where keys have diverse
+  /// prefixes (e.g., different column values in a secondary index).
+  static key_view_set multi_tag(std::uint8_t tag_count, std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 9;
+    ks.buf_.resize(n * 9);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      const auto tag = static_cast<std::uint8_t>(1 + (i % tag_count));
+      auto kv = enc.reset()
+                    .encode(tag)
+                    .encode(static_cast<std::uint64_t>(i / tag_count))
+                    .get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
+      ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
+    }
+    return ks;
+  }
+
+  /// G6: Fixed-length keys with maximum chain depth.
+  ///
+  /// Produces keys of exactly @p key_len bytes: tag(1) + pad(key_len-2)
+  /// + variant(1).  All keys within a tag group share (key_len-1) bytes,
+  /// producing chain depth = (key_len - 2) / 8.  Four tag groups create
+  /// a root I4.  Used in the key length sweep to characterize
+  /// per-chain-level cost.
+  ///
+  /// @param key_len Key length in bytes (must be >= 2).
+  /// @param n Number of keys (must be <= 256 * 4 = 1024).
+  static key_view_set chain_depth(std::size_t key_len, std::size_t n) {
+    UNODB_DETAIL_ASSERT(key_len >= 2);
+    key_view_set ks;
+    ks.key_len_ = key_len;
+    ks.buf_.resize(n * key_len);
+    ks.views_.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      auto* const dst = ks.buf_.data() + i * key_len;
+      // tag byte: rotate through 4 tags to create a root I4.
+      dst[0] = static_cast<std::byte>(1 + (i / 256) % 4);
+      // pad bytes: all 0x42 (shared prefix).
+      for (std::size_t j = 1; j + 1 < key_len; ++j) dst[j] = std::byte{0x42};
+      // variant byte: unique within each tag group.
+      dst[key_len - 1] = static_cast<std::byte>(i & 0xFF);
+      ks.views_.emplace_back(dst, key_len);
+    }
+    return ks;
+  }
+
+  /// G5: Dense sequential keys — no chains.
+  ///
+  /// encode(uint64) only, producing 8-byte keys with no shared prefix.
+  /// Baseline for isolating key_view encoding overhead vs u64 keys.
+  static key_view_set dense_sequential(std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 8;
+    ks.buf_.resize(n * 8);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      auto kv =
+          enc.reset().encode(static_cast<std::uint64_t>(i)).get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 8);
+      ks.views_.emplace_back(ks.buf_.data() + i * 8, 8);
+    }
+    return ks;
+  }
+
+  [[nodiscard]] const std::vector<unodb::key_view>& keys() const noexcept {
+    return views_;
+  }
+  [[nodiscard]] std::size_t size() const noexcept { return views_.size(); }
+  [[nodiscard]] unodb::key_view operator[](std::size_t i) const noexcept {
+    return views_[i];
+  }
+
+ private:
+  std::vector<std::byte> buf_;
+  std::vector<unodb::key_view> views_;
+  std::size_t key_len_{0};
+};
+
+/// Insert all keys from a key_view_set into a tree.
+template <class Db>
+void populate_tree(Db& instance, const key_view_set& ks,
+                   unodb::value_view val) {
+  for (const auto& k : ks.keys()) {
+    ::benchmark::DoNotOptimize(instance.insert(k, val));
+  }
+}
+
+/// OLC specialization — quiescent state not needed for insert.
+template <>
+inline void populate_tree(kv_olc_db& instance, const key_view_set& ks,
+                          unodb::value_view val) {
+  for (const auto& k : ks.keys()) {
+    ::benchmark::DoNotOptimize(instance.insert(k, val));
+  }
+}
 
 }  // namespace unodb::benchmark
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1639,24 +1639,12 @@ template <typename Key, typename Value, class INode>
         std::move(*child_critical_section)};
     if (UNODB_DETAIL_UNLIKELY(child_guard.must_restart())) return {};
 
-    // For variable-length keys, check leave_last_child precondition:
-    // prefix merge must not overflow key_prefix_capacity.
-    if constexpr (std::is_same_v<Key, key_view>) {
-      const std::uint8_t child_to_leave = (child_i == 0) ? 1U : 0U;
-      const auto remaining = inode.get_child(child_to_leave);
-      if (remaining.type() != node_type::LEAF) {
-        const auto* const ri{
-            remaining
-                .template ptr<detail::olc_inode_base<Key, Value> const*>()};
-        if (ri->get_key_prefix().length() + inode.get_key_prefix().length() +
-                1 >
-            detail::key_prefix_capacity) {
-          child_guard.unlock_and_obsolete();
-          inode.remove(child_i, db_instance);
-          *child_in_parent = nullptr;
-          return true;
-        }
-      }
+    // Prefix merge must not overflow key_prefix_capacity.
+    if (!inode.can_collapse(child_i)) {
+      child_guard.unlock_and_obsolete();
+      inode.remove(child_i, db_instance);
+      *child_in_parent = nullptr;
+      return true;
     }
     auto current_node{olc_art_policy<Key, Value>::make_db_inode_reclaimable_ptr(
         &inode, db_instance)};

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1000,8 +1000,8 @@ class db_leaf_qsbr_deleter {
 
   static_assert(std::is_trivially_destructible_v<leaf_type>);
 
-  constexpr explicit db_leaf_qsbr_deleter(Db& db_
-                                          UNODB_DETAIL_LIFETIMEBOUND) noexcept
+  constexpr explicit db_leaf_qsbr_deleter(
+      Db& db_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
       : db_instance{db_} {}
 
   void operator()(leaf_type* to_delete) const {
@@ -1040,8 +1040,9 @@ class db_leaf_qsbr_deleter {
 /// associated with the unodb::detail::olc_node_ptr..
 ///
 /// \note This returns the lock rather than trying to acquire the lock.
-[[nodiscard]] inline auto& node_ptr_lock(const unodb::detail::olc_node_ptr& node
-                                         UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+[[nodiscard]] inline auto& node_ptr_lock(
+    const unodb::detail::olc_node_ptr&
+        node UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return node.ptr<unodb::detail::olc_node_header*>()->lock();
 }
 
@@ -1049,16 +1050,16 @@ class db_leaf_qsbr_deleter {
 
 template <typename Key, typename Value>
 [[nodiscard]] auto& node_ptr_lock(
-    const unodb::detail::olc_leaf_type<Key, Value>* const node
-    UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+    const unodb::detail::olc_leaf_type<Key, Value>* const
+        node UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return node->lock();
 }
 
 #endif
 
 template <class INode>
-[[nodiscard]] constexpr auto& lock(const INode& inode
-                                   UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+[[nodiscard]] constexpr auto& lock(
+    const INode& inode UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return inode.lock();
 }
 
@@ -3313,9 +3314,7 @@ olc_db<Key, Value>::try_chain_cut(
 
   // --- Step 4.4: Reclaim leaf and chain nodes ---
   leaf_guard.unlock_and_obsolete();
-  {
-    const auto r{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
-  }
+  { const auto r{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)}; }
 
   // chain_bottom_guard may have been consumed by init() in the shrink path.
   // must_restart() returns true when the guard is inactive (no lock).

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -188,8 +188,8 @@ void add_to_orphan_list(
 /// \param orphan_list Global orphaned request list
 /// \return Taken orphaned request list
 [[nodiscard]] detail::dealloc_vector_list_node* take_orphan_list(
-    std::atomic<detail::dealloc_vector_list_node*>& orphan_list
-    UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+    std::atomic<detail::dealloc_vector_list_node*>&
+        orphan_list UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return orphan_list.exchange(nullptr, std::memory_order_acq_rel);
 }
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -163,9 +163,8 @@ class [[nodiscard]] qsbr_epoch final {
 // LCOV_EXCL_START
 /// Print the epoch \a value to the output stream \a os. For debug purposes
 /// only.
-[[gnu::cold]] inline std::ostream& operator<<(std::ostream& os
-                                              UNODB_DETAIL_LIFETIMEBOUND,
-                                              qsbr_epoch value) {
+[[gnu::cold]] inline std::ostream& operator<<(
+    std::ostream& os UNODB_DETAIL_LIFETIMEBOUND, qsbr_epoch value) {
   value.dump(os);
   return os;
 }
@@ -403,8 +402,8 @@ struct qsbr_state {
   atomic_fetch_dec_threads_in_previous_epoch(std::atomic<type>& word) noexcept;
 
   /// Assert that all invariants hold for \a word.
-  static constexpr void assert_invariants(type word
-                                          UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+  static constexpr void assert_invariants(
+      type word UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
     const auto thread_count = do_get_thread_count(word);
     UNODB_DETAIL_ASSERT(thread_count <= max_qsbr_threads);

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -428,8 +428,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeAttemptDeleteAbsent) {
 
   verifier.insert(2, unodb::test::test_values[1]);
 
-  unodb::test::must_not_allocate(
-      [&verifier] { verifier.attempt_remove_missing_keys({1, 3, 0xFF02}); });
+  unodb::test::must_not_allocate([&verifier] {
+    verifier.attempt_remove_missing_keys({1, 3, 0xFF02});
+  });
 
   verifier.check_present_values();
   verifier.check_absent_keys({1, 3, 0xFF02});
@@ -891,8 +892,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, MissingKeyMatchingInodePath) {
   verifier.insert(0x0100, unodb::test::test_values[0]);
   verifier.insert(0x0200, unodb::test::test_values[1]);
 
-  unodb::test::must_not_allocate(
-      [&verifier] { verifier.attempt_remove_missing_keys({0x0101, 0x0202}); });
+  unodb::test::must_not_allocate([&verifier] {
+    verifier.attempt_remove_missing_keys({0x0101, 0x0202});
+  });
 }
 
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -49,8 +49,8 @@ class allocation_failure_injector final {
   ///
   /// \note Do not call directly: use UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION()
   /// instead.
-  static void fail_on_nth_allocation(std::uint64_t n
-                                     UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+  static void fail_on_nth_allocation(
+      std::uint64_t n UNODB_DETAIL_USED_IN_DEBUG) noexcept {
     fail_on_nth_allocation_.store(n, std::memory_order_release);
   }
 


### PR DESCRIPTION
Add micro-benchmark coverage for key_view operations:
- chain_insert / chain_get / chain_remove — single-tag chain structures
- chain_scan — forward scan over chain keys
- compound variant — multi-component encoded keys (tag + uint64)
- Parameterized by tree size (256 to 262144 keys)
- Covers db, mutex_db, and olc_db

These benchmarks establish a performance baseline for key_view operations ahead of the leaf-key-removal work (#612).

Closes #841.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive micro-benchmark suite for key_view-based tree operations (insert, get, remove, scan), key-length sweeps, and comparisons to a numeric-key baseline; integrated into regular, quick, and valgrind runs.
  * Added utilities to generate and populate varied key sets for performance experiments.
* **Bug Fixes**
  * Improved ART tree removal guards to better handle prefix-overflow cases during collapse/detach decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->