### PR TITLE
Feat/leaf key removal

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -1414,7 +1414,8 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
     auto remaining = k;
     remaining.shift_right(depth);
     auto chain{inode_4::create(*this, full_key, remaining,
-                               tree_depth_type{depth}, dispatch, current)};
+                               tree_depth_type{static_cast<std::uint32_t>(depth)},
+                               dispatch, current)};
     current = detail::node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
     account_growing_inode<node_type::I4>();
@@ -1424,7 +1425,8 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
   // Tail: remaining bytes from start_depth to pos.
   if (pos > start) {
     const auto dispatch = full_key[pos - 1];
-    auto chain{inode_4::create(*this, full_key, tree_depth_type{start},
+    auto chain{inode_4::create(*this, full_key,
+                               tree_depth_type{static_cast<std::uint32_t>(start)},
                                static_cast<detail::key_prefix_size>(pos - start - 1),
                                dispatch, current)};
     current = detail::node_ptr{chain.release(), node_type::I4};

--- a/art.hpp
+++ b/art.hpp
@@ -1390,7 +1390,6 @@ bool db<Key, Value>::insert_internal_fixed(art_key_type insert_key,
     (void)insert_key;
     (void)v;
     UNODB_DETAIL_CANNOT_HAPPEN();
-    return false;
   } else {
     auto* node = &root;
     tree_depth_type depth{};

--- a/art.hpp
+++ b/art.hpp
@@ -371,11 +371,20 @@ class db final {
     /// LTE the search_key and invalidated if there is no such entry.
     iterator& seek(art_key_type search_key, bool& match, bool fwd = true);
 
-    /// Return the key_view associated with the current position of
-    /// the iterator.
+    /// Return type for get_key(): key_view when the leaf stores the key,
+    /// scoped_key_view when the key is reconstructed from the inode path.
+    using get_key_result = std::conditional_t<
+        detail::art_policy<Key, Value>::full_key_in_inode_path,
+        scoped_key_view, key_view>;
+
+    /// Return the key associated with the current position of the iterator.
+    ///
+    /// For full_key_in_inode_path trees, returns a scoped_key_view that is
+    /// valid only until the next iterator movement.  For other trees,
+    /// returns a key_view into the leaf (stable for the leaf's lifetime).
     ///
     /// \pre The iterator MUST be valid().
-    [[nodiscard]] key_view get_key() noexcept;
+    [[nodiscard]] get_key_result get_key() noexcept;
 
     /// Return the value_view associated with the current position of
     /// the iterator.
@@ -2038,19 +2047,18 @@ typename db<Key, Value>::iterator& db<Key, Value>::iterator::seek(
 
 UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
 template <typename Key, typename Value>
-key_view db<Key, Value>::iterator::get_key() noexcept {
+typename db<Key, Value>::iterator::get_key_result
+db<Key, Value>::iterator::get_key() noexcept {
   UNODB_DETAIL_ASSERT(valid());  // by contract
-  // TODO(thompsonbry) : variable length keys. The simplest case
-  // where this does not work today is a single root leaf.  In that
-  // case, there is no inode path and we can not properly track the
-  // key in the key_buffer.
-  //
-  // return keybuf_.get_key_view();
-  const auto& e = stack_.top();
-  const auto& node = e.node;
-  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);      // On a leaf.
-  const auto* const leaf{node.template ptr<leaf_type*>()};  // current leaf.
-  return leaf->get_key_view();
+  if constexpr (art_policy::full_key_in_inode_path) {
+    return scoped_key_view{keybuf_.get_key_view()};
+  } else {
+    const auto& e = stack_.top();
+    const auto& node = e.node;
+    UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
+    const auto* const leaf{node.template ptr<leaf_type*>()};
+    return leaf->get_key_view();
+  }
 }
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 

--- a/art.hpp
+++ b/art.hpp
@@ -1216,6 +1216,9 @@ std::optional<detail::node_ptr*> impl_helpers::remove_or_choose_subtree(
             &inode, db_instance)};
         *node_in_parent =
             current_node->leave_last_child(child_i, db_instance);
+#ifdef UNODB_DETAIL_WITH_STATS
+        db_instance.template account_shrinking_inode<INode::type>();
+#endif
       } else {
         // Prefix overflow — cannot collapse.  Just remove the child entry.
         inode.remove(child_i, db_instance);
@@ -1225,10 +1228,10 @@ std::optional<detail::node_ptr*> impl_helpers::remove_or_choose_subtree(
           INode::smaller_derived_type::create(db_instance, inode, child_i)};
       *node_in_parent =
           node_ptr{new_node.release(), INode::smaller_derived_type::type};
-    }
 #ifdef UNODB_DETAIL_WITH_STATS
-    db_instance.template account_shrinking_inode<INode::type>();
-#endif  // UNODB_DETAIL_WITH_STATS
+      db_instance.template account_shrinking_inode<INode::type>();
+#endif
+    }
     return nullptr;
   }
 
@@ -1380,6 +1383,9 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
     auto chain{inode_4::create(*this, full_key, remaining,
                                tree_depth_type{depth}, dispatch, current)};
     current = detail::node_ptr{chain.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+    account_growing_inode<node_type::I4>();
+#endif
     pos = depth;
   }
   // Tail: 1..cap bytes at the start of the key.
@@ -1389,6 +1395,9 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
                                static_cast<detail::key_prefix_size>(pos - 1),
                                dispatch, current)};
     current = detail::node_ptr{chain.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+    account_growing_inode<node_type::I4>();
+#endif
   }
   return current;
 }

--- a/art.hpp
+++ b/art.hpp
@@ -19,8 +19,8 @@
 #include <iostream>
 #include <optional>
 #include <stack>
-#include <vector>
 #include <type_traits>
+#include <vector>
 
 #include <boost/container/small_vector.hpp>
 
@@ -98,9 +98,9 @@ using inode_base = basic_inode_impl<art_policy<Key, Value>>;
 
 /// Leaf node type for non-thread-safe ART.
 ///
-/// Stores a key-value pair at the leaf level of the tree.
-template <typename Key>
-using leaf_type = basic_leaf<Key, node_header>;
+/// Stores a key-value pair (or value only for keyless leaves).
+template <typename Key, typename Value>
+using leaf_type = basic_leaf<leaf_key_type<Key, Value>, node_header>;
 
 /// Internal node base class for non-thread-safe ART.
 ///
@@ -144,8 +144,8 @@ class db final {
   /// Internal encoded key type used for tree operations.
   using art_key_type = detail::basic_art_key<Key>;
 
-  /// Leaf node type storing key-value pairs.
-  using leaf_type = detail::leaf_type<Key>;
+  /// Leaf node type (keyless when can_eliminate_key_in_leaf).
+  using leaf_type = detail::leaf_type<Key, Value>;
 
   /// Database type (self-reference for template instantiation).
   using db_type = db<Key, Value>;
@@ -372,14 +372,14 @@ class db final {
     iterator& seek(art_key_type search_key, bool& match, bool fwd = true);
 
     /// Return type for get_key(): key_view when the leaf stores the key,
-    /// scoped_key_view when the key is reconstructed from the inode path.
+    /// transient_key_view when the key is reconstructed from the inode path.
     using get_key_result = std::conditional_t<
-        detail::art_policy<Key, Value>::full_key_in_inode_path,
-        scoped_key_view, key_view>;
+        detail::art_policy<Key, Value>::full_key_in_inode_path, transient_key_view,
+        key_view>;
 
     /// Return the key associated with the current position of the iterator.
     ///
-    /// For full_key_in_inode_path trees, returns a scoped_key_view that is
+    /// For full_key_in_inode_path trees, returns a transient_key_view that is
     /// valid only until the next iterator movement.  For other trees,
     /// returns a key_view into the leaf (stable for the leaf's lifetime).
     ///
@@ -449,6 +449,7 @@ class db final {
       std::reverse(result.begin(), result.end());
       return result;
     }
+
    protected:
     /// Descend to left-most leaf from given \a node.
     ///
@@ -543,9 +544,8 @@ class db final {
       UNODB_DETAIL_ASSERT(!empty());
 
       const auto& e = top();
-      const auto n = (e.node.type() != node_type::LEAF)
-                         ? e.prefix.length() + 1
-                         : 0;
+      const auto n = static_cast<std::size_t>(
+          (e.node.type() != node_type::LEAF) ? e.prefix.length() + 1 : 0);
       keybuf_.pop(n);
       stack_.pop();
     }
@@ -1206,7 +1206,7 @@ detail::node_ptr* impl_helpers::add_or_choose_subtree(
   if constexpr (!std::is_same_v<INode, inode_256<Key, Value>>) {
     if (UNODB_DETAIL_UNLIKELY(children_count == INode::capacity)) {
       auto larger_node{INode::larger_derived_type::create(
-          db_instance, inode, std::move(leaf), depth)};
+          db_instance, inode, std::move(leaf), depth, key_byte)};
       *node_in_parent =
           node_ptr{larger_node.release(), INode::larger_derived_type::type};
 #ifdef UNODB_DETAIL_WITH_STATS
@@ -1221,8 +1221,9 @@ detail::node_ptr* impl_helpers::add_or_choose_subtree(
         if (chain_start < k.size()) {
           // FIXME(@laurynas-biveinis): volatile works around #700.
           const volatile auto* vp = node_in_parent;
-          auto& new_inode = *const_cast<detail::node_ptr&>(*vp)
-              .template ptr<typename INode::larger_derived_type*>();
+          auto& new_inode =
+              *const_cast<detail::node_ptr&>(*vp)
+                   .template ptr<typename INode::larger_derived_type*>();
           auto* const slot = unwrap_fake_critical_section(
               new_inode.find_child(key_byte).second);
           UNODB_DETAIL_ASSERT(slot != nullptr);
@@ -1233,7 +1234,7 @@ detail::node_ptr* impl_helpers::add_or_choose_subtree(
       return child;
     }
   }
-  inode.add_to_nonfull(std::move(leaf), depth, children_count);
+  inode.add_to_nonfull(std::move(leaf), depth, key_byte, children_count);
 
   // For full_key_in_inode_path: wrap the bare leaf in a chain encoding
   // the remaining key suffix.  The leaf was just inserted into the slot
@@ -1277,8 +1278,7 @@ std::optional<detail::node_ptr*> impl_helpers::remove_or_choose_subtree(
       if (UNODB_DETAIL_LIKELY(inode.can_collapse(child_i))) {
         auto current_node{art_policy<Key, Value>::make_db_inode_unique_ptr(
             &inode, db_instance)};
-        *node_in_parent =
-            current_node->leave_last_child(child_i, db_instance);
+        *node_in_parent = current_node->leave_last_child(child_i, db_instance);
 #ifdef UNODB_DETAIL_WITH_STATS
         db_instance.template account_shrinking_inode<INode::type>();
 #endif
@@ -1322,7 +1322,12 @@ typename db<Key, Value>::get_result db<Key, Value>::get_internal(
     const auto node_type = node.type();
     if (node_type == node_type::LEAF) {
       const auto* const leaf{node.template ptr<leaf_type*>()};
-      if (leaf->matches(k)) return leaf->template get_value<value_type>();
+      if constexpr (art_policy::can_eliminate_key_in_leaf) {
+        if (remaining_key.size() == 0)
+          return leaf->template get_value<value_type>();
+      } else {
+        if (leaf->matches(k)) return leaf->template get_value<value_type>();
+      }
       return {};
     }
 
@@ -1350,9 +1355,17 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26430)
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
 template <typename Key, typename Value>
 bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
+  if constexpr (std::is_same_v<Key, key_view>) {
+    if (UNODB_DETAIL_UNLIKELY(
+            insert_key.size() >
+            std::numeric_limits<unodb::key_size_type>::max())) {
+      throw std::length_error("Key length must fit in std::uint32_t");
+    }
+  }
+
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) {
     auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-    if constexpr (art_policy::can_eliminate_leaf) {
+    if constexpr (art_policy::can_eliminate_key_in_leaf) {
       root = build_chain(insert_key,
                          detail::node_ptr{leaf.release(), node_type::LEAF},
                          tree_depth_type{0});
@@ -1372,60 +1385,69 @@ bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
 template <typename Key, typename Value>
 bool db<Key, Value>::insert_internal_fixed(art_key_type insert_key,
                                            value_type v) {
-  auto* node = &root;
-  tree_depth_type depth{};
-  auto remaining_key{insert_key};
+  if constexpr (std::is_same_v<Key, key_view>) {
+    // Never called for key_view — dispatch goes to insert_internal_key_view.
+    (void)insert_key;
+    (void)v;
+    UNODB_DETAIL_CANNOT_HAPPEN();
+    return false;
+  } else {
+    auto* node = &root;
+    tree_depth_type depth{};
+    auto remaining_key{insert_key};
 
-  while (true) {
-    const auto node_type = node->type();
-    if (node_type == node_type::LEAF) {
-      auto* const leaf{node->template ptr<leaf_type*>()};
-      const auto existing_key{leaf->get_key_view()};
-      const auto cmp = insert_key.cmp(existing_key);
-      if (UNODB_DETAIL_UNLIKELY(cmp == 0)) {
-        return false;  // exists
+    while (true) {
+      const auto node_type = node->type();
+      if (node_type == node_type::LEAF) {
+        auto* const leaf{node->template ptr<leaf_type*>()};
+        const auto existing_key{leaf->get_key_view()};
+        const auto cmp = insert_key.cmp(existing_key);
+        if (UNODB_DETAIL_UNLIKELY(cmp == 0)) {
+          return false;  // exists
+        }
+        auto new_leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
+        auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
+                                      leaf, std::move(new_leaf))};
+        *node = detail::node_ptr{new_node.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+        account_growing_inode<node_type::I4>();
+#endif  // UNODB_DETAIL_WITH_STATS
+        return true;
       }
-      auto new_leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-      auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
-                                    leaf, std::move(new_leaf))};
-      *node = detail::node_ptr{new_node.release(), node_type::I4};
+
+      UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
+
+      auto* const inode{node->template ptr<inode_type*>()};
+      const auto& key_prefix{inode->get_key_prefix()};
+      const auto key_prefix_length{key_prefix.length()};
+      const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
+      if (shared_prefix_len < key_prefix_length) {
+        auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
+        auto new_node =
+            inode_4::create(*this, *node, shared_prefix_len, depth,
+                            std::move(leaf), remaining_key[shared_prefix_len]);
+        *node = detail::node_ptr{new_node.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
-      account_growing_inode<node_type::I4>();
+        account_growing_inode<node_type::I4>();
+        ++key_prefix_splits;
+        UNODB_DETAIL_ASSERT(growing_inode_counts[internal_as_i<node_type::I4>] >
+                            key_prefix_splits);
 #endif  // UNODB_DETAIL_WITH_STATS
-      return true;
+        return true;
+      }
+      UNODB_DETAIL_ASSERT(shared_prefix_len == key_prefix_length);
+      depth += key_prefix_length;
+      remaining_key.shift_right(key_prefix_length);
+
+      node = inode->template add_or_choose_subtree<detail::node_ptr*>(
+          node_type, remaining_key[0], insert_key, v, *this, depth, node);
+
+      if (node == nullptr) return true;
+
+      ++depth;
+      remaining_key.shift_right(1);
     }
-
-    UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
-
-    auto* const inode{node->template ptr<inode_type*>()};
-    const auto& key_prefix{inode->get_key_prefix()};
-    const auto key_prefix_length{key_prefix.length()};
-    const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
-    if (shared_prefix_len < key_prefix_length) {
-      auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-      auto new_node = inode_4::create(*this, *node, shared_prefix_len, depth,
-                                      std::move(leaf));
-      *node = detail::node_ptr{new_node.release(), node_type::I4};
-#ifdef UNODB_DETAIL_WITH_STATS
-      account_growing_inode<node_type::I4>();
-      ++key_prefix_splits;
-      UNODB_DETAIL_ASSERT(growing_inode_counts[internal_as_i<node_type::I4>] >
-                          key_prefix_splits);
-#endif  // UNODB_DETAIL_WITH_STATS
-      return true;
-    }
-    UNODB_DETAIL_ASSERT(shared_prefix_len == key_prefix_length);
-    depth += key_prefix_length;
-    remaining_key.shift_right(key_prefix_length);
-
-    node = inode->template add_or_choose_subtree<detail::node_ptr*>(
-        node_type, remaining_key[0], insert_key, v, *this, depth, node);
-
-    if (node == nullptr) return true;
-
-    ++depth;
-    remaining_key.shift_right(1);
-  }
+  }  // else (non-key_view)
 }
 
 template <typename Key, typename Value>
@@ -1445,9 +1467,9 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
     const auto dispatch = full_key[pos - 1];
     auto remaining = k;
     remaining.shift_right(depth);
-    auto chain{inode_4::create(*this, full_key, remaining,
-                               tree_depth_type{static_cast<std::uint32_t>(depth)},
-                               dispatch, current)};
+    auto chain{inode_4::create(
+        *this, full_key, remaining,
+        tree_depth_type{static_cast<std::uint32_t>(depth)}, dispatch, current)};
     current = detail::node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
     account_growing_inode<node_type::I4>();
@@ -1457,10 +1479,10 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
   // Tail: remaining bytes from start_depth to pos.
   if (pos > start) {
     const auto dispatch = full_key[pos - 1];
-    auto chain{inode_4::create(*this, full_key,
-                               tree_depth_type{static_cast<std::uint32_t>(start)},
-                               static_cast<detail::key_prefix_size>(pos - start - 1),
-                               dispatch, current)};
+    auto chain{inode_4::create(
+        *this, full_key, tree_depth_type{static_cast<std::uint32_t>(start)},
+        static_cast<detail::key_prefix_size>(pos - start - 1), dispatch,
+        current)};
     current = detail::node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
     account_growing_inode<node_type::I4>();
@@ -1479,50 +1501,58 @@ bool db<Key, Value>::insert_internal_key_view(art_key_type insert_key,
   while (true) {
     const auto node_type = node->type();
     if (node_type == node_type::LEAF) {
-      auto* const leaf{node->template ptr<leaf_type*>()};
-      const auto existing_key{leaf->get_key_view()};
-      const auto cmp = insert_key.cmp(existing_key);
-      if (UNODB_DETAIL_UNLIKELY(cmp == 0)) {
-        return false;  // exists
-      }
-      constexpr auto cap = detail::key_prefix_capacity;
-      const auto remaining_existing = existing_key.subspan(depth);
-      const auto shared = detail::key_prefix_snapshot::shared_len(
-          detail::get_u64(remaining_existing), remaining_key.get_u64(), cap);
-      if (shared >= cap && remaining_existing.size() > cap &&
-          remaining_key.size() > cap &&
-          remaining_existing[cap] == remaining_key[cap]) {
-        const auto dispatch = remaining_existing[cap];
-        auto chain{inode_4::create(*this, existing_key, remaining_key, depth,
-                                   dispatch, *node)};
-        *node = detail::node_ptr{chain.release(), node_type::I4};
+      if constexpr (art_policy::can_eliminate_key_in_leaf) {
+        // Keyless leaf: the inode path consumed all bytes of the existing
+        // key.  The ART prefix restriction guarantees no key is a prefix
+        // of another, so remaining_key must be empty → duplicate.
+        UNODB_DETAIL_ASSERT(remaining_key.size() == 0);
+        return false;
+      } else {
+        auto* const leaf{node->template ptr<leaf_type*>()};
+        const auto existing_key{leaf->get_key_view()};
+        const auto cmp = insert_key.cmp(existing_key);
+        if (UNODB_DETAIL_UNLIKELY(cmp == 0)) {
+          return false;  // exists
+        }
+        constexpr auto cap = detail::key_prefix_capacity;
+        const auto remaining_existing = existing_key.subspan(depth);
+        const auto shared = detail::key_prefix_snapshot::shared_len(
+            detail::get_u64(remaining_existing), remaining_key.get_u64(), cap);
+        if (shared >= cap && remaining_existing.size() > cap &&
+            remaining_key.size() > cap &&
+            remaining_existing[cap] == remaining_key[cap]) {
+          const auto dispatch = remaining_existing[cap];
+          auto chain{inode_4::create(*this, existing_key, remaining_key, depth,
+                                     dispatch, *node)};
+          *node = detail::node_ptr{chain.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+          account_growing_inode<node_type::I4>();
+#endif  // UNODB_DETAIL_WITH_STATS
+          continue;
+        }
+        auto new_leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
+        auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
+                                      leaf, std::move(new_leaf))};
+        *node = detail::node_ptr{new_node.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
         account_growing_inode<node_type::I4>();
 #endif  // UNODB_DETAIL_WITH_STATS
-        continue;
-      }
-      auto new_leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-      auto new_node{inode_4::create(*this, existing_key, remaining_key, depth,
-                                    leaf, std::move(new_leaf))};
-      *node = detail::node_ptr{new_node.release(), node_type::I4};
-#ifdef UNODB_DETAIL_WITH_STATS
-      account_growing_inode<node_type::I4>();
-#endif  // UNODB_DETAIL_WITH_STATS
 
-      if constexpr (art_policy::full_key_in_inode_path) {
-        const auto chain_start =
-            static_cast<tree_depth_type>(depth + shared + 1);
-        if (chain_start < insert_key.size()) {
-          auto* const new_inode = node->template ptr<inode_type*>();
-          auto* const slot =
-              new_inode->find_child(node_type::I4, remaining_key[shared])
-                  .second;
-          UNODB_DETAIL_ASSERT(slot != nullptr);
-          *slot = build_chain(insert_key, *slot, chain_start);
+        if constexpr (art_policy::full_key_in_inode_path) {
+          const auto chain_start =
+              static_cast<tree_depth_type>(depth + shared + 1);
+          if (chain_start < insert_key.size()) {
+            auto* const new_inode = node->template ptr<inode_type*>();
+            auto* const slot =
+                new_inode->find_child(node_type::I4, remaining_key[shared])
+                    .second;
+            UNODB_DETAIL_ASSERT(slot != nullptr);
+            *slot = build_chain(insert_key, *slot, chain_start);
+          }
         }
-      }
 
-      return true;
+        return true;
+      }  // else (keyed leaf)
     }
 
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
@@ -1533,8 +1563,9 @@ bool db<Key, Value>::insert_internal_key_view(art_key_type insert_key,
     const auto shared_prefix_len{key_prefix.get_shared_length(remaining_key)};
     if (shared_prefix_len < key_prefix_length) {
       auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-      auto new_node = inode_4::create(*this, *node, shared_prefix_len, depth,
-                                      std::move(leaf));
+      auto new_node =
+          inode_4::create(*this, *node, shared_prefix_len, depth,
+                          std::move(leaf), remaining_key[shared_prefix_len]);
       *node = detail::node_ptr{new_node.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
       account_growing_inode<node_type::I4>();
@@ -1549,8 +1580,8 @@ bool db<Key, Value>::insert_internal_key_view(art_key_type insert_key,
         if (chain_start < insert_key.size()) {
           auto* const new_inode = node->template ptr<inode_type*>();
           auto* const slot =
-              new_inode->find_child(node_type::I4,
-                                    remaining_key[shared_prefix_len])
+              new_inode
+                  ->find_child(node_type::I4, remaining_key[shared_prefix_len])
                   .second;
           UNODB_DETAIL_ASSERT(slot != nullptr);
           *slot = build_chain(insert_key, *slot, chain_start);
@@ -1664,14 +1695,22 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
 
     // Found a leaf — verify it matches.
     auto* const leaf{child_val.template ptr<leaf_type*>()};
-    if (!leaf->matches(remove_key)) return false;
+    if constexpr (art_policy::can_eliminate_key_in_leaf) {
+      // Keyless leaf: verify all key bytes were consumed by the inode
+      // path.  remaining_key[0] is the dispatch byte (already matched
+      // by find_child).  Any additional bytes mean the search key is
+      // longer than the stored key.
+      if (remaining_key.size() != 1) return false;
+    } else {
+      if (!leaf->matches(remove_key)) return false;
+    }
 
     // --- Upward pass ---
     const auto count = inode->get_children_count();
 
     if (count > 1 || ntype != node_type::I4) {
-      const auto remove_result
-          UNODB_DETAIL_USED_IN_DEBUG{inode->template remove_or_choose_subtree<
+      const auto remove_result UNODB_DETAIL_USED_IN_DEBUG{
+          inode->template remove_or_choose_subtree<
               std::optional<detail::node_ptr*>>(ntype, remaining_key[0],
                                                 remove_key, *this, slot)};
       UNODB_DETAIL_ASSERT(remove_result.has_value());
@@ -1681,9 +1720,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
 
     // Single-child inode (chain node).  Reclaim leaf and chain,
     // then walk up cleaning any further empty chains.
-    {
-      const auto rl{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
-    }
+    { const auto rl{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)}; }
     {
       const auto ri{art_policy::make_db_inode_unique_ptr(
           node_val.template ptr<inode_4*>(), *this)};
@@ -1728,11 +1765,12 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26815) bool db<
           }
           remaining_inode->get_key_prefix().prepend(pi4->get_key_prefix(),
                                                     remaining_iter.key_byte);
+        } else if constexpr (art_policy::can_eliminate_key_in_leaf) {
+          // Keyless leaf: don't collapse — keep the chain intact.
+          return true;
         }
         *entry.slot = remaining;
-        {
-          const auto ri{art_policy::make_db_inode_unique_ptr(pi4, *this)};
-        }
+        { const auto ri{art_policy::make_db_inode_unique_ptr(pi4, *this)}; }
 #ifdef UNODB_DETAIL_WITH_STATS
         account_shrinking_inode<node_type::I4>();
 #endif
@@ -1913,7 +1951,12 @@ typename db<Key, Value>::iterator& db<Key, Value>::iterator::seek(
     if (node_type == node_type::LEAF) {
       const auto* const leaf{node.template ptr<leaf_type*>()};
       push_leaf(node);
-      const auto cmp_ = leaf->cmp(k);
+      int cmp_;
+      if constexpr (art_policy::full_key_in_inode_path) {
+        cmp_ = unodb::detail::compare(keybuf_.get_key_view(), k.get_key_view());
+      } else {
+        cmp_ = leaf->cmp(k);
+      }
       if (cmp_ == 0) {
         match = true;
         return *this;
@@ -2054,7 +2097,7 @@ typename db<Key, Value>::iterator::get_key_result
 db<Key, Value>::iterator::get_key() noexcept {
   UNODB_DETAIL_ASSERT(valid());  // by contract
   if constexpr (art_policy::full_key_in_inode_path) {
-    return scoped_key_view{keybuf_.get_key_view()};
+    return transient_key_view{keybuf_.get_key_view()};
   } else {
     const auto& e = stack_.top();
     const auto& node = e.node;
@@ -2066,8 +2109,8 @@ db<Key, Value>::iterator::get_key() noexcept {
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
 template <typename Key, typename Value>
-typename db<Key, Value>::value_type
-db<Key, Value>::iterator::get_val() const noexcept {
+typename db<Key, Value>::value_type db<Key, Value>::iterator::get_val()
+    const noexcept {
   UNODB_DETAIL_ASSERT(valid());  // by contract
   const auto& e = stack_.top();
   const auto& node = e.node;

--- a/art.hpp
+++ b/art.hpp
@@ -181,10 +181,12 @@ class db final {
   /// (with prefix from the start of the key) becomes the root.
   ///
   /// \param k The full encoded key
-  /// \param child The leaf node to place at the bottom of the chain
-  /// \return The chain top node, or \a child itself if the key is empty
-  [[nodiscard]] detail::node_ptr build_chain(art_key_type k,
-                                             detail::node_ptr child);
+  /// \param child The node to place at the bottom of the chain
+  /// \param start_depth Depth at which the chain starts (default 0)
+  /// \return The chain top node, or \a child if no bytes to encode
+  [[nodiscard]] detail::node_ptr build_chain(
+      art_key_type k, detail::node_ptr child,
+      detail::tree_depth<art_key_type> start_depth = {});
 
   /// Remove the entry associated with the encoded key \a remove_key.
   ///
@@ -1182,10 +1184,40 @@ detail::node_ptr* impl_helpers::add_or_choose_subtree(
       db_instance
           .template account_growing_inode<INode::larger_derived_type::type>();
 #endif  // UNODB_DETAIL_WITH_STATS
+
+      // For full_key_in_inode_path: wrap the bare leaf in a chain.
+      if constexpr (art_policy<Key, Value>::full_key_in_inode_path) {
+        auto& new_inode = *node_in_parent->template ptr<
+            typename INode::larger_derived_type*>();
+        auto* const slot = unwrap_fake_critical_section(
+            new_inode.find_child(key_byte).second);
+        UNODB_DETAIL_ASSERT(slot != nullptr);
+        const auto chain_start =
+            static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
+        if (chain_start < k.size()) {
+          *slot = db_instance.build_chain(k, *slot, chain_start);
+        }
+      }
+
       return child;
     }
   }
   inode.add_to_nonfull(std::move(leaf), depth, children_count);
+
+  // For full_key_in_inode_path: wrap the bare leaf in a chain encoding
+  // the remaining key suffix.  The leaf was just inserted into the slot
+  // for key_byte — find it and replace with the chain top.
+  if constexpr (art_policy<Key, Value>::full_key_in_inode_path) {
+    auto* const slot = unwrap_fake_critical_section(
+        inode.find_child(key_byte).second);
+    UNODB_DETAIL_ASSERT(slot != nullptr);
+    const auto chain_start =
+        static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
+    if (chain_start < k.size()) {
+      *slot = db_instance.build_chain(k, *slot, chain_start);
+    }
+  }
+
   return child;
 }
 
@@ -1366,16 +1398,17 @@ bool db<Key, Value>::insert_internal_fixed(art_key_type insert_key,
 
 template <typename Key, typename Value>
 detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
-                                             detail::node_ptr child) {
+                                             detail::node_ptr child,
+                                             tree_depth_type start_depth) {
   constexpr std::size_t cap = detail::key_prefix_capacity;
   const auto full_key = k.get_key_view();
   const auto key_len = k.size();
+  const auto start = static_cast<std::size_t>(start_depth);
   auto current = child;
-  // Build bottom-up: start from end of key, work toward root.
+  // Build bottom-up: start from end of key, work toward start_depth.
   // Each chain I4 consumes up to cap prefix bytes + 1 dispatch byte.
-  // The last I4 created (with prefix from key[0..]) becomes the root.
   std::size_t pos = key_len;
-  while (pos > cap) {
+  while (pos > start + cap) {
     const auto depth = pos - cap - 1;
     const auto dispatch = full_key[pos - 1];
     auto remaining = k;
@@ -1388,11 +1421,11 @@ detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
 #endif
     pos = depth;
   }
-  // Tail: 1..cap bytes at the start of the key.
-  if (pos > 0) {
+  // Tail: remaining bytes from start_depth to pos.
+  if (pos > start) {
     const auto dispatch = full_key[pos - 1];
-    auto chain{inode_4::create(*this, full_key, tree_depth_type{0},
-                               static_cast<detail::key_prefix_size>(pos - 1),
+    auto chain{inode_4::create(*this, full_key, tree_depth_type{start},
+                               static_cast<detail::key_prefix_size>(pos - start - 1),
                                dispatch, current)};
     current = detail::node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/art.hpp
+++ b/art.hpp
@@ -1289,7 +1289,7 @@ template <typename Key, typename Value>
 bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) {
     auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-    if constexpr (std::is_same_v<Key, key_view>) {
+    if constexpr (art_policy::can_eliminate_leaf) {
       root = build_chain(insert_key,
                          detail::node_ptr{leaf.release(), node_type::LEAF});
     } else {

--- a/art.hpp
+++ b/art.hpp
@@ -171,6 +171,21 @@ class db final {
   [[nodiscard]] bool insert_internal_key_view(art_key_type insert_key,
                                               value_type v);
 
+  /// Build an inode chain for the first key_view insert into an empty tree.
+  ///
+  /// For key_view keys, the tree must always have at least one inode above
+  /// every leaf so that the iterator's key buffer (keybuf_) is populated
+  /// during traversal.  This method wraps \a child in a chain of single-child
+  /// I4 nodes, each consuming up to key_prefix_capacity prefix bytes + 1
+  /// dispatch byte from the key.  Built bottom-up: the last I4 created
+  /// (with prefix from the start of the key) becomes the root.
+  ///
+  /// \param k The full encoded key
+  /// \param child The leaf node to place at the bottom of the chain
+  /// \return The chain top node, or \a child itself if the key is empty
+  [[nodiscard]] detail::node_ptr build_chain(art_key_type k,
+                                             detail::node_ptr child);
+
   /// Remove the entry associated with the encoded key \a remove_key.
   ///
   /// \return true if the delete was successful (i.e. the key was found in the
@@ -1196,9 +1211,15 @@ std::optional<detail::node_ptr*> impl_helpers::remove_or_choose_subtree(
 
   if (UNODB_DETAIL_UNLIKELY(inode.is_min_size())) {
     if constexpr (std::is_same_v<INode, inode_4<Key, Value>>) {
-      auto current_node{art_policy<Key, Value>::make_db_inode_unique_ptr(
-          &inode, db_instance)};
-      *node_in_parent = current_node->leave_last_child(child_i, db_instance);
+      if (UNODB_DETAIL_LIKELY(inode.can_collapse(child_i))) {
+        auto current_node{art_policy<Key, Value>::make_db_inode_unique_ptr(
+            &inode, db_instance)};
+        *node_in_parent =
+            current_node->leave_last_child(child_i, db_instance);
+      } else {
+        // Prefix overflow — cannot collapse.  Just remove the child entry.
+        inode.remove(child_i, db_instance);
+      }
     } else {
       auto new_node{
           INode::smaller_derived_type::create(db_instance, inode, child_i)};
@@ -1265,7 +1286,12 @@ template <typename Key, typename Value>
 bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
   if (UNODB_DETAIL_UNLIKELY(root == nullptr)) {
     auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
-    root = detail::node_ptr{leaf.release(), node_type::LEAF};
+    if constexpr (std::is_same_v<Key, key_view>) {
+      root = build_chain(insert_key,
+                         detail::node_ptr{leaf.release(), node_type::LEAF});
+    } else {
+      root = detail::node_ptr{leaf.release(), node_type::LEAF};
+    }
     return true;
   }
 
@@ -1333,6 +1359,38 @@ bool db<Key, Value>::insert_internal_fixed(art_key_type insert_key,
     ++depth;
     remaining_key.shift_right(1);
   }
+}
+
+template <typename Key, typename Value>
+detail::node_ptr db<Key, Value>::build_chain(art_key_type k,
+                                             detail::node_ptr child) {
+  constexpr std::size_t cap = detail::key_prefix_capacity;
+  const auto full_key = k.get_key_view();
+  const auto key_len = k.size();
+  auto current = child;
+  // Build bottom-up: start from end of key, work toward root.
+  // Each chain I4 consumes up to cap prefix bytes + 1 dispatch byte.
+  // The last I4 created (with prefix from key[0..]) becomes the root.
+  std::size_t pos = key_len;
+  while (pos > cap) {
+    const auto depth = pos - cap - 1;
+    const auto dispatch = full_key[pos - 1];
+    auto remaining = k;
+    remaining.shift_right(depth);
+    auto chain{inode_4::create(*this, full_key, remaining,
+                               tree_depth_type{depth}, dispatch, current)};
+    current = detail::node_ptr{chain.release(), node_type::I4};
+    pos = depth;
+  }
+  // Tail: 1..cap bytes at the start of the key.
+  if (pos > 0) {
+    const auto dispatch = full_key[pos - 1];
+    auto chain{inode_4::create(*this, full_key, tree_depth_type{0},
+                               static_cast<detail::key_prefix_size>(pos - 1),
+                               dispatch, current)};
+    current = detail::node_ptr{chain.release(), node_type::I4};
+  }
+  return current;
 }
 
 template <typename Key, typename Value>

--- a/art.hpp
+++ b/art.hpp
@@ -1474,6 +1474,20 @@ bool db<Key, Value>::insert_internal_key_view(art_key_type insert_key,
 #ifdef UNODB_DETAIL_WITH_STATS
       account_growing_inode<node_type::I4>();
 #endif  // UNODB_DETAIL_WITH_STATS
+
+      if constexpr (art_policy::full_key_in_inode_path) {
+        const auto chain_start =
+            static_cast<tree_depth_type>(depth + shared + 1);
+        if (chain_start < insert_key.size()) {
+          auto* const new_inode = node->template ptr<inode_type*>();
+          auto* const slot =
+              new_inode->find_child(node_type::I4, remaining_key[shared])
+                  .second;
+          UNODB_DETAIL_ASSERT(slot != nullptr);
+          *slot = build_chain(insert_key, *slot, chain_start);
+        }
+      }
+
       return true;
     }
 
@@ -1494,6 +1508,20 @@ bool db<Key, Value>::insert_internal_key_view(art_key_type insert_key,
       UNODB_DETAIL_ASSERT(growing_inode_counts[internal_as_i<node_type::I4>] >
                           key_prefix_splits);
 #endif  // UNODB_DETAIL_WITH_STATS
+
+      if constexpr (art_policy::full_key_in_inode_path) {
+        const auto chain_start =
+            static_cast<tree_depth_type>(depth + shared_prefix_len + 1);
+        if (chain_start < insert_key.size()) {
+          auto* const new_inode = node->template ptr<inode_type*>();
+          auto* const slot =
+              new_inode->find_child(node_type::I4,
+                                    remaining_key[shared_prefix_len])
+                  .second;
+          UNODB_DETAIL_ASSERT(slot != nullptr);
+          *slot = build_chain(insert_key, *slot, chain_start);
+        }
+      }
       return true;
     }
     UNODB_DETAIL_ASSERT(shared_prefix_len == key_prefix_length);

--- a/art.hpp
+++ b/art.hpp
@@ -133,7 +133,7 @@ class db final {
   /// Result type for get operations.
   ///
   /// Contains value_view if key was found, otherwise empty.
-  using get_result = std::optional<value_view>;
+  using get_result = std::optional<value_type>;
 
   /// Base class type for internal nodes.
   using inode_base = detail::inode_base<Key, Value>;

--- a/art.hpp
+++ b/art.hpp
@@ -138,9 +138,6 @@ class db final {
   /// Base class type for internal nodes.
   using inode_base = detail::inode_base<Key, Value>;
 
-  // TODO(laurynas): added temporarily during development
-  static_assert(std::is_same_v<value_type, unodb::value_view>);
-
  private:
   /// Internal encoded key type used for tree operations.
   using art_key_type = detail::basic_art_key<Key>;

--- a/art.hpp
+++ b/art.hpp
@@ -1187,14 +1187,16 @@ detail::node_ptr* impl_helpers::add_or_choose_subtree(
 
       // For full_key_in_inode_path: wrap the bare leaf in a chain.
       if constexpr (art_policy<Key, Value>::full_key_in_inode_path) {
-        auto& new_inode = *node_in_parent->template ptr<
-            typename INode::larger_derived_type*>();
-        auto* const slot = unwrap_fake_critical_section(
-            new_inode.find_child(key_byte).second);
-        UNODB_DETAIL_ASSERT(slot != nullptr);
         const auto chain_start =
             static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
         if (chain_start < k.size()) {
+          // FIXME(@laurynas-biveinis): volatile works around #700.
+          const volatile auto* vp = node_in_parent;
+          auto& new_inode = *const_cast<detail::node_ptr&>(*vp)
+              .template ptr<typename INode::larger_derived_type*>();
+          auto* const slot = unwrap_fake_critical_section(
+              new_inode.find_child(key_byte).second);
+          UNODB_DETAIL_ASSERT(slot != nullptr);
           *slot = db_instance.build_chain(k, *slot, chain_start);
         }
       }
@@ -1208,12 +1210,12 @@ detail::node_ptr* impl_helpers::add_or_choose_subtree(
   // the remaining key suffix.  The leaf was just inserted into the slot
   // for key_byte — find it and replace with the chain top.
   if constexpr (art_policy<Key, Value>::full_key_in_inode_path) {
-    auto* const slot = unwrap_fake_critical_section(
-        inode.find_child(key_byte).second);
-    UNODB_DETAIL_ASSERT(slot != nullptr);
     const auto chain_start =
         static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
     if (chain_start < k.size()) {
+      auto* const slot = unwrap_fake_critical_section(
+          UNODB_DETAIL_RELOAD(inode).find_child(key_byte).second);
+      UNODB_DETAIL_ASSERT(slot != nullptr);
       *slot = db_instance.build_chain(k, *slot, chain_start);
     }
   }

--- a/art.hpp
+++ b/art.hpp
@@ -473,14 +473,17 @@ class db final {
     /// \return -1, 0, or 1 if this key is LT, EQ, or GT the other
     /// key.
     [[nodiscard]] int cmp(art_key_type akey) const noexcept {
-      // TODO(thompsonbry) : variable length keys. Explore a cheaper way to
-      // handle the exclusive bound case when developing variable length key
-      // support based on the maintained key buffer.
       UNODB_DETAIL_ASSERT(!stack_.empty());
-      auto& node = stack_.top().node;
-      UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
-      const auto* const leaf{node.template ptr<leaf_type*>()};
-      return unodb::detail::compare(leaf->get_key_view(), akey.get_key_view());
+      if constexpr (art_policy::full_key_in_inode_path) {
+        return unodb::detail::compare(keybuf_.get_key_view(),
+                                      akey.get_key_view());
+      } else {
+        auto& node = stack_.top().node;
+        UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
+        const auto* const leaf{node.template ptr<leaf_type*>()};
+        return unodb::detail::compare(leaf->get_key_view(),
+                                      akey.get_key_view());
+      }
     }
 
     /// \name Stack access methods

--- a/art.hpp
+++ b/art.hpp
@@ -186,7 +186,7 @@ class db final {
   /// \return The chain top node, or \a child if no bytes to encode
   [[nodiscard]] detail::node_ptr build_chain(
       art_key_type k, detail::node_ptr child,
-      detail::tree_depth<art_key_type> start_depth = {});
+      detail::tree_depth<art_key_type> start_depth);
 
   /// Remove the entry associated with the encoded key \a remove_key.
   ///
@@ -1323,7 +1323,8 @@ bool db<Key, Value>::insert_internal(art_key_type insert_key, value_type v) {
     auto leaf = art_policy::make_db_leaf_ptr(insert_key, v, *this);
     if constexpr (art_policy::can_eliminate_leaf) {
       root = build_chain(insert_key,
-                         detail::node_ptr{leaf.release(), node_type::LEAF});
+                         detail::node_ptr{leaf.release(), node_type::LEAF},
+                         tree_depth_type{0});
     } else {
       root = detail::node_ptr{leaf.release(), node_type::LEAF};
     }

--- a/art.hpp
+++ b/art.hpp
@@ -362,7 +362,7 @@ class db final {
     /// the iterator.
     ///
     /// \pre The iterator MUST be valid().
-    [[nodiscard, gnu::pure]] value_view get_val() const noexcept;
+    [[nodiscard, gnu::pure]] value_type get_val() const noexcept;
 
     /// Output iterator state to stream \a os for debugging.
     // LCOV_EXCL_START
@@ -865,7 +865,7 @@ class db final {
   // Type names in the Doxygen comments below make them clickable in the output
 
   /// detail::make_db_leaf_ptr
-  friend auto detail::make_db_leaf_ptr<Key, Value, db>(art_key_type, value_view,
+  friend auto detail::make_db_leaf_ptr<Key, Value, db>(art_key_type, value_type,
                                                        db&);
 
   /// detail::basic_db_leaf_deleter
@@ -923,7 +923,7 @@ struct impl_helpers {
   /// \return Pointer to location for further descent or insertion
   template <typename Key, typename Value, class INode>
   [[nodiscard]] static detail::node_ptr* add_or_choose_subtree(
-      INode& inode, std::byte key_byte, basic_art_key<Key> k, value_view v,
+      INode& inode, std::byte key_byte, basic_art_key<Key> k, Value v,
       db<Key, Value>& db_instance, tree_depth<basic_art_key<Key>> depth,
       detail::node_ptr* node_in_parent);
 
@@ -1146,7 +1146,7 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 /// byte, create the leaf and insert it in the current node.
 template <typename Key, typename Value, class INode>
 detail::node_ptr* impl_helpers::add_or_choose_subtree(
-    INode& inode, std::byte key_byte, basic_art_key<Key> k, value_view v,
+    INode& inode, std::byte key_byte, basic_art_key<Key> k, Value v,
     db<Key, Value>& db_instance, tree_depth<basic_art_key<Key>> depth,
     detail::node_ptr* node_in_parent) {
   auto* const child =
@@ -1235,7 +1235,7 @@ typename db<Key, Value>::get_result db<Key, Value>::get_internal(
     const auto node_type = node.type();
     if (node_type == node_type::LEAF) {
       const auto* const leaf{node.template ptr<leaf_type*>()};
-      if (leaf->matches(k)) return leaf->get_value_view();
+      if (leaf->matches(k)) return leaf->template get_value<value_type>();
       return {};
     }
 
@@ -1905,13 +1905,14 @@ key_view db<Key, Value>::iterator::get_key() noexcept {
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
 template <typename Key, typename Value>
-value_view db<Key, Value>::iterator::get_val() const noexcept {
+typename db<Key, Value>::value_type
+db<Key, Value>::iterator::get_val() const noexcept {
   UNODB_DETAIL_ASSERT(valid());  // by contract
   const auto& e = stack_.top();
   const auto& node = e.node;
   UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);      // On a leaf.
   const auto* const leaf{node.template ptr<leaf_type*>()};  // current leaf.
-  return leaf->get_value_view();
+  return leaf->template get_value<value_type>();
 }
 
 //

--- a/art.hpp
+++ b/art.hpp
@@ -13,11 +13,13 @@
 // Should be the first include
 #include "global.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <optional>
 #include <stack>
+#include <vector>
 #include <type_traits>
 
 #include <boost/container/small_vector.hpp>
@@ -427,6 +429,17 @@ class db final {
     /// Return true unless the stack is empty (exposed to tests).
     [[nodiscard]] bool valid() const noexcept { return !stack_.empty(); }
 
+    /// Return stack entries bottom-to-top (test only).
+    [[nodiscard]] std::vector<stack_entry> test_only_stack() const {
+      auto tmp = stack_;
+      std::vector<stack_entry> result;
+      while (!tmp.empty()) {
+        result.push_back(tmp.top());
+        tmp.pop();
+      }
+      std::reverse(result.begin(), result.end());
+      return result;
+    }
    protected:
     /// Descend to left-most leaf from given \a node.
     ///
@@ -508,6 +521,7 @@ class db final {
       const auto node_type = e.node.type();
       if (UNODB_DETAIL_UNLIKELY(node_type == node_type::LEAF)) {
         push_leaf(e.node);
+        return;
       }
       push(e.node, e.key_byte, e.child_index, e.prefix);
     }
@@ -516,8 +530,11 @@ class db final {
     void pop() noexcept {
       UNODB_DETAIL_ASSERT(!empty());
 
-      const auto prefix_len = top().prefix.length();
-      keybuf_.pop(prefix_len);
+      const auto& e = top();
+      const auto n = (e.node.type() != node_type::LEAF)
+                         ? e.prefix.length() + 1
+                         : 0;
+      keybuf_.pop(n);
       stack_.pop();
     }
 

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -41,6 +41,36 @@ using key_size_type = std::uint32_t;
 /// Non-owning view of key bytes, copied into index upon insertion.
 using key_view = std::span<const std::byte>;
 
+/// Non-owning view of key bytes with scoped lifetime.  Returned by
+/// iterator get_key() when the key is reconstructed from the inode
+/// path (full_key_in_inode_path trees).  The view is valid only until
+/// the next iterator movement (next/prior/seek/invalidate).
+///
+/// Implicitly converts to key_view for read access.  Does NOT allow
+/// implicit construction from key_view, preventing accidental storage
+/// of a key_view where a scoped_key_view is expected.
+class scoped_key_view {
+  key_view kv_;
+
+ public:
+  explicit constexpr scoped_key_view(key_view kv) noexcept : kv_{kv} {}
+
+  [[nodiscard]] constexpr auto data() const noexcept { return kv_.data(); }
+  [[nodiscard]] constexpr auto size() const noexcept { return kv_.size(); }
+  [[nodiscard]] constexpr auto size_bytes() const noexcept {
+    return kv_.size_bytes();
+  }
+  [[nodiscard]] constexpr auto operator[](std::size_t i) const noexcept {
+    return kv_[i];
+  }
+  [[nodiscard]] constexpr auto begin() const noexcept { return kv_.begin(); }
+  [[nodiscard]] constexpr auto end() const noexcept { return kv_.end(); }
+  [[nodiscard]] constexpr bool empty() const noexcept { return kv_.empty(); }
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr operator key_view() const noexcept { return kv_; }
+};
+
 /// Type alias determining the maximum size of a value that may be stored in the
 /// index.
 using value_size_type = std::uint32_t;

--- a/art_common.hpp
+++ b/art_common.hpp
@@ -34,6 +34,10 @@ class db;
 template <typename Key, typename Value>
 class olc_db;
 
+namespace detail {
+
+}  // namespace detail
+
 /// Type alias determining the maximum size in bytes of a key that may be stored
 /// in the index.
 using key_size_type = std::uint32_t;
@@ -41,19 +45,42 @@ using key_size_type = std::uint32_t;
 /// Non-owning view of key bytes, copied into index upon insertion.
 using key_view = std::span<const std::byte>;
 
+namespace detail {
+
+/// Tag type used as the Key parameter for keyless leaves.  When the full
+/// key is encoded in the inode path, the leaf stores only the value.
+struct no_key_tag {};
+
+/// Whether the key can be omitted from the leaf.  True when Key is
+/// key_view and Value fits in a pointer-sized slot.
+template <typename Key, typename Value>
+inline constexpr bool can_eliminate_key_in_leaf_v =
+    std::is_same_v<Key, key_view> && (sizeof(Value) <= sizeof(std::uint64_t));
+
+/// The Key type used for the leaf template.  Maps to no_key_tag when
+/// the key can be eliminated, otherwise passes Key through unchanged.
+template <typename Key, typename Value>
+using leaf_key_type =
+    std::conditional_t<can_eliminate_key_in_leaf_v<Key, Value>,
+                       no_key_tag, Key>;
+
+}  // namespace detail
+
 /// Non-owning view of key bytes with scoped lifetime.  Returned by
 /// iterator get_key() when the key is reconstructed from the inode
 /// path (full_key_in_inode_path trees).  The view is valid only until
 /// the next iterator movement (next/prior/seek/invalidate).
 ///
-/// Implicitly converts to key_view for read access.  Does NOT allow
-/// implicit construction from key_view, preventing accidental storage
-/// of a key_view where a scoped_key_view is expected.
-class scoped_key_view {
+/// Does NOT allow implicit construction from key_view, preventing accidental
+/// storage of a key_view where a transient_key_view is expected.  Does NOT
+/// implicitly convert to key_view — use .view() for explicit access.
+class transient_key_view {
   key_view kv_;
 
  public:
-  explicit constexpr scoped_key_view(key_view kv) noexcept : kv_{kv} {}
+  explicit constexpr transient_key_view(key_view kv) noexcept : kv_{kv} {}
+
+  [[nodiscard]] constexpr key_view view() const noexcept { return kv_; }
 
   [[nodiscard]] constexpr auto data() const noexcept { return kv_.data(); }
   [[nodiscard]] constexpr auto size() const noexcept { return kv_.size(); }
@@ -66,9 +93,6 @@ class scoped_key_view {
   [[nodiscard]] constexpr auto begin() const noexcept { return kv_.begin(); }
   [[nodiscard]] constexpr auto end() const noexcept { return kv_.end(); }
   [[nodiscard]] constexpr bool empty() const noexcept { return kv_.empty(); }
-
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  constexpr operator key_view() const noexcept { return kv_; }
 };
 
 /// Type alias determining the maximum size of a value that may be stored in the

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -326,13 +326,15 @@ template <class Db>
 class basic_db_leaf_deleter {
  public:
   /// Leaf type managed by this deleter.
-  using leaf_type = basic_leaf<typename Db::key_type, typename Db::header_type>;
+  using leaf_type =
+      basic_leaf<leaf_key_type<typename Db::key_type, typename Db::value_type>,
+                 typename Db::header_type>;
 
   static_assert(std::is_trivially_destructible_v<leaf_type>);
 
   /// Construct leaf deleter for database \a db_
-  constexpr explicit basic_db_leaf_deleter(Db& db_
-                                           UNODB_DETAIL_LIFETIMEBOUND) noexcept
+  constexpr explicit basic_db_leaf_deleter(
+      Db& db_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
       : db{db_} {}
 
   /// Delete a leaf node \a to_delete through the database.
@@ -359,7 +361,7 @@ class basic_db_leaf_deleter {
 template <typename Key, typename Value, class Header,
           template <typename, typename> class Db>
 using basic_db_leaf_unique_ptr =
-    std::unique_ptr<basic_leaf<Key, Header>,
+    std::unique_ptr<basic_leaf<leaf_key_type<Key, Value>, Header>,
                     basic_db_leaf_deleter<Db<Key, Value>>>;
 
 // TODO(laurynas): extract a base class db_ref?
@@ -375,8 +377,8 @@ template <class INode, class Db>
 class basic_db_inode_deleter {
  public:
   /// Construct internal node deleter for database \a db_.
-  constexpr explicit basic_db_inode_deleter(Db& db_
-                                            UNODB_DETAIL_LIFETIMEBOUND) noexcept
+  constexpr explicit basic_db_inode_deleter(
+      Db& db_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
       : db{db_} {}
 
   /// Delete an internal node \a inode_ptr through the database.

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -219,6 +219,22 @@ class [[nodiscard]] basic_leaf final : public Header {
     return value_view{data + key_size, value_size};
   }
 
+  /// Return value stored in leaf, converted to the given type.
+  ///
+  /// For value_view, returns a span over the stored bytes.
+  /// For fixed-width types (e.g., uint64_t), deserializes from stored bytes.
+  template <typename Value>
+  [[nodiscard, gnu::pure]] constexpr auto get_value() const noexcept {
+    if constexpr (std::is_same_v<Value, value_view>) {
+      return get_value_view();
+    } else {
+      static_assert(std::is_trivially_copyable_v<Value>);
+      Value v{};
+      std::memcpy(&v, data + key_size, sizeof(v));
+      return v;
+    }
+  }
+
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
@@ -286,29 +302,38 @@ class [[nodiscard]] basic_leaf final : public Header {
 ///
 /// \throws std::length_error if key or value exceeds maximum size
 template <typename Key, typename Value, template <typename, typename> class Db>
-[[nodiscard]] auto make_db_leaf_ptr(basic_art_key<Key> k, value_view v,
+[[nodiscard]] auto make_db_leaf_ptr(basic_art_key<Key> k, Value v,
                                     Db<Key, Value>& db
                                     UNODB_DETAIL_LIFETIMEBOUND) {
   using db_type = Db<Key, Value>;
   using header_type = typename db_type::header_type;
   using leaf_type = basic_leaf<Key, header_type>;
 
-  // TODO(thompsonbry) We should have a discussion about limits.  To
-  // my mind, limits should be explicit configuration values, not
-  // uint32_t.
   if constexpr (std::is_same_v<Key, key_view>) {
     if (UNODB_DETAIL_UNLIKELY(k.size() > leaf_type::max_key_size)) {
       throw std::length_error("Key length must fit in std::uint32_t");
     }
   }
 
-  if (UNODB_DETAIL_UNLIKELY(v.size_bytes() > leaf_type::max_value_size)) {
+  // Serialize value to bytes for leaf storage.
+  value_view val_bytes;
+  [[maybe_unused]] std::byte val_buf[sizeof(Value)];
+  if constexpr (std::is_same_v<Value, value_view>) {
+    val_bytes = v;
+  } else {
+    static_assert(std::is_trivially_copyable_v<Value>);
+    std::memcpy(val_buf, &v, sizeof(v));
+    val_bytes = value_view{val_buf, sizeof(v)};
+  }
+
+  if (UNODB_DETAIL_UNLIKELY(val_bytes.size_bytes() >
+                            leaf_type::max_value_size)) {
     throw std::length_error("Value length must fit in std::uint32_t");
   }
 
   const auto size = leaf_type::compute_size(
       static_cast<typename leaf_type::key_size_type>(k.size()),
-      static_cast<typename leaf_type::value_size_type>(v.size_bytes()));
+      static_cast<typename leaf_type::value_size_type>(val_bytes.size_bytes()));
 
   auto* const leaf_mem = static_cast<std::byte*>(
       allocate_aligned(size, alignment_for_new<leaf_type>()));
@@ -318,7 +343,8 @@ template <typename Key, typename Value, template <typename, typename> class Db>
 #endif  // UNODB_DETAIL_WITH_STATS
 
   return basic_db_leaf_unique_ptr<Key, Value, header_type, Db>{
-      new (leaf_mem) leaf_type{k, v}, basic_db_leaf_deleter<db_type>{db}};
+      new (leaf_mem) leaf_type{k, val_bytes},
+      basic_db_leaf_deleter<db_type>{db}};
 }
 
 /// Metaprogramming struct listing all concrete internal node types.
@@ -518,7 +544,7 @@ struct basic_art_policy final {
   /// \param db_instance Database for memory tracking
   ///
   /// \return Unique pointer to newly allocated leaf
-  [[nodiscard]] static auto make_db_leaf_ptr(art_key_type k, value_view v,
+  [[nodiscard]] static auto make_db_leaf_ptr(art_key_type k, value_type v,
                                              db_type& db_instance
                                              UNODB_DETAIL_LIFETIMEBOUND) {
     return ::unodb::detail::make_db_leaf_ptr<Key, Value, Db>(k, v, db_instance);

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -482,6 +482,17 @@ struct basic_art_policy final {
   static_assert(sizeof(std::uintptr_t) <= sizeof(std::uint64_t),
                 "node_ptr must fit in a uint64_t slot");
 
+  /// Whether the full key is encoded in the inode path (prefix + dispatch
+  /// bytes at every level).  True for key_view keys with small values.
+  static constexpr bool full_key_in_inode_path =
+      std::is_same_v<Key, key_view> && value_in_slot;
+
+  /// Whether leaf allocation can be eliminated entirely.  Requires the
+  /// full key in the inode path (so the leaf need not store the key) and
+  /// the value in the inode child slot (so the leaf need not store the
+  /// value).  Currently equivalent to full_key_in_inode_path.
+  static constexpr bool can_eliminate_leaf = full_key_in_inode_path;
+
   /// Leaf type.
   using leaf_type = basic_leaf<Key, header_type>;
 

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -450,6 +450,12 @@ struct basic_art_policy final {
   /// Tree depth wrapper.
   using tree_depth_type = tree_depth<art_key_type>;
 
+  /// Whether values are stored directly in inode child slots rather than
+  /// in separate leaf nodes.  True when the value fits in a uint64_t.
+  static constexpr bool value_in_slot = (sizeof(Value) <= sizeof(std::uint64_t));
+  static_assert(sizeof(std::uintptr_t) <= sizeof(std::uint64_t),
+                "node_ptr must fit in a uint64_t slot");
+
   /// Leaf type.
   using leaf_type = basic_leaf<Key, header_type>;
 

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -230,6 +230,7 @@ class [[nodiscard]] basic_leaf final : public Header {
     } else {
       static_assert(std::is_trivially_copyable_v<Value>);
       Value v{};
+      // cppcheck-suppress memsetClass
       std::memcpy(&v, data + key_size, sizeof(v));
       return v;
     }
@@ -2260,7 +2261,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
       keys.byte_array[i] = keys.byte_array[i - 1];
       children[i] = children[i - 1];
     }
-    keys.byte_array[insert_pos_index] = static_cast<std::byte>(key_byte);
+    keys.byte_array[insert_pos_index] = key_byte;
     children[insert_pos_index] = node_ptr{child.release(), node_type::LEAF};
 
     ++children_count_;
@@ -2746,7 +2747,7 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
 
     UNODB_DETAIL_ASSUME(i < parent_class::capacity);
 
-    keys.byte_array[i] = static_cast<std::byte>(key_byte);
+    keys.byte_array[i] = key_byte;
     children[i] = node_ptr{child.release(), node_type::LEAF};
     ++i;
 

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -286,6 +286,96 @@ class [[nodiscard]] basic_leaf final : public Header {
   std::byte data[1];
 };  // class basic_leaf
 
+/// Keyless leaf specialization.  Stores only the value — no key data,
+/// no key access methods.  Used when can_eliminate_key_in_leaf is true
+/// (full key is encoded in the inode path).
+///
+/// get_key(), get_key_view(), cmp(), and matches() are intentionally
+/// absent.  Any call site that attempts to access the key from a keyless
+/// leaf will produce a compile error.
+template <class Header>
+class [[nodiscard]] basic_leaf<no_key_tag, Header> final : public Header {
+ public:
+  using value_size_type = unodb::value_size_type;
+
+  static constexpr std::size_t max_value_size =
+      std::numeric_limits<value_size_type>::max();
+
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26485)
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
+
+  /// Construct keyless leaf with value only.
+  constexpr explicit basic_leaf(value_view v) noexcept
+      : value_size{static_cast<value_size_type>(v.size())} {
+    UNODB_DETAIL_ASSERT(v.size() <= max_value_size);
+    if (!v.empty()) std::memcpy(data, v.data(), value_size);
+  }
+
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+  /// Keyless leaf always matches — the key was verified by the inode path.
+  template <typename ArtKey>
+  [[nodiscard, gnu::pure]] constexpr auto matches(ArtKey /*k*/) const noexcept {
+    return true;
+  }
+
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26485)
+
+  /// Return view onto value stored in leaf.
+  [[nodiscard, gnu::pure]] constexpr auto get_value_view() const noexcept {
+    return value_view{data, value_size};
+  }
+
+  /// Return value stored in leaf, converted to the given type.
+  template <typename Value>
+  [[nodiscard, gnu::pure]] constexpr auto get_value() const noexcept {
+    if constexpr (std::is_same_v<Value, value_view>) {
+      return get_value_view();
+    } else {
+      static_assert(std::is_trivially_copyable_v<Value>);
+      Value v{};
+      std::memcpy(&v, data, sizeof(v));
+      return v;
+    }
+  }
+
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+#ifdef UNODB_DETAIL_WITH_STATS
+  [[nodiscard, gnu::pure]] constexpr auto get_size() const noexcept {
+    return compute_size(value_size);
+  }
+#endif
+
+  /// Dump keyless leaf contents to stream for debugging.
+  [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
+                                                bool /*recursive*/) const {
+    os << ", (keyless), ";
+    ::unodb::detail::dump_val(os, get_value_view());
+    os << '\n';
+  }
+
+  /// Compute required byte size for a keyless leaf.
+  [[nodiscard, gnu::const]] static constexpr auto compute_size(
+      value_size_type val_size) noexcept {
+    return sizeof(basic_leaf<no_key_tag, Header>) + val_size - 1;
+  }
+
+  /// Two-arg overload for compatibility with generic code.
+  [[nodiscard, gnu::const]] static constexpr auto compute_size(
+      // cppcheck-suppress passedByValue
+      key_size_type /*key_size*/, value_size_type val_size) noexcept {
+    return compute_size(val_size);
+  }
+
+ private:
+  const value_size_type value_size;
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  std::byte data[1];
+};  // class basic_leaf<no_key_tag, Header>
+
 /// Create unique pointer to new leaf with given key and value.
 ///
 /// Allocates memory for leaf and constructs it with placement new.
@@ -302,16 +392,18 @@ class [[nodiscard]] basic_leaf final : public Header {
 ///
 /// \throws std::length_error if key or value exceeds maximum size
 template <typename Key, typename Value, template <typename, typename> class Db>
-[[nodiscard]] auto make_db_leaf_ptr(basic_art_key<Key> k, Value v,
-                                    Db<Key, Value>& db
-                                    UNODB_DETAIL_LIFETIMEBOUND) {
+[[nodiscard]] auto make_db_leaf_ptr(
+    basic_art_key<Key> k, Value v,
+    Db<Key, Value>& db UNODB_DETAIL_LIFETIMEBOUND) {
   using db_type = Db<Key, Value>;
   using header_type = typename db_type::header_type;
-  using leaf_type = basic_leaf<Key, header_type>;
+  using leaf_type = basic_leaf<leaf_key_type<Key, Value>, header_type>;
 
-  if constexpr (std::is_same_v<Key, key_view>) {
-    if (UNODB_DETAIL_UNLIKELY(k.size() > leaf_type::max_key_size)) {
-      throw std::length_error("Key length must fit in std::uint32_t");
+  if constexpr (!can_eliminate_key_in_leaf_v<Key, Value>) {
+    if constexpr (std::is_same_v<Key, key_view>) {
+      if (UNODB_DETAIL_UNLIKELY(k.size() > leaf_type::max_key_size)) {
+        throw std::length_error("Key length must fit in std::uint32_t");
+      }
     }
   }
 
@@ -331,9 +423,17 @@ template <typename Key, typename Value, template <typename, typename> class Db>
     throw std::length_error("Value length must fit in std::uint32_t");
   }
 
-  const auto size = leaf_type::compute_size(
-      static_cast<typename leaf_type::key_size_type>(k.size()),
-      static_cast<typename leaf_type::value_size_type>(val_bytes.size_bytes()));
+  std::size_t size;
+  if constexpr (can_eliminate_key_in_leaf_v<Key, Value>) {
+    size = leaf_type::compute_size(
+        static_cast<typename leaf_type::value_size_type>(
+            val_bytes.size_bytes()));
+  } else {
+    size = leaf_type::compute_size(
+        static_cast<typename leaf_type::key_size_type>(k.size()),
+        static_cast<typename leaf_type::value_size_type>(
+            val_bytes.size_bytes()));
+  }
 
   auto* const leaf_mem = static_cast<std::byte*>(
       allocate_aligned(size, alignment_for_new<leaf_type>()));
@@ -343,7 +443,13 @@ template <typename Key, typename Value, template <typename, typename> class Db>
 #endif  // UNODB_DETAIL_WITH_STATS
 
   return basic_db_leaf_unique_ptr<Key, Value, header_type, Db>{
-      new (leaf_mem) leaf_type{k, val_bytes},
+      [&]() {
+        if constexpr (can_eliminate_key_in_leaf_v<Key, Value>) {
+          return new (leaf_mem) leaf_type{val_bytes};
+        } else {
+          return new (leaf_mem) leaf_type{k, val_bytes};
+        }
+      }(),
       basic_db_leaf_deleter<db_type>{db}};
 }
 
@@ -478,7 +584,8 @@ struct basic_art_policy final {
 
   /// Whether values are stored directly in inode child slots rather than
   /// in separate leaf nodes.  True when the value fits in a uint64_t.
-  static constexpr bool value_in_slot = (sizeof(Value) <= sizeof(std::uint64_t));
+  static constexpr bool value_in_slot =
+      (sizeof(Value) <= sizeof(std::uint64_t));
   static_assert(sizeof(std::uintptr_t) <= sizeof(std::uint64_t),
                 "node_ptr must fit in a uint64_t slot");
 
@@ -487,14 +594,17 @@ struct basic_art_policy final {
   static constexpr bool full_key_in_inode_path =
       std::is_same_v<Key, key_view> && value_in_slot;
 
-  /// Whether leaf allocation can be eliminated entirely.  Requires the
-  /// full key in the inode path (so the leaf need not store the key) and
-  /// the value in the inode child slot (so the leaf need not store the
-  /// value).  Currently equivalent to full_key_in_inode_path.
-  static constexpr bool can_eliminate_leaf = full_key_in_inode_path;
+  /// Whether the key can be omitted from the leaf.
+  static constexpr bool can_eliminate_key_in_leaf =
+      can_eliminate_key_in_leaf_v<Key, Value>;
 
-  /// Leaf type.
-  using leaf_type = basic_leaf<Key, header_type>;
+  /// Whether leaf allocation can be eliminated entirely.  Requires the
+  /// full key in the inode path AND the value in the inode child slot.
+  static constexpr bool can_eliminate_leaf =
+      full_key_in_inode_path && value_in_slot;
+
+  /// Leaf type (keyless when can_eliminate_key_in_leaf).
+  using leaf_type = basic_leaf<leaf_key_type<Key, Value>, header_type>;
 
   /// Database type.
   using db_type = Db<Key, Value>;
@@ -555,9 +665,9 @@ struct basic_art_policy final {
   /// \param db_instance Database for memory tracking
   ///
   /// \return Unique pointer to newly allocated leaf
-  [[nodiscard]] static auto make_db_leaf_ptr(art_key_type k, value_type v,
-                                             db_type& db_instance
-                                             UNODB_DETAIL_LIFETIMEBOUND) {
+  [[nodiscard]] static auto make_db_leaf_ptr(
+      art_key_type k, value_type v,
+      db_type& db_instance UNODB_DETAIL_LIFETIMEBOUND) {
     return ::unodb::detail::make_db_leaf_ptr<Key, Value, Db>(k, v, db_instance);
   }
 
@@ -604,9 +714,8 @@ struct basic_art_policy final {
   /// \return Unique pointer to newly constructed node
   UNODB_DETAIL_DISABLE_GCC_11_WARNING("-Wmismatched-new-delete")
   template <class INode, class... Args>
-  [[nodiscard]] static auto make_db_inode_unique_ptr(db_type& db_instance
-                                                     UNODB_DETAIL_LIFETIMEBOUND,
-                                                     Args&&... args) {
+  [[nodiscard]] static auto make_db_inode_unique_ptr(
+      db_type& db_instance UNODB_DETAIL_LIFETIMEBOUND, Args&&... args) {
     auto* const inode_mem = static_cast<std::byte*>(
         allocate_aligned(sizeof(INode), alignment_for_new<INode>()));
 
@@ -1250,6 +1359,24 @@ class basic_inode_impl : public ArtPolicy::header_type {
   /// basic_inode_256 node type.
   using inode256_type = typename ArtPolicy::inode256_type;
 
+  /// Leaf type.
+  using leaf_type = typename ArtPolicy::leaf_type;
+
+  /// Read the dispatch byte from a leaf at the given depth.
+  /// For keyless leaves this is unreachable — the caller must not
+  /// invoke this path.
+  [[nodiscard]] static constexpr std::uint8_t leaf_key_byte_at(
+      const leaf_type* leaf, tree_depth_type depth) noexcept {
+    if constexpr (ArtPolicy::can_eliminate_key_in_leaf) {
+      (void)leaf;
+      (void)depth;
+      UNODB_DETAIL_CANNOT_HAPPEN();
+      return 0;
+    } else {
+      return static_cast<std::uint8_t>(leaf->get_key_view()[depth]);
+    }
+  }
+
   /// \}
 
  public:
@@ -1659,9 +1786,6 @@ class basic_inode_impl : public ArtPolicy::header_type {
   /// Iterator result value at the end of iteration.
   static constexpr iter_result_opt end_result{};
 
-  /// Leaf node type.
-  using leaf_type = basic_leaf<key_type, header_type>;
-
   friend class unodb::db<key_type, value_type>;
   friend class unodb::olc_db<key_type, value_type>;
   friend struct olc_inode_immediate_deleter;
@@ -1905,10 +2029,19 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   /// \param child1 Child leaf to add (ownership transferred)
   constexpr basic_inode_4(db_type&, node_ptr source_node, unsigned len,
                           // cppcheck-suppress passedByValue
-                          tree_depth_type depth,
+                          [[maybe_unused]] tree_depth_type depth,
                           db_leaf_unique_ptr&& child1) noexcept
       : parent_class{len, *source_node.template ptr<inode_type*>()} {
     init(source_node, len, depth, std::move(child1));
+  }
+
+  /// Construct by splitting prefix, with explicit dispatch byte for child1.
+  constexpr basic_inode_4(db_type&, node_ptr source_node, unsigned len,
+                          // cppcheck-suppress passedByValue
+                          tree_depth_type depth, db_leaf_unique_ptr&& child1,
+                          std::byte child1_key_byte) noexcept
+      : parent_class{len, *source_node.template ptr<inode_type*>()} {
+    init(source_node, len, depth, std::move(child1), child1_key_byte);
   }
 
   /// Construct by shrinking from basic_inode_16 \a source_node.
@@ -1940,7 +2073,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   /// \param child The single child node
   constexpr basic_inode_4(db_type&, key_view k1, art_key_type remaining_key,
                           // cppcheck-suppress passedByValue
-                          tree_depth_type depth, std::byte key_byte,
+                          [[maybe_unused]] tree_depth_type depth, std::byte key_byte,
                           node_ptr child) noexcept
       : parent_class{k1, remaining_key, depth,
                      typename parent_class::single_child_tag{}} {
@@ -1953,7 +2086,11 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
     UNODB_DETAIL_ASSERT(this->is_min_size());
     const std::uint8_t child_to_leave = (child_to_delete == 0) ? 1U : 0U;
     const auto child_ptr = children[child_to_leave].load();
-    if (child_ptr.type() == node_type::LEAF) return true;
+    if (child_ptr.type() == node_type::LEAF) {
+      // For keyless leaves, collapsing would lose key bytes encoded
+      // in this inode's prefix+dispatch.  Keep the chain intact.
+      return !ArtPolicy::can_eliminate_key_in_leaf;
+    }
     const auto* const child_inode{child_ptr.template ptr<inode_type*>()};
     return this->get_key_prefix().length() +
                child_inode->get_key_prefix().length() <
@@ -1964,7 +2101,7 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   /// Used by build_chain when remaining key <= key_prefix_capacity.
   constexpr basic_inode_4(db_type&, key_view k1,
                           // cppcheck-suppress passedByValue
-                          tree_depth_type depth,
+                          [[maybe_unused]] tree_depth_type depth,
                           detail::key_prefix_size prefix_len,
                           std::byte key_byte, node_ptr child) noexcept
       : parent_class{prefix_len, k1, depth,
@@ -1983,18 +2120,31 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   /// \param shared_prefix_len Length of shared prefix
   /// \param depth Current tree depth
   /// \param child1 New leaf child to insert
+  /// \param child1_key_byte Dispatch byte for child1 (used for keyless
+  ///   leaves where the byte cannot be read from the leaf)
+  template <typename LeafPtr>
   constexpr void init(node_ptr source_node, unsigned shared_prefix_len,
-                      tree_depth_type depth, db_leaf_unique_ptr&& child1) {
+                      [[maybe_unused]] tree_depth_type depth, LeafPtr&& child1,
+                      std::byte child1_key_byte) {
     auto* const source_inode{source_node.template ptr<inode_type*>()};
     auto& source_key_prefix = source_inode->get_key_prefix();
     UNODB_DETAIL_ASSERT(shared_prefix_len < source_key_prefix.length());
 
-    const auto diff_key_byte_i = depth + shared_prefix_len;
     const auto source_node_key_byte = source_key_prefix[shared_prefix_len];
     source_key_prefix.cut(static_cast<key_prefix_size>(shared_prefix_len) + 1U);
-    const auto new_key_byte = child1->get_key_view()[diff_key_byte_i];
-    add_two_to_empty(source_node_key_byte, source_node, new_key_byte,
+    add_two_to_empty(source_node_key_byte, source_node, child1_key_byte,
                      std::move(child1));
+  }
+
+  /// Initialize by splitting prefix from source node (keyed leaf variant).
+  /// Reads the dispatch byte from the leaf's key.
+  template <typename LeafPtr>
+  constexpr void init(node_ptr source_node, unsigned shared_prefix_len,
+                      [[maybe_unused]] tree_depth_type depth, LeafPtr&& child1) {
+    const auto diff_key_byte_i = depth + shared_prefix_len;
+    init(source_node, shared_prefix_len, depth, std::forward<LeafPtr>(child1),
+         static_cast<std::byte>(this->leaf_key_byte_at(
+             child1.get(), tree_depth_type{diff_key_byte_i})));
   }
 
   /// Initialize by shrinking from basic_inode_16 node.
@@ -2085,24 +2235,22 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
   /// have already loaded it.
   constexpr void add_to_nonfull(db_leaf_unique_ptr&& child,
                                 // cppcheck-suppress passedByValue
-                                tree_depth_type depth,
+                                [[maybe_unused]] tree_depth_type depth, std::byte key_byte,
                                 std::uint8_t children_count_) noexcept {
     UNODB_DETAIL_ASSERT(children_count_ == this->children_count);
     UNODB_DETAIL_ASSERT(children_count_ < parent_class::capacity);
     UNODB_DETAIL_ASSERT(std::is_sorted(
         keys.byte_array.cbegin(), keys.byte_array.cbegin() + children_count_));
 
-    const auto key_byte =
-        static_cast<std::uint8_t>(child->get_key_view()[depth]);
-
+    const auto kb = static_cast<std::uint8_t>(key_byte);
 #ifdef UNODB_DETAIL_X86_64
     const auto mask = (1U << children_count_) - 1;
-    const auto insert_pos_index = get_insert_pos(key_byte, mask);
+    const auto insert_pos_index = get_insert_pos(kb, mask);
 #else
     // This is also currently the best ARM implementation.
-    const auto first_lt = ((keys.integer & 0xFFU) < key_byte) ? 1 : 0;
-    const auto second_lt = (((keys.integer >> 8U) & 0xFFU) < key_byte) ? 1 : 0;
-    const auto third_lt = ((keys.integer >> 16U) & 0xFFU) < key_byte ? 1 : 0;
+    const auto first_lt = ((keys.integer & 0xFFU) < kb) ? 1 : 0;
+    const auto second_lt = (((keys.integer >> 8U) & 0xFFU) < kb) ? 1 : 0;
+    const auto third_lt = ((keys.integer >> 16U) & 0xFFU) < kb ? 1 : 0;
     const auto insert_pos_index =
         static_cast<unsigned>(first_lt + second_lt + third_lt);
 #endif
@@ -2547,10 +2695,10 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
   /// \param child New child to add
   /// \param depth Current tree depth
   constexpr basic_inode_16(db_type& db_instance, inode4_type& source_node,
-                           db_leaf_unique_ptr&& child,
-                           tree_depth_type depth) noexcept
+                           db_leaf_unique_ptr&& child, [[maybe_unused]] tree_depth_type depth,
+                           std::byte key_byte) noexcept
       : parent_class{source_node} {
-    init(db_instance, source_node, std::move(child), depth);
+    init(db_instance, source_node, std::move(child), depth, key_byte);
   }
 
   /// Construct by shrinking from basic_inode_48 and removing a child.
@@ -2571,22 +2719,21 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
   /// \param child New child to add
   /// \param depth Current tree depth
   constexpr void init(db_type& db_instance, inode4_type& source_node,
-                      db_leaf_unique_ptr child,
-                      tree_depth_type depth) noexcept {
+                      db_leaf_unique_ptr child, [[maybe_unused]] tree_depth_type depth,
+                      std::byte key_byte) noexcept {
     const auto reclaim_source_node{
         ArtPolicy::template make_db_inode_reclaimable_ptr<inode4_type>(
             &source_node, db_instance)};
-    const auto key_byte =
-        static_cast<std::uint8_t>(child->get_key_view()[depth]);
+    const auto kb = static_cast<std::uint8_t>(key_byte);
 
 #ifdef UNODB_DETAIL_X86_64
-    const auto insert_pos_index = source_node.get_insert_pos(key_byte, 0xFU);
+    const auto insert_pos_index = source_node.get_insert_pos(kb, 0xFU);
 #else
     const auto keys_integer = source_node.keys.integer.load();
-    const auto first_lt = ((keys_integer & 0xFFU) < key_byte) ? 1 : 0;
-    const auto second_lt = (((keys_integer >> 8U) & 0xFFU) < key_byte) ? 1 : 0;
-    const auto third_lt = (((keys_integer >> 16U) & 0xFFU) < key_byte) ? 1 : 0;
-    const auto fourth_lt = (((keys_integer >> 24U) & 0xFFU) < key_byte) ? 1 : 0;
+    const auto first_lt = ((keys_integer & 0xFFU) < kb) ? 1 : 0;
+    const auto second_lt = (((keys_integer >> 8U) & 0xFFU) < kb) ? 1 : 0;
+    const auto third_lt = (((keys_integer >> 16U) & 0xFFU) < kb) ? 1 : 0;
+    const auto fourth_lt = (((keys_integer >> 24U) & 0xFFU) < kb) ? 1 : 0;
     const auto insert_pos_index =
         static_cast<unsigned>(first_lt + second_lt + third_lt + fourth_lt);
 #endif
@@ -2655,14 +2802,12 @@ class basic_inode_16 : public basic_inode_16_parent<ArtPolicy> {
   /// \note The node already keeps its current children count, but all callers
   /// have already loaded it.
   constexpr void add_to_nonfull(db_leaf_unique_ptr&& child,
-                                tree_depth_type depth,
+                                [[maybe_unused]] tree_depth_type depth, std::byte key_byte,
                                 std::uint8_t children_count_) noexcept {
     UNODB_DETAIL_ASSERT(children_count_ == this->children_count);
     UNODB_DETAIL_ASSERT(children_count_ < parent_class::capacity);
     UNODB_DETAIL_ASSERT(std::is_sorted(
         keys.byte_array.cbegin(), keys.byte_array.cbegin() + children_count_));
-
-    const auto key_byte = child->get_key_view()[depth];
 
     const auto insert_pos_index =
         get_sorted_key_array_insert_position(key_byte);
@@ -3035,10 +3180,10 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   /// \param depth Current tree depth
   constexpr basic_inode_48(db_type& db_instance,
                            inode16_type& __restrict source_node,
-                           db_leaf_unique_ptr&& child,
-                           tree_depth_type depth) noexcept
+                           db_leaf_unique_ptr&& child, [[maybe_unused]] tree_depth_type depth,
+                           std::byte key_byte) noexcept
       : parent_class{source_node} {
-    init(db_instance, source_node, std::move(child), depth);
+    init(db_instance, source_node, std::move(child), depth, key_byte);
   }
 
   /// Construct by shrinking from basic_inode_256 and removing a child.
@@ -3061,8 +3206,8 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   /// \param depth Current tree depth
   constexpr void init(db_type& db_instance,
                       inode16_type& __restrict source_node,
-                      db_leaf_unique_ptr child,
-                      tree_depth_type depth) noexcept {
+                      db_leaf_unique_ptr child, [[maybe_unused]] tree_depth_type depth,
+                      std::byte key_byte) noexcept {
     const auto reclaim_source_node{
         ArtPolicy::template make_db_inode_reclaimable_ptr<inode16_type>(
             &source_node, db_instance)};
@@ -3078,13 +3223,11 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
       children.pointer_array[i] = source_node.children[i];
     }
 
-    const auto key_byte =
-        static_cast<std::uint8_t>(child_ptr->get_key_view()[depth]);
-
-    UNODB_DETAIL_ASSERT(child_indexes[key_byte] == empty_child);
+    UNODB_DETAIL_ASSERT(child_indexes[static_cast<std::uint8_t>(key_byte)] ==
+                        empty_child);
     UNODB_DETAIL_ASSUME(i == inode16_type::capacity);
 
-    child_indexes[key_byte] = i;
+    child_indexes[static_cast<std::uint8_t>(key_byte)] = i;
     children.pointer_array[i] = node_ptr{child_ptr, node_type::LEAF};
     for (i = this->children_count; i < basic_inode_48::capacity; i++) {
       children.pointer_array[i] = node_ptr{nullptr};
@@ -3133,14 +3276,14 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
   /// \note The node already keeps its current children count, but all callers
   /// have already loaded it.
   constexpr void add_to_nonfull(db_leaf_unique_ptr&& child,
-                                tree_depth_type depth,
+                                [[maybe_unused]] tree_depth_type depth, std::byte key_byte,
                                 std::uint8_t children_count_) noexcept {
     UNODB_DETAIL_ASSERT(this->children_count == children_count_);
     UNODB_DETAIL_ASSERT(children_count_ >= parent_class::min_size);
     UNODB_DETAIL_ASSERT(children_count_ < parent_class::capacity);
 
-    const auto key_byte = static_cast<uint8_t>(child->get_key_view()[depth]);
-    UNODB_DETAIL_ASSERT(child_indexes[key_byte] == empty_child);
+    UNODB_DETAIL_ASSERT(child_indexes[static_cast<std::uint8_t>(key_byte)] ==
+                        empty_child);
     unsigned i{0};
 #ifdef UNODB_DETAIL_SSE4_2
     const auto nullptr_vector = _mm_setzero_si128();
@@ -3252,7 +3395,8 @@ class basic_inode_48 : public basic_inode_48_parent<ArtPolicy> {
       UNODB_DETAIL_ASSERT(children.pointer_array[j] != nullptr);
 #endif
 
-    child_indexes[key_byte] = static_cast<std::uint8_t>(i);
+    child_indexes[static_cast<std::uint8_t>(key_byte)] =
+        static_cast<std::uint8_t>(i);
     children.pointer_array[i] = node_ptr{child.release(), node_type::LEAF};
     this->children_count = children_count_ + 1U;
   }
@@ -3668,10 +3812,10 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
   /// \param child New child to add
   /// \param depth Current tree depth
   constexpr basic_inode_256(db_type& db_instance, inode48_type& source_node,
-                            db_leaf_unique_ptr&& child,
-                            tree_depth_type depth) noexcept
+                            db_leaf_unique_ptr&& child, [[maybe_unused]] tree_depth_type depth,
+                            std::byte key_byte) noexcept
       : parent_class{source_node} {
-    init(db_instance, source_node, std::move(child), depth);
+    init(db_instance, source_node, std::move(child), depth, key_byte);
   }
 
   /// Initialize by growing from basic_inode_48 and adding a child.
@@ -3682,8 +3826,8 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
   /// \param depth Current tree depth
   constexpr void init(db_type& db_instance,
                       inode48_type& __restrict source_node,
-                      db_leaf_unique_ptr child,
-                      tree_depth_type depth) noexcept {
+                      db_leaf_unique_ptr child, [[maybe_unused]] tree_depth_type depth,
+                      std::byte key_byte) noexcept {
     const auto reclaim_source_node{
         ArtPolicy::template make_db_inode_reclaimable_ptr<inode48_type>(
             &source_node, db_instance)};
@@ -3704,9 +3848,10 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
     ++i;
     for (; i < basic_inode_256::capacity; ++i) children[i] = node_ptr{nullptr};
 
-    const auto key_byte = static_cast<uint8_t>(child->get_key_view()[depth]);
-    UNODB_DETAIL_ASSERT(children[key_byte] == nullptr);
-    children[key_byte] = node_ptr{child.release(), node_type::LEAF};
+    UNODB_DETAIL_ASSERT(children[static_cast<std::uint8_t>(key_byte)] ==
+                        nullptr);
+    children[static_cast<std::uint8_t>(key_byte)] =
+        node_ptr{child.release(), node_type::LEAF};
   }
 
   /// Add child to non-full node.
@@ -3718,15 +3863,15 @@ class basic_inode_256 : public basic_inode_256_parent<ArtPolicy> {
   /// \note The node already keeps its current children count, but all callers
   /// have already loaded it.
   constexpr void add_to_nonfull(db_leaf_unique_ptr&& child,
-                                tree_depth_type depth,
+                                [[maybe_unused]] tree_depth_type depth, std::byte key_byte,
                                 std::uint8_t children_count_) noexcept {
     UNODB_DETAIL_ASSERT(this->children_count == children_count_);
     UNODB_DETAIL_ASSERT(children_count_ < parent_class::capacity);
 
-    const auto key_byte =
-        static_cast<std::uint8_t>(child->get_key_view()[depth]);
-    UNODB_DETAIL_ASSERT(children[key_byte] == nullptr);
-    children[key_byte] = node_ptr{child.release(), node_type::LEAF};
+    UNODB_DETAIL_ASSERT(children[static_cast<std::uint8_t>(key_byte)] ==
+                        nullptr);
+    children[static_cast<std::uint8_t>(key_byte)] =
+        node_ptr{child.release(), node_type::LEAF};
     this->children_count = static_cast<std::uint8_t>(children_count_ + 1U);
   }
 

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -939,6 +939,11 @@ union [[nodiscard]] key_prefix {
   key_prefix(key_view k1, ArtKey shifted_k2, tree_depth<ArtKey> depth) noexcept
       : u64{make_u64(k1, shifted_k2, depth)} {}
 
+  /// Construct with explicit prefix length, copying bytes from k1 at depth.
+  key_prefix(detail::key_prefix_size prefix_len, key_view k1,
+             tree_depth<ArtKey> depth) noexcept
+      : u64{make_u64_explicit(prefix_len, k1, depth)} {}
+
   /// Construct with truncated length from source.
   ///
   /// \param key_prefix_len New prefix length (must not exceed capacity)
@@ -1098,6 +1103,15 @@ union [[nodiscard]] key_prefix {
 
     return k1_u64 | length_to_word(shared_len(k1_u64, shifted_k2.get_u64(),
                                               key_prefix_capacity));
+  }
+
+  /// Build u64 with explicit prefix length, copying bytes from k1 at depth.
+  [[nodiscard, gnu::const]] static constexpr std::uint64_t make_u64_explicit(
+      detail::key_prefix_size prefix_len, key_view k1,
+      tree_depth<ArtKey> depth) noexcept {
+    k1 = k1.subspan(depth);
+    const auto k1_u64 = get_u64(k1) & key_bytes_mask;
+    return k1_u64 | length_to_word(prefix_len);
   }
 };  // class key_prefix
 
@@ -1579,6 +1593,13 @@ class basic_inode_impl : public ArtPolicy::header_type {
       : k_prefix{k1, shifted_k2, depth},
         children_count{static_cast<std::uint8_t>(children_count_)} {}
 
+  /// Construct with explicit prefix length from key at depth.
+  constexpr basic_inode_impl(unsigned children_count_,
+                             detail::key_prefix_size prefix_len, key_view k1,
+                             tree_depth<art_key_type> depth) noexcept
+      : k_prefix{prefix_len, k1, depth},
+        children_count{static_cast<std::uint8_t>(children_count_)} {}
+
   /// Construct with truncated prefix from source node.
   ///
   /// \param children_count_ Initial children count
@@ -1778,6 +1799,13 @@ class [[nodiscard]] basic_inode : public basic_inode_impl<ArtPolicy> {
                         tree_depth<art_key_type> depth,
                         single_child_tag) noexcept
       : parent{1, k1, shifted_k2, depth} {}
+
+  /// Construct single-child node with explicit prefix length.
+  /// Used by build_chain when remaining key < key_prefix_capacity.
+  constexpr basic_inode(detail::key_prefix_size prefix_len, unodb::key_view k1,
+                        tree_depth<art_key_type> depth,
+                        single_child_tag) noexcept
+      : parent{1, prefix_len, k1, depth} {}
 };
 
 /// Type alias for basic_inode_4 parent class.
@@ -1904,6 +1932,31 @@ class basic_inode_4 : public basic_inode_4_parent<ArtPolicy> {
                           tree_depth_type depth, std::byte key_byte,
                           node_ptr child) noexcept
       : parent_class{k1, remaining_key, depth,
+                     typename parent_class::single_child_tag{}} {
+    init(key_byte, child);
+  }
+
+  /// Check if collapsing this min-size I4 would overflow the prefix.
+  [[nodiscard]] constexpr bool can_collapse(
+      std::uint8_t child_to_delete) const noexcept {
+    UNODB_DETAIL_ASSERT(this->is_min_size());
+    const std::uint8_t child_to_leave = (child_to_delete == 0) ? 1U : 0U;
+    const auto child_ptr = children[child_to_leave].load();
+    if (child_ptr.type() == node_type::LEAF) return true;
+    const auto* const child_inode{child_ptr.template ptr<inode_type*>()};
+    return this->get_key_prefix().length() +
+               child_inode->get_key_prefix().length() <
+           detail::key_prefix_capacity;
+  }
+
+  /// Construct single-child chain node with explicit prefix length.
+  /// Used by build_chain when remaining key <= key_prefix_capacity.
+  constexpr basic_inode_4(db_type&, key_view k1,
+                          // cppcheck-suppress passedByValue
+                          tree_depth_type depth,
+                          detail::key_prefix_size prefix_len,
+                          std::byte key_byte, node_ptr child) noexcept
+      : parent_class{prefix_len, k1, depth,
                      typename parent_class::single_child_tag{}} {
     init(key_byte, child);
   }

--- a/assert.hpp
+++ b/assert.hpp
@@ -85,9 +85,10 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 /// Implementation for marking a source code location as unreachable.
 ///
 /// Should not be called directly - use UNODB_DETAIL_CANNOT_HAPPEN instead.
-[[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_HEADER_NOINLINE void
-cannot_happen(const char* file, int line, const char* func) noexcept {
+[[noreturn,
+  gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1) UNODB_DETAIL_C_STRING_ARG(3)
+    UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char* file, int line,
+                                                    const char* func) noexcept {
   unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
   std::ostringstream buf;
   buf << "Execution reached an unreachable point at " << file << ':' << line
@@ -101,9 +102,9 @@ cannot_happen(const char* file, int line, const char* func) noexcept {
 #define UNODB_DETAIL_DEBUG_CRASH()
 
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3)
-UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char*, int,
-                                                const char*) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3)
+        UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char*, int,
+                                                        const char*) noexcept {
   UNODB_DETAIL_UNREACHABLE();
 }
 
@@ -116,8 +117,9 @@ UNODB_DETAIL_HEADER_NOINLINE void cannot_happen(const char*, int,
 ///
 /// Should not be called directly - use UNODB_DETAIL_CRASH instead.
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_HEADER_NOINLINE void
-crash(const char* file, int line, const char* func) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3)
+        UNODB_DETAIL_HEADER_NOINLINE void crash(const char* file, int line,
+                                                const char* func) noexcept {
   UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(0);
   std::ostringstream buf;
   buf << "Crash requested at " << file << ':' << line << ", function \"" << func
@@ -145,10 +147,10 @@ crash(const char* file, int line, const char* func) noexcept {
 ///
 /// Should not be called directly - used UNODB_DETAIL_ASSERT instead.
 [[noreturn, gnu::cold]] UNODB_DETAIL_C_STRING_ARG(1)
-UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_C_STRING_ARG(4)
-UNODB_DETAIL_HEADER_NOINLINE void
-assert_failure(const char* file, int line, const char* func,
-               const char* condition) noexcept {
+    UNODB_DETAIL_C_STRING_ARG(3) UNODB_DETAIL_C_STRING_ARG(4)
+        UNODB_DETAIL_HEADER_NOINLINE void assert_failure(
+            const char* file, int line, const char* func,
+            const char* condition) noexcept {
   unodb::test::allocation_failure_injector::fail_on_nth_allocation(0);
   std::ostringstream buf;
   buf << "Assertion \"" << condition << "\" failed at " << file << ':' << line

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -88,6 +88,7 @@ function(ADD_CONCURRENT_BENCHMARK_TARGET TARGET)
 endfunction()
 
 add_benchmark_target(micro_benchmark_key_prefix)
+add_benchmark_target(micro_benchmark_key_view)
 add_node_benchmark_target(micro_benchmark_n4)
 add_node_benchmark_target(micro_benchmark_n16)
 add_node_benchmark_target(micro_benchmark_n48)

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -1,0 +1,332 @@
+// Copyright 2026 UnoDB contributors
+
+// Should be the first include
+#include "global.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+#include <benchmark/benchmark.h>
+
+#include "micro_benchmark_utils.hpp"
+#include "qsbr.hpp"
+
+/// @file
+/// key_view micro-benchmarks for ART tree operations.
+///
+/// Establishes a performance baseline for key_view tree operations
+/// before PR #2 optimizations (remove key from leaf, lift small values
+/// into inodes).  Measures gains against this baseline as optimizations
+/// land.
+///
+/// ## Benchmark groups
+///
+/// **Core chain benchmarks** (8-byte values):
+/// Exercise insert/get/remove/scan across four key generators at
+/// multiple tree sizes (1K, 16K, 262K).
+///
+/// **kv_vs_u64 comparison** (100-byte values):
+/// Direct comparison against the u64 dense_insert benchmark.  Uses
+/// dense sequential 8-byte encoded keys (no chains) and 100-byte
+/// values to match the u64 benchmark's value size.  Timing structure
+/// (PauseTiming/destroy_tree) is identical to the u64 benchmark.
+///
+/// **Key length sweep** (8-byte values, 1024 keys):
+/// Varies key length from 8 to 256 bytes, producing chain depths
+/// from 0 to 31.  Characterizes the per-chain-level cost.
+///
+/// ## Key generators
+///
+/// - **G1 compound** (9 bytes): tag(1) + uint64.  Same tag for all
+///   keys → 1-level chain.  The basic chain workload.
+/// - **G2 deep** (18 bytes): tag(1) + uint64 + mid(1) + uint64.
+///   Same tag + fixed uint64 → 2-level chain.  Exercises multi-level
+///   chain insert/remove and the Step 2 loop in the atomic chain cut.
+/// - **G4 multi_tag** (9 bytes): 8 distinct first bytes, round-robin.
+///   Root inode is I16 with 8 independent chain subtrees.  Simulates
+///   real-world key distribution where keys have diverse prefixes
+///   (e.g., different column values in a secondary index).
+/// - **G5 dense** (8 bytes): encode(uint64) only, no chains.
+///   Baseline for isolating key_view encoding overhead vs u64.
+/// - **G6 chain_depth** (variable length): fixed-length keys with
+///   maximum shared prefix.  Chain depth = (key_len - 2) / 8.
+///   Used in the key length sweep.
+
+UNODB_START_BENCHMARKS()
+
+using unodb::benchmark::key_view_set;
+
+namespace {
+
+constexpr auto val_bytes = std::array<std::byte, 8>{};
+const auto val = unodb::value_view{val_bytes};
+
+constexpr auto val100_bytes = std::array<std::byte, 100>{};
+const auto val100 = unodb::value_view{val100_bytes};
+
+// ===================================================================
+// Core benchmarks — timing matches u64 dense_insert exactly:
+//   PauseTiming → construct → ClobberMemory → ResumeTiming
+//   ... timed work ...
+//   PauseTiming → destroy_tree (clear + ClobberMemory + ResumeTiming)
+// ===================================================================
+
+template <class Db>
+void chain_insert(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.insert(ks[i], val));
+    state.PauseTiming();
+    unodb::benchmark::destroy_tree(db, state);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void chain_get(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  Db db;
+  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.remove(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = gen(n);
+  Db db;
+  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (auto _ : state) {
+    std::size_t count = 0;
+    db.scan([&count](auto /*visitor*/) {
+      ++count;
+      return false;
+    });
+    benchmark::DoNotOptimize(count);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+// ===================================================================
+// Comparison vs u64: 100-byte values, dense 8B keys.
+// ===================================================================
+
+template <class Db>
+void kv_vs_u64_insert(benchmark::State& state) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = key_view_set::dense_sequential(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.insert(ks[i], val100));
+    state.PauseTiming();
+    unodb::benchmark::destroy_tree(db, state);
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void kv_vs_u64_get(benchmark::State& state) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = key_view_set::dense_sequential(n);
+  Db db;
+  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+  for (auto _ : state) {
+    for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+template <class Db>
+void kv_vs_u64_remove(benchmark::State& state) {
+  const auto n = static_cast<std::size_t>(state.range(0));
+  const auto ks = key_view_set::dense_sequential(n);
+  for (auto _ : state) {
+    state.PauseTiming();
+    Db db;
+    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+    benchmark::ClobberMemory();
+    state.ResumeTiming();
+    for (std::size_t i = 0; i < n; ++i)
+      benchmark::DoNotOptimize(db.remove(ks[i]));
+  }
+  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+                          static_cast<std::int64_t>(n));
+}
+
+// ===================================================================
+// Key generators
+// ===================================================================
+
+key_view_set gen_compound(std::size_t n) {
+  return key_view_set::compound(0x42, n);
+}
+key_view_set gen_deep(std::size_t n) {
+  return key_view_set::deep_compound(0x42, n);
+}
+key_view_set gen_multi_tag(std::size_t n) {
+  return key_view_set::multi_tag(8, n);
+}
+key_view_set gen_dense(std::size_t n) {
+  return key_view_set::dense_sequential(n);
+}
+
+// ===================================================================
+// Sizes
+// ===================================================================
+
+void kv_sizes(benchmark::internal::Benchmark* b) {
+  for (auto n : {1 << 10, 1 << 14, 1 << 18}) b->Arg(n);
+}
+
+void u64_sizes(benchmark::internal::Benchmark* b) {
+  for (auto n : {1 << 12, 1 << 15, 1 << 18}) b->Arg(n);
+}
+
+// ===================================================================
+// Registration: db
+// ===================================================================
+
+using DB = unodb::benchmark::kv_db;
+
+BENCHMARK_CAPTURE(chain_insert<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, deep, gen_deep)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, multi_tag, gen_multi_tag)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_get<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, deep, gen_deep)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, multi_tag, gen_multi_tag)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, deep, gen_deep)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, multi_tag, gen_multi_tag)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_scan<DB>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_scan<DB>, dense, gen_dense)->Apply(kv_sizes);
+
+// ===================================================================
+// Registration: olc_db (same functions — destroy_tree handles OLC)
+// ===================================================================
+
+using OLC = unodb::benchmark::kv_olc_db;
+
+BENCHMARK_CAPTURE(chain_insert<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_insert<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_get<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_get<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_remove<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+BENCHMARK_CAPTURE(chain_scan<OLC>, compound, gen_compound)->Apply(kv_sizes);
+BENCHMARK_CAPTURE(chain_scan<OLC>, dense, gen_dense)->Apply(kv_sizes);
+
+// ===================================================================
+// Registration: kv vs u64 comparison (100B values)
+// ===================================================================
+
+BENCHMARK(kv_vs_u64_insert<DB>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_get<DB>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_remove<DB>)->Apply(u64_sizes);
+BENCHMARK(kv_vs_u64_insert<OLC>)->Apply(u64_sizes);
+
+// ===================================================================
+// Key length sweep (G6): chain depth = (key_len-2)/8
+// key_len:    8   16   32   64  128  256
+// chain depth: 0    1    3    7   15   31
+// ===================================================================
+
+key_view_set gen_kl8(std::size_t n) { return key_view_set::chain_depth(8, n); }
+key_view_set gen_kl16(std::size_t n) {
+  return key_view_set::chain_depth(16, n);
+}
+key_view_set gen_kl32(std::size_t n) {
+  return key_view_set::chain_depth(32, n);
+}
+key_view_set gen_kl64(std::size_t n) {
+  return key_view_set::chain_depth(64, n);
+}
+key_view_set gen_kl128(std::size_t n) {
+  return key_view_set::chain_depth(128, n);
+}
+key_view_set gen_kl256(std::size_t n) {
+  return key_view_set::chain_depth(256, n);
+}
+
+void kl_sizes(benchmark::internal::Benchmark* b) { b->Arg(1024); }
+
+BENCHMARK_CAPTURE(chain_insert<DB>, kl8, gen_kl8)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl32, gen_kl32)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl128, gen_kl128)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<DB>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_get<DB>, kl8, gen_kl8)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl32, gen_kl32)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl128, gen_kl128)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<DB>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<DB>, kl8, gen_kl8)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl32, gen_kl32)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl128, gen_kl128)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<DB>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_insert<OLC>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<OLC>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_insert<OLC>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_get<OLC>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<OLC>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_get<OLC>, kl256, gen_kl256)->Apply(kl_sizes);
+
+BENCHMARK_CAPTURE(chain_remove<OLC>, kl16, gen_kl16)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<OLC>, kl64, gen_kl64)->Apply(kl_sizes);
+BENCHMARK_CAPTURE(chain_remove<OLC>, kl256, gen_kl256)->Apply(kl_sizes);
+
+}  // namespace
+
+UNODB_BENCHMARK_MAIN();

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -85,7 +85,7 @@ void chain_insert(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     state.PauseTiming();
     unodb::benchmark::destroy_tree(db, state);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 
@@ -98,7 +98,7 @@ void chain_get(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   for (auto _ : state) {
     for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 
@@ -115,7 +115,7 @@ void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.remove(ks[i]));
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 
@@ -133,7 +133,7 @@ void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
     });
     benchmark::DoNotOptimize(count);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 
@@ -155,7 +155,7 @@ void kv_vs_u64_insert(benchmark::State& state) {
     state.PauseTiming();
     unodb::benchmark::destroy_tree(db, state);
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 
@@ -168,7 +168,7 @@ void kv_vs_u64_get(benchmark::State& state) {
   for (auto _ : state) {
     for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 
@@ -185,7 +185,7 @@ void kv_vs_u64_remove(benchmark::State& state) {
     for (std::size_t i = 0; i < n; ++i)
       benchmark::DoNotOptimize(db.remove(ks[i]));
   }
-  state.SetItemsProcessed(static_cast<std::int64_t>(state.iterations()) *
+  state.SetItemsProcessed(state.iterations() *
                           static_cast<std::int64_t>(n));
 }
 

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -94,7 +94,7 @@ void chain_get(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   const auto n = static_cast<std::size_t>(state.range(0));
   const auto ks = gen(n);
   Db db;
-  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
   for (auto _ : state) {
     for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
   }
@@ -109,7 +109,7 @@ void chain_remove(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   for (auto _ : state) {
     state.PauseTiming();
     Db db;
-    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+    for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
     benchmark::ClobberMemory();
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)
@@ -124,7 +124,7 @@ void chain_scan(benchmark::State& state, key_view_set (*gen)(std::size_t)) {
   const auto n = static_cast<std::size_t>(state.range(0));
   const auto ks = gen(n);
   Db db;
-  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val);
+  for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val);
   for (auto _ : state) {
     std::size_t count = 0;
     db.scan([&count](auto /*visitor*/) {
@@ -164,7 +164,7 @@ void kv_vs_u64_get(benchmark::State& state) {
   const auto n = static_cast<std::size_t>(state.range(0));
   const auto ks = key_view_set::dense_sequential(n);
   Db db;
-  for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+  for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val100);
   for (auto _ : state) {
     for (std::size_t i = 0; i < n; ++i) benchmark::DoNotOptimize(db.get(ks[i]));
   }
@@ -179,7 +179,7 @@ void kv_vs_u64_remove(benchmark::State& state) {
   for (auto _ : state) {
     state.PauseTiming();
     Db db;
-    for (std::size_t i = 0; i < n; ++i) db.insert(ks[i], val100);
+    for (std::size_t i = 0; i < n; ++i) std::ignore = db.insert(ks[i], val100);
     benchmark::ClobberMemory();
     state.ResumeTiming();
     for (std::size_t i = 0; i < n; ++i)

--- a/benchmark/micro_benchmark_node_utils.hpp
+++ b/benchmark/micro_benchmark_node_utils.hpp
@@ -407,8 +407,8 @@ inline void set_size_counter(::benchmark::State& state,
 
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 template <class Db, node_type DominatingINodeType>
-void assert_dominating_inode_tree(const Db& test_db
-                                  UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+void assert_dominating_inode_tree(
+    const Db& test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
   static_assert(DominatingINodeType != node_type::LEAF);
   const auto node_counts{test_db.get_node_counts()};
@@ -441,9 +441,9 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
 UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
 
 template <class Db, unsigned SmallerNodeSize>
-void assert_growing_nodes(const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
-                          std::uint64_t expected_number_of_nodes
-                          UNODB_DETAIL_USED_IN_DEBUG)
+void assert_growing_nodes(
+    const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
+    std::uint64_t expected_number_of_nodes UNODB_DETAIL_USED_IN_DEBUG)
 #ifndef NDEBUG
     noexcept
 #endif
@@ -462,9 +462,9 @@ void assert_growing_nodes(const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
 }
 
 template <class Db, unsigned SmallerNodeSize>
-void assert_shrinking_nodes(const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
-                            std::uint64_t expected_number_of_nodes
-                            UNODB_DETAIL_USED_IN_DEBUG)
+void assert_shrinking_nodes(
+    const Db& test_db UNODB_DETAIL_USED_IN_DEBUG,
+    std::uint64_t expected_number_of_nodes UNODB_DETAIL_USED_IN_DEBUG)
 #ifndef NDEBUG
     noexcept
 #endif
@@ -491,8 +491,8 @@ namespace detail {
 template <class Db>
 class [[nodiscard]] tree_shape_snapshot final {
  public:
-  explicit constexpr tree_shape_snapshot(const Db& test_db
-                                         UNODB_DETAIL_USED_IN_DEBUG) noexcept
+  explicit constexpr tree_shape_snapshot(
+      const Db& test_db UNODB_DETAIL_USED_IN_DEBUG) noexcept
 #ifndef NDEBUG
       : db{test_db}
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/benchmark/micro_benchmark_utils.cpp
+++ b/benchmark/micro_benchmark_utils.cpp
@@ -30,4 +30,11 @@ template void destroy_tree<unodb::mutex_db<std::uint64_t, unodb::value_view>>(
 template void destroy_tree<unodb::olc_db<std::uint64_t, unodb::value_view>>(
     unodb::olc_db<std::uint64_t, unodb::value_view>&, ::benchmark::State&);
 
+template void destroy_tree<unodb::db<unodb::key_view, unodb::value_view>>(
+    unodb::db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+template void destroy_tree<unodb::mutex_db<unodb::key_view, unodb::value_view>>(
+    unodb::mutex_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+template void destroy_tree<unodb::olc_db<unodb::key_view, unodb::value_view>>(
+    unodb::olc_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+
 }  // namespace unodb::benchmark

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -360,7 +360,7 @@ class key_view_set {
       const auto tag = static_cast<std::uint8_t>(1 + (i % tag_count));
       auto kv = enc.reset()
                     .encode(tag)
-                    .encode(static_cast<std::uint64_t>(i / tag_count))
+                    .encode(std::uint64_t{i / tag_count})
                     .get_key_view();
       std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
       ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #endif
 #include <random>
+#include <vector>
 
 #include <benchmark/benchmark.h>
 
@@ -40,11 +41,17 @@
 
 namespace unodb::benchmark {
 
-// Benchmarked tree types
+// Benchmarked tree types (u64 keys)
 
 using db = unodb::db<std::uint64_t, unodb::value_view>;
 using mutex_db = unodb ::mutex_db<std::uint64_t, unodb::value_view>;
 using olc_db = unodb::olc_db<std::uint64_t, unodb::value_view>;
+
+// Benchmarked tree types (key_view keys)
+
+using kv_db = unodb::db<unodb::key_view, unodb::value_view>;
+using kv_mutex_db = unodb::mutex_db<unodb::key_view, unodb::value_view>;
+using kv_olc_db = unodb::olc_db<unodb::key_view, unodb::value_view>;
 
 // Values
 
@@ -266,6 +273,180 @@ destroy_tree<unodb::mutex_db<std::uint64_t, unodb::value_view>>(
 extern template void
 destroy_tree<unodb::olc_db<std::uint64_t, unodb::value_view>>(
     unodb::olc_db<std::uint64_t, unodb::value_view>&, ::benchmark::State&);
+
+extern template void
+destroy_tree<unodb::db<unodb::key_view, unodb::value_view>>(
+    unodb::db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+extern template void
+destroy_tree<unodb::mutex_db<unodb::key_view, unodb::value_view>>(
+    unodb::mutex_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+extern template void
+destroy_tree<unodb::olc_db<unodb::key_view, unodb::value_view>>(
+    unodb::olc_db<unodb::key_view, unodb::value_view>&, ::benchmark::State&);
+
+// ===================================================================
+// key_view benchmark utilities
+// ===================================================================
+
+/// Pre-generated key set with stable storage for benchmarking.
+///
+/// Keys are stored in a contiguous byte buffer; key_view instances
+/// point into it.  The buffer lifetime matches the key_view_set
+/// lifetime, so key_views remain valid as long as the set exists.
+///
+/// Designed to be parameterized on value type in the future (PR #2)
+/// for benchmarking Value=uint64_t (tuple identifier use case).
+class key_view_set {
+ public:
+  /// G1: 9-byte compound keys (tag + uint64).
+  ///
+  /// All keys share the same tag byte → 8 shared prefix bytes →
+  /// 1-level chain I4 at the root.  The uint64 component varies
+  /// sequentially (0..n-1), producing unique dispatch bytes.
+  static key_view_set compound(std::uint8_t tag, std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 9;
+    ks.buf_.resize(n * 9);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      auto kv = enc.reset()
+                    .encode(tag)
+                    .encode(static_cast<std::uint64_t>(i))
+                    .get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
+      ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
+    }
+    return ks;
+  }
+
+  /// G2: 18-byte deep compound keys (tag + uint64 + mid + uint64).
+  ///
+  /// All keys share tag + fixed uint64 → 16 shared prefix bytes →
+  /// 2-level chain.  Exercises multi-level chain insert/remove and
+  /// the Step 2 loop in the atomic chain cut algorithm.
+  static key_view_set deep_compound(std::uint8_t tag, std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 18;
+    ks.buf_.resize(n * 18);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      auto kv = enc.reset()
+                    .encode(tag)
+                    .encode(std::uint64_t{0x4242424242424242ULL})
+                    .encode(static_cast<std::uint8_t>(i & 0xFF))
+                    .encode(static_cast<std::uint64_t>(i))
+                    .get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 18);
+      ks.views_.emplace_back(ks.buf_.data() + i * 18, 18);
+    }
+    return ks;
+  }
+
+  /// G4: Multi-tag compound keys — independent chain subtrees.
+  ///
+  /// Uses @p tag_count distinct first bytes, assigned round-robin.
+  /// The root inode fans out to tag_count independent chain subtrees.
+  /// Simulates real-world key distribution where keys have diverse
+  /// prefixes (e.g., different column values in a secondary index).
+  static key_view_set multi_tag(std::uint8_t tag_count, std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 9;
+    ks.buf_.resize(n * 9);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      const auto tag = static_cast<std::uint8_t>(1 + (i % tag_count));
+      auto kv = enc.reset()
+                    .encode(tag)
+                    .encode(static_cast<std::uint64_t>(i / tag_count))
+                    .get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
+      ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
+    }
+    return ks;
+  }
+
+  /// G6: Fixed-length keys with maximum chain depth.
+  ///
+  /// Produces keys of exactly @p key_len bytes: tag(1) + pad(key_len-2)
+  /// + variant(1).  All keys within a tag group share (key_len-1) bytes,
+  /// producing chain depth = (key_len - 2) / 8.  Four tag groups create
+  /// a root I4.  Used in the key length sweep to characterize
+  /// per-chain-level cost.
+  ///
+  /// @param key_len Key length in bytes (must be >= 2).
+  /// @param n Number of keys (must be <= 256 * 4 = 1024).
+  static key_view_set chain_depth(std::size_t key_len, std::size_t n) {
+    UNODB_DETAIL_ASSERT(key_len >= 2);
+    key_view_set ks;
+    ks.key_len_ = key_len;
+    ks.buf_.resize(n * key_len);
+    ks.views_.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+      auto* const dst = ks.buf_.data() + i * key_len;
+      // tag byte: rotate through 4 tags to create a root I4.
+      dst[0] = static_cast<std::byte>(1 + (i / 256) % 4);
+      // pad bytes: all 0x42 (shared prefix).
+      for (std::size_t j = 1; j + 1 < key_len; ++j) dst[j] = std::byte{0x42};
+      // variant byte: unique within each tag group.
+      dst[key_len - 1] = static_cast<std::byte>(i & 0xFF);
+      ks.views_.emplace_back(dst, key_len);
+    }
+    return ks;
+  }
+
+  /// G5: Dense sequential keys — no chains.
+  ///
+  /// encode(uint64) only, producing 8-byte keys with no shared prefix.
+  /// Baseline for isolating key_view encoding overhead vs u64 keys.
+  static key_view_set dense_sequential(std::size_t n) {
+    key_view_set ks;
+    ks.key_len_ = 8;
+    ks.buf_.resize(n * 8);
+    ks.views_.reserve(n);
+    unodb::key_encoder enc;
+    for (std::size_t i = 0; i < n; ++i) {
+      auto kv =
+          enc.reset().encode(static_cast<std::uint64_t>(i)).get_key_view();
+      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 8);
+      ks.views_.emplace_back(ks.buf_.data() + i * 8, 8);
+    }
+    return ks;
+  }
+
+  [[nodiscard]] const std::vector<unodb::key_view>& keys() const noexcept {
+    return views_;
+  }
+  [[nodiscard]] std::size_t size() const noexcept { return views_.size(); }
+  [[nodiscard]] unodb::key_view operator[](std::size_t i) const noexcept {
+    return views_[i];
+  }
+
+ private:
+  std::vector<std::byte> buf_;
+  std::vector<unodb::key_view> views_;
+  std::size_t key_len_{0};
+};
+
+/// Insert all keys from a key_view_set into a tree.
+template <class Db>
+void populate_tree(Db& instance, const key_view_set& ks,
+                   unodb::value_view val) {
+  for (const auto& k : ks.keys()) {
+    ::benchmark::DoNotOptimize(instance.insert(k, val));
+  }
+}
+
+/// OLC specialization — quiescent state not needed for insert.
+template <>
+inline void populate_tree(kv_olc_db& instance, const key_view_set& ks,
+                          unodb::value_view val) {
+  for (const auto& k : ks.keys()) {
+    ::benchmark::DoNotOptimize(instance.insert(k, val));
+  }
+}
 
 }  // namespace unodb::benchmark
 

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -35,9 +35,6 @@ class mutex_db final {
   using get_result = std::pair<typename db<Key, value_view>::get_result,
                                std::unique_lock<std::mutex>>;
 
-  // TODO(laurynas): added temporarily during development
-  static_assert(std::is_same_v<value_type, unodb::value_view>);
-
  private:
   using art_key_type = detail::basic_art_key<Key>;
 

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -32,7 +32,7 @@ class mutex_db final {
   /// then the second member is a locked tree mutex which must be released ASAP
   /// after reading the first pair member. Otherwise, the second member is
   /// undefined.
-  using get_result = std::pair<typename db<Key, value_view>::get_result,
+  using get_result = std::pair<typename db<Key, Value>::get_result,
                                std::unique_lock<std::mutex>>;
 
  private:

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -375,7 +375,7 @@ class olc_db final {
     /// Return type for get_key().
     using get_key_result = std::conditional_t<
         detail::olc_art_policy<Key, Value>::full_key_in_inode_path,
-        scoped_key_view, key_view>;
+        transient_key_view, key_view>;
 
     /// Return the key associated with the current position of the iterator.
     ///
@@ -511,9 +511,8 @@ class olc_db final {
       // sync with one another.  So we can just do a simple POP for
       // each of them.
       const auto& e = top();
-      const auto n = (e.node.type() != node_type::LEAF)
-                         ? e.prefix.length() + 1
-                         : 0;
+      const auto n = static_cast<std::size_t>(
+          (e.node.type() != node_type::LEAF) ? e.prefix.length() + 1 : 0);
       keybuf_[keybuf_ix_].pop(n);
       stack_.pop();
     }
@@ -536,7 +535,7 @@ class olc_db final {
     /// post-condition: The iterator is !valid().
     iterator& invalidate() noexcept {
       while (!stack_.empty()) stack_.pop();  // clear the stack
-      keybuf_[keybuf_ix_].reset();                       // clear the key buffer
+      keybuf_[keybuf_ix_].reset();           // clear the key buffer
       return *this;
     }
 
@@ -960,8 +959,7 @@ class olc_db final {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   friend auto detail::make_db_leaf_ptr<Key, Value, olc_db>(art_key_type,
-                                                           value_type,
-                                                           olc_db&);
+                                                           value_type, olc_db&);
 
   template <class>
   friend class detail::basic_db_leaf_deleter;
@@ -1027,12 +1025,13 @@ template <class Db>
 class db_leaf_qsbr_deleter {
  public:
   using key_type = typename Db::key_type;
-  using leaf_type = basic_leaf<key_type, typename Db::header_type>;
+  using leaf_type = basic_leaf<leaf_key_type<key_type, typename Db::value_type>,
+                               typename Db::header_type>;
 
   static_assert(std::is_trivially_destructible_v<leaf_type>);
 
-  constexpr explicit db_leaf_qsbr_deleter(Db& db_
-                                          UNODB_DETAIL_LIFETIMEBOUND) noexcept
+  constexpr explicit db_leaf_qsbr_deleter(
+      Db& db_ UNODB_DETAIL_LIFETIMEBOUND) noexcept
       : db_instance{db_} {}
 
   void operator()(leaf_type* to_delete) const {
@@ -1071,8 +1070,9 @@ class db_leaf_qsbr_deleter {
 /// associated with the unodb::detail::olc_node_ptr..
 ///
 /// \note This returns the lock rather than trying to acquire the lock.
-[[nodiscard]] inline auto& node_ptr_lock(const unodb::detail::olc_node_ptr& node
-                                         UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+[[nodiscard]] inline auto& node_ptr_lock(
+    const unodb::detail::olc_node_ptr&
+        node UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return node.ptr<unodb::detail::olc_node_header*>()->lock();
 }
 
@@ -1080,16 +1080,16 @@ class db_leaf_qsbr_deleter {
 
 template <typename Key, typename Value>
 [[nodiscard]] auto& node_ptr_lock(
-    const unodb::detail::olc_leaf_type<Key, Value>* const node
-    UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+    const unodb::detail::olc_leaf_type<Key, Value>* const
+        node UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return node->lock();
 }
 
 #endif
 
 template <class INode>
-[[nodiscard]] constexpr auto& lock(const INode& inode
-                                   UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+[[nodiscard]] constexpr auto& lock(
+    const INode& inode UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return inode.lock();
 }
 
@@ -1176,6 +1176,7 @@ class [[nodiscard]] olc_inode_4 final : public olc_inode_4_parent<Key, Value> {
 
   using parent_class::parent_class;
 
+  using parent_class::init;
   void init(db_type& db_instance, inode_16_type& source_node,
             unodb::optimistic_lock::write_guard& source_node_guard,
             std::uint8_t child_to_delete,
@@ -1268,11 +1269,11 @@ class [[nodiscard]] olc_inode_16 final
 
   void init(db_type& db_instance, inode_4_type& source_node,
             unodb::optimistic_lock::write_guard& source_node_guard,
-            olc_db_leaf_unique_ptr_type&& child,
-            tree_depth_type depth) noexcept {
+            olc_db_leaf_unique_ptr_type&& child, tree_depth_type depth,
+            std::byte key_byte) noexcept {
     UNODB_DETAIL_ASSERT(source_node_guard.guards(lock(source_node)));
     parent_class::init(db_instance, obsolete(source_node, source_node_guard),
-                       std::move(child), depth);
+                       std::move(child), depth, key_byte);
     UNODB_DETAIL_ASSERT(!source_node_guard.active());
   }
 
@@ -1363,11 +1364,11 @@ class [[nodiscard]] olc_inode_48 final
 
   void init(db_type& db_instance, inode_16_type& source_node,
             unodb::optimistic_lock::write_guard& source_node_guard,
-            olc_db_leaf_unique_ptr_type&& child,
-            tree_depth_type depth) noexcept {
+            olc_db_leaf_unique_ptr_type&& child, tree_depth_type depth,
+            std::byte key_byte) noexcept {
     UNODB_DETAIL_ASSERT(source_node_guard.guards(lock(source_node)));
     parent_class::init(db_instance, obsolete(source_node, source_node_guard),
-                       std::move(child), depth);
+                       std::move(child), depth, key_byte);
     UNODB_DETAIL_ASSERT(!source_node_guard.active());
   }
 
@@ -1450,11 +1451,11 @@ class [[nodiscard]] olc_inode_256 final
 
   void init(db_type& db_instance, inode_48_type& source_node,
             unodb::optimistic_lock::write_guard& source_node_guard,
-            olc_db_leaf_unique_ptr_type&& child,
-            tree_depth_type depth) noexcept {
+            olc_db_leaf_unique_ptr_type&& child, tree_depth_type depth,
+            std::byte key_byte) noexcept {
     UNODB_DETAIL_ASSERT(source_node_guard.guards(lock(source_node)));
     parent_class::init(db_instance, obsolete(source_node, source_node_guard),
-                       std::move(child), depth);
+                       std::move(child), depth, key_byte);
     UNODB_DETAIL_ASSERT(!source_node_guard.active());
   }
 
@@ -1554,16 +1555,18 @@ olc_impl_helpers::add_or_choose_subtree(
           if (UNODB_DETAIL_UNLIKELY(node_write_guard.must_restart())) return {};
 
           larger_node->init(db_instance, inode, node_write_guard,
-                            std::move(cached_leaf), depth);
+                            std::move(cached_leaf), depth, key_byte);
           *node_in_parent = detail::olc_node_ptr{
               larger_node.release(), INode::larger_derived_type::type};
 
-          if constexpr (detail::olc_art_policy<Key, Value>::full_key_in_inode_path) {
+          if constexpr (detail::olc_art_policy<Key,
+                                               Value>::full_key_in_inode_path) {
             const auto chain_start =
                 static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
             if (chain_start < k.size()) {
-              auto* const new_inode = node_in_parent->load().template ptr<
-                  typename INode::larger_derived_type*>();
+              auto* const new_inode =
+                  node_in_parent->load()
+                      .template ptr<typename INode::larger_derived_type*>();
               auto* const slot = new_inode->find_child(key_byte).second;
               UNODB_DETAIL_ASSERT(slot != nullptr);
               *slot = db_instance.build_chain(k, slot->load(), chain_start);
@@ -1589,7 +1592,8 @@ olc_impl_helpers::add_or_choose_subtree(
     if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
       return {};  // LCOV_EXCL_LINE
 
-    inode.add_to_nonfull(std::move(cached_leaf), depth, children_count);
+    inode.add_to_nonfull(std::move(cached_leaf), depth, key_byte,
+                         children_count);
 
     // For full_key_in_inode_path: wrap the bare leaf in a chain.
     if constexpr (detail::olc_art_policy<Key, Value>::full_key_in_inode_path) {
@@ -1712,6 +1716,12 @@ template <typename Key, typename Value, class INode>
           *child_in_parent = nullptr;
           return true;
         }
+      } else if constexpr (detail::can_eliminate_key_in_leaf_v<Key, Value>) {
+        // Keyless leaf: don't collapse — keep the chain intact.
+        child_guard.unlock_and_obsolete();
+        inode.remove(child_i, db_instance);
+        *child_in_parent = nullptr;
+        return true;
       }
     }
     auto current_node{olc_art_policy<Key, Value>::make_db_inode_reclaimable_ptr(
@@ -1863,7 +1873,14 @@ typename olc_db<Key, Value>::try_get_result_type olc_db<Key, Value>::try_get(
 
     if (node_type == node_type::LEAF) {
       const auto* const leaf{node.ptr<leaf_type*>()};
-      if (leaf->matches(k)) {
+      const bool key_matches = [&]() {
+        if constexpr (art_policy::can_eliminate_key_in_leaf) {
+          return remaining_key.size() == 0;
+        } else {
+          return leaf->matches(k);
+        }
+      }();
+      if (key_matches) {
         const auto val{leaf->template get_value<Value>()};
         if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
           return {};  // LCOV_EXCL_LINE
@@ -1912,6 +1929,14 @@ typename olc_db<Key, Value>::try_get_result_type olc_db<Key, Value>::try_get(
 template <typename Key, typename Value>
 bool olc_db<Key, Value>::insert_internal(art_key_type insert_key,
                                          value_type v) {
+  if constexpr (std::is_same_v<Key, key_view>) {
+    if (UNODB_DETAIL_UNLIKELY(
+            insert_key.size() >
+            std::numeric_limits<unodb::key_size_type>::max())) {
+      throw std::length_error("Key length must fit in std::uint32_t");
+    }
+  }
+
   try_update_result_type result;
   olc_db_leaf_unique_ptr_type cached_leaf{
       nullptr, detail::basic_db_leaf_deleter<olc_db<Key, Value>>{*this}};
@@ -1926,8 +1951,7 @@ bool olc_db<Key, Value>::insert_internal(art_key_type insert_key,
 
 template <typename Key, typename Value>
 detail::olc_node_ptr olc_db<Key, Value>::build_chain(
-    art_key_type k, detail::olc_node_ptr child,
-    tree_depth_type start_depth) {
+    art_key_type k, detail::olc_node_ptr child, tree_depth_type start_depth) {
   constexpr std::size_t cap = detail::key_prefix_capacity;
   const auto full_key = k.get_key_view();
   const auto key_len = k.size();
@@ -1939,9 +1963,9 @@ detail::olc_node_ptr olc_db<Key, Value>::build_chain(
     const auto dispatch = full_key[pos - 1];
     auto remaining = k;
     remaining.shift_right(depth);
-    auto chain{inode_4::create(*this, full_key, remaining,
-                               tree_depth_type{static_cast<std::uint32_t>(depth)},
-                               dispatch, current)};
+    auto chain{inode_4::create(
+        *this, full_key, remaining,
+        tree_depth_type{static_cast<std::uint32_t>(depth)}, dispatch, current)};
     current = detail::olc_node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
     account_growing_inode<node_type::I4>();
@@ -1950,10 +1974,10 @@ detail::olc_node_ptr olc_db<Key, Value>::build_chain(
   }
   if (pos > start) {
     const auto dispatch = full_key[pos - 1];
-    auto chain{inode_4::create(*this, full_key,
-                               tree_depth_type{static_cast<std::uint32_t>(start)},
-                               static_cast<detail::key_prefix_size>(pos - start - 1),
-                               dispatch, current)};
+    auto chain{inode_4::create(
+        *this, full_key, tree_depth_type{static_cast<std::uint32_t>(start)},
+        static_cast<detail::key_prefix_size>(pos - start - 1), dispatch,
+        current)};
     current = detail::olc_node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
     account_growing_inode<node_type::I4>();
@@ -1986,7 +2010,7 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
       return {};  // LCOV_EXCL_LINE
     }
 
-    if constexpr (art_policy::can_eliminate_leaf) {
+    if constexpr (art_policy::can_eliminate_key_in_leaf) {
       root = build_chain(
           k, detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF},
           tree_depth_type{0});
@@ -2014,35 +2038,71 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
     const auto node_type = node.type();
 
     if (node_type == node_type::LEAF) {
-      const auto* const leaf{node.template ptr<leaf_type*>()};
-      const auto existing_key{leaf->get_key_view()};
-      if (UNODB_DETAIL_UNLIKELY(k.cmp(existing_key) == 0)) {
+      if constexpr (art_policy::can_eliminate_key_in_leaf) {
+        // Keyless leaf: the inode path consumed all bytes of the existing
+        // key.  The ART prefix restriction guarantees no key is a prefix
+        // of another, so remaining_key must be empty → duplicate.
+        UNODB_DETAIL_ASSERT(remaining_key.size() == 0);
         if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
-          return {};  // LCOV_EXCL_LINE
+          return {};
         if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
-          return {};  // LCOV_EXCL_LINE
-
+          return {};
         if (UNODB_DETAIL_UNLIKELY(cached_leaf != nullptr)) {
-          cached_leaf.reset();  // LCOV_EXCL_LINE
+          cached_leaf.reset();
         }
-        return false;  // exists
-      }
+        return false;
+      } else {
+        const auto* const leaf{node.template ptr<leaf_type*>()};
+        const auto existing_key{leaf->get_key_view()};
+        if (UNODB_DETAIL_UNLIKELY(k.cmp(existing_key) == 0)) {
+          if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
+            return {};  // LCOV_EXCL_LINE
+          if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
+            return {};  // LCOV_EXCL_LINE
 
-      // When the keys share more than key_prefix_capacity bytes at
-      // this depth, the dispatch bytes collide and we cannot create a
-      // two-child inode_4 directly.  Instead, create a single-child
-      // chain inode_4 and restart — the next attempt will descend
-      // through the chain and repeat until the keys diverge.
-      constexpr auto cap = detail::key_prefix_capacity;
-      const auto remaining_existing = existing_key.subspan(depth);
-      const auto shared = detail::key_prefix_snapshot::shared_len(
-          detail::get_u64(remaining_existing), remaining_key.get_u64(), cap);
-      if (shared >= cap && remaining_existing.size() > cap &&
-          remaining_key.size() > cap &&
-          remaining_existing[cap] == remaining_key[cap]) {
-        const auto dispatch = remaining_existing[cap];
-        auto chain{inode_4::create(*this, existing_key, remaining_key, depth,
-                                   dispatch, node)};
+          if (UNODB_DETAIL_UNLIKELY(cached_leaf != nullptr)) {
+            cached_leaf.reset();  // LCOV_EXCL_LINE
+          }
+          return false;  // exists
+        }
+
+        // When the keys share more than key_prefix_capacity bytes at
+        // this depth, the dispatch bytes collide and we cannot create a
+        // two-child inode_4 directly.  Instead, create a single-child
+        // chain inode_4 and restart — the next attempt will descend
+        // through the chain and repeat until the keys diverge.
+        constexpr auto cap = detail::key_prefix_capacity;
+        const auto remaining_existing = existing_key.subspan(depth);
+        const auto shared = detail::key_prefix_snapshot::shared_len(
+            detail::get_u64(remaining_existing), remaining_key.get_u64(), cap);
+        if (shared >= cap && remaining_existing.size() > cap &&
+            remaining_key.size() > cap &&
+            remaining_existing[cap] == remaining_key[cap]) {
+          const auto dispatch = remaining_existing[cap];
+          auto chain{inode_4::create(*this, existing_key, remaining_key, depth,
+                                     dispatch, node)};
+          {
+            const optimistic_lock::write_guard parent_guard{
+                std::move(parent_critical_section)};
+            if (UNODB_DETAIL_UNLIKELY(parent_guard.must_restart())) return {};
+
+            const optimistic_lock::write_guard node_guard{
+                std::move(node_critical_section)};
+            if (UNODB_DETAIL_UNLIKELY(node_guard.must_restart())) return {};
+
+            *node_in_parent =
+                detail::olc_node_ptr{chain.release(), node_type::I4};
+          }
+#ifdef UNODB_DETAIL_WITH_STATS
+          account_growing_inode<node_type::I4>();
+#endif                // UNODB_DETAIL_WITH_STATS
+          return {};  // restart to descend through the new chain node
+        }
+
+        create_leaf_if_needed(cached_leaf, k, v, *this);
+        auto new_node{
+            inode_4::create(*this, existing_key, remaining_key, depth)};
+
         {
           const optimistic_lock::write_guard parent_guard{
               std::move(parent_critical_section)};
@@ -2052,49 +2112,30 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
               std::move(node_critical_section)};
           if (UNODB_DETAIL_UNLIKELY(node_guard.must_restart())) return {};
 
+          new_node->init(existing_key, remaining_key, depth, leaf,
+                         std::move(cached_leaf));
           *node_in_parent =
-              detail::olc_node_ptr{chain.release(), node_type::I4};
+              detail::olc_node_ptr{new_node.release(), node_type::I4};
+
+          if constexpr (art_policy::full_key_in_inode_path) {
+            const auto chain_start =
+                static_cast<tree_depth_type>(depth + shared + 1);
+            if (chain_start < k.size()) {
+              auto* const new_i4 =
+                  node_in_parent->load().template ptr<inode_type*>();
+              auto* const slot =
+                  new_i4->find_child(node_type::I4, remaining_key[shared])
+                      .second;
+              UNODB_DETAIL_ASSERT(slot != nullptr);
+              *slot = build_chain(k, slot->load(), chain_start);
+            }
+          }
         }
 #ifdef UNODB_DETAIL_WITH_STATS
         account_growing_inode<node_type::I4>();
-#endif              // UNODB_DETAIL_WITH_STATS
-        return {};  // restart to descend through the new chain node
-      }
-
-      create_leaf_if_needed(cached_leaf, k, v, *this);
-      auto new_node{inode_4::create(*this, existing_key, remaining_key, depth)};
-
-      {
-        const optimistic_lock::write_guard parent_guard{
-            std::move(parent_critical_section)};
-        if (UNODB_DETAIL_UNLIKELY(parent_guard.must_restart())) return {};
-
-        const optimistic_lock::write_guard node_guard{
-            std::move(node_critical_section)};
-        if (UNODB_DETAIL_UNLIKELY(node_guard.must_restart())) return {};
-
-        new_node->init(existing_key, remaining_key, depth, leaf,
-                       std::move(cached_leaf));
-        *node_in_parent =
-            detail::olc_node_ptr{new_node.release(), node_type::I4};
-
-        if constexpr (art_policy::full_key_in_inode_path) {
-          const auto chain_start =
-              static_cast<tree_depth_type>(depth + shared + 1);
-          if (chain_start < k.size()) {
-            auto* const new_i4 =
-                node_in_parent->load().template ptr<inode_type*>();
-            auto* const slot =
-                new_i4->find_child(node_type::I4, remaining_key[shared]).second;
-            UNODB_DETAIL_ASSERT(slot != nullptr);
-            *slot = build_chain(k, slot->load(), chain_start);
-          }
-        }
-      }
-#ifdef UNODB_DETAIL_WITH_STATS
-      account_growing_inode<node_type::I4>();
 #endif  // UNODB_DETAIL_WITH_STATS
-      return true;
+        return true;
+      }  // else (keyed leaf)
     }
 
     UNODB_DETAIL_ASSERT(node_type != node_type::LEAF);
@@ -2119,7 +2160,8 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
         if (UNODB_DETAIL_UNLIKELY(node_guard.must_restart())) return {};
 
         new_node->init(node, shared_prefix_length, depth,
-                       std::move(cached_leaf));
+                       std::move(cached_leaf),
+                       remaining_key[shared_prefix_length]);
         *node_in_parent =
             detail::olc_node_ptr{new_node.release(), node_type::I4};
 
@@ -2130,7 +2172,10 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
             auto* const new_i4 =
                 node_in_parent->load().template ptr<inode_type*>();
             auto* const slot =
-                new_i4->find_child(node_type::I4, remaining_key[shared_prefix_length]).second;
+                new_i4
+                    ->find_child(node_type::I4,
+                                 remaining_key[shared_prefix_length])
+                    .second;
             UNODB_DETAIL_ASSERT(slot != nullptr);
             *slot = build_chain(k, slot->load(), chain_start);
           }
@@ -2303,7 +2348,14 @@ olc_db<Key, Value>::try_remove_key_view(art_key_type k) {
         UNODB_DETAIL_DISABLE_MSVC_WARNING(26462)
         const auto* const leaf{cv.template ptr<leaf_type*>()};
         UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
-        if (!leaf->matches(k)) {
+        const bool mismatch = [&]() {
+          if constexpr (art_policy::can_eliminate_key_in_leaf) {
+            return remaining_key.size() != 1;
+          } else {
+            return !leaf->matches(k);
+          }
+        }();
+        if (mismatch) {
           if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))
             return {};  // LCOV_EXCL_LINE
           if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
@@ -2564,7 +2616,13 @@ typename olc_db<Key, Value>::iterator& olc_db<Key, Value>::iterator::next() {
     // copy of the key since actions on the stack will make it
     // impossible to reconstruct the key.  So maybe we have two
     // internal buffers on the iterator to support this?
-    const auto& akey = leaf->get_key();  // access the key on the leaf.
+    art_key_type akey{[&]() -> art_key_type {
+      if constexpr (art_policy::full_key_in_inode_path) {
+        return art_key_type{keybuf_[keybuf_ix_].get_key_view()};
+      } else {
+        return leaf->get_key();
+      }
+    }()};
     if (UNODB_DETAIL_LIKELY(try_next())) return *this;
     while (true) {
       bool match{};
@@ -2637,7 +2695,13 @@ typename olc_db<Key, Value>::iterator& olc_db<Key, Value>::iterator::prior() {
     // copy of the key since actions on the stack will make it
     // impossible to reconstruct the key.  So maybe we have two
     // internal buffers on the iterator to support this?
-    const auto& akey = leaf->get_key();  // access the key on the leaf.
+    art_key_type akey{[&]() -> art_key_type {
+      if constexpr (art_policy::full_key_in_inode_path) {
+        return art_key_type{keybuf_[keybuf_ix_].get_key_view()};
+      } else {
+        return leaf->get_key();
+      }
+    }()};
     if (UNODB_DETAIL_LIKELY(try_prior())) return *this;
     while (true) {
       bool match{};
@@ -2775,7 +2839,13 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
       const auto* const leaf{node.template ptr<leaf_type*>()};
       if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
         return false;  // LCOV_EXCL_LINE
-      const auto cmp_ = leaf->cmp(k);
+      int cmp_;
+      if constexpr (art_policy::full_key_in_inode_path) {
+        cmp_ = unodb::detail::compare(keybuf_[keybuf_ix_].get_key_view(),
+                                      k.get_key_view());
+      } else {
+        cmp_ = leaf->cmp(k);
+      }
       if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
         return false;  // LCOV_EXCL_LINE
       if (cmp_ == 0) {
@@ -3083,7 +3153,7 @@ typename olc_db<Key, Value>::iterator::get_key_result
 olc_db<Key, Value>::iterator::get_key() noexcept {
   UNODB_DETAIL_ASSERT(valid());  // by contract
   if constexpr (art_policy::full_key_in_inode_path) {
-    return scoped_key_view{keybuf_[keybuf_ix_].get_key_view()};
+    return transient_key_view{keybuf_[keybuf_ix_].get_key_view()};
   } else {
     const auto& e = stack_.top();
     const auto& node = e.node;
@@ -3229,6 +3299,10 @@ bool olc_db<Key, Value>::try_collapse_i4(
       return false;  // prefix overflow — leave as single-child I4
     }
     ri->get_key_prefix().prepend(i4->get_key_prefix(), rem_iter.key_byte);
+  } else if constexpr (art_policy::can_eliminate_key_in_leaf) {
+    // Keyless leaf: collapsing would lose key bytes encoded in this
+    // inode's prefix+dispatch.  Keep the chain intact.
+    return false;
   }
   if (slot != nullptr)
     *slot = rem;
@@ -3453,9 +3527,7 @@ olc_db<Key, Value>::try_chain_cut(
 
   // --- Step 4.4: Reclaim leaf and chain nodes ---
   leaf_guard.unlock_and_obsolete();
-  {
-    const auto r{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)};
-  }
+  { const auto r{art_policy::reclaim_leaf_on_scope_exit(leaf, *this)}; }
 
   // chain_bottom_guard may have been consumed by init() in the shrink path.
   // must_restart() returns true when the guard is inactive (no lock).

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -813,7 +813,7 @@ class olc_db final {
   /// Build an inode chain encoding key bytes from start_depth to end.
   [[nodiscard]] detail::olc_node_ptr build_chain(
       art_key_type k, detail::olc_node_ptr child,
-      detail::tree_depth<art_key_type> start_depth = {});
+      detail::tree_depth<art_key_type> start_depth);
 
   [[nodiscard]] try_update_result_type try_remove(art_key_type k);
 
@@ -1967,7 +1967,8 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
 
     if constexpr (art_policy::can_eliminate_leaf) {
       root = build_chain(
-          k, detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF});
+          k, detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF},
+          tree_depth_type{0});
     } else {
       root = detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF};
     }

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1938,7 +1938,7 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
       return {};  // LCOV_EXCL_LINE
     }
 
-    if constexpr (std::is_same_v<Key, key_view>) {
+    if constexpr (art_policy::can_eliminate_leaf) {
       root = build_chain(
           k, detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF});
     } else {

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -162,7 +162,7 @@ class olc_db final {
   /// The type of the value associated with the key in the index.
   using value_type = Value;
   using value_view = unodb::qsbr_value_view;
-  using get_result = std::optional<value_view>;
+  using get_result = std::optional<value_type>;
   using inode_base = detail::olc_inode_base<Key, Value>;
   using leaf_type = detail::olc_leaf_type<Key, Value>;
   using db_type = olc_db<Key, Value>;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -372,11 +372,15 @@ class olc_db final {
     /// LTE the search_key and invalidated if there is no such entry.
     iterator& seek(art_key_type search_key, bool& match, bool fwd = true);
 
-    /// Return the key_view associated with the current position of
-    /// the iterator.
+    /// Return type for get_key().
+    using get_key_result = std::conditional_t<
+        detail::olc_art_policy<Key, Value>::full_key_in_inode_path,
+        scoped_key_view, key_view>;
+
+    /// Return the key associated with the current position of the iterator.
     ///
     /// \pre The iterator MUST be valid().
-    [[nodiscard]] key_view get_key() noexcept;
+    [[nodiscard]] get_key_result get_key() noexcept;
 
     /// Return the value_view associated with the current position of
     /// the iterator.
@@ -3075,22 +3079,18 @@ bool olc_db<Key, Value>::iterator::try_right_most_traversal(
 
 UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=pure")
 template <typename Key, typename Value>
-key_view olc_db<Key, Value>::iterator::get_key() noexcept {
+typename olc_db<Key, Value>::iterator::get_key_result
+olc_db<Key, Value>::iterator::get_key() noexcept {
   UNODB_DETAIL_ASSERT(valid());  // by contract
-  // Note: If the iterator is on a leaf, we return the key for that
-  // leaf regardless of whether the leaf has been deleted.  This is
-  // part of the design semantics for the OLC ART scan.
-  //
-  // TODO(thompsonbry) : Switch to keybuf_[keybuf_ix_].get_key_view()
-  // once D1 (no root leaf for key_view) is implemented.  With no root
-  // leaf, every leaf has an inode path and keybuf_ is always populated.
-  // The dual key_buffer (keybuf_[2] + keybuf_ix_) is already in place
-  // for OLC restart safety in next()/prior().
-  const auto& e = stack_.top();
-  const auto& node = e.node;
-  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);      // On a leaf.
-  const auto* const leaf{node.template ptr<leaf_type*>()};  // current leaf.
-  return leaf->get_key_view();
+  if constexpr (art_policy::full_key_in_inode_path) {
+    return scoped_key_view{keybuf_[keybuf_ix_].get_key_view()};
+  } else {
+    const auto& e = stack_.top();
+    const auto& node = e.node;
+    UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
+    const auto* const leaf{node.template ptr<leaf_type*>()};
+    return leaf->get_key_view();
+  }
 }
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -44,6 +44,10 @@ inline sync_point sync_after_chain_locked;
 /// Sync point: fires inside Step 2 loop between chain node locks.
 inline sync_point sync_between_chain_locks;
 
+/// Sync point: fires in remove_or_choose_subtree after leaf match confirmed
+/// and min_size read, before write guard acquisition.
+inline sync_point sync_before_remove_write_guard;
+
 /// OLC ART node header contains an unodb::optimistic_lock object for this node.
 ///
 /// The node type is constant throughout the node lifetime, is stored outside of
@@ -1603,6 +1607,8 @@ template <typename Key, typename Value, class INode>
   }
 
   const auto is_node_min_size{inode.is_min_size()};
+
+  detail::sync(detail::sync_before_remove_write_guard);
 
   if (UNODB_DETAIL_LIKELY(!is_node_min_size)) {
     if (UNODB_DETAIL_UNLIKELY(!parent_critical_section.try_read_unlock()))

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -3114,14 +3114,16 @@ auto olc_db<Key, Value>::iterator::get_val() const noexcept
 
 template <typename Key, typename Value>
 int olc_db<Key, Value>::iterator::cmp(const art_key_type& akey) const noexcept {
-  // TODO(thompsonbry) : variable length keys. Explore a cheaper way
-  // to handle the exclusive bound case when developing variable
-  // length key support based on the maintained key buffer.
   UNODB_DETAIL_ASSERT(!stack_.empty());
-  auto& node = stack_.top().node;
-  UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
-  const auto* const leaf{node.template ptr<leaf_type*>()};
-  return unodb::detail::compare(leaf->get_key_view(), akey.get_key_view());
+  if constexpr (art_policy::full_key_in_inode_path) {
+    return unodb::detail::compare(keybuf_[keybuf_ix_].get_key_view(),
+                                  akey.get_key_view());
+  } else {
+    auto& node = stack_.top().node;
+    UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
+    const auto* const leaf{node.template ptr<leaf_type*>()};
+    return unodb::detail::compare(leaf->get_key_view(), akey.get_key_view());
+  }
 }
 
 ///

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -810,10 +810,10 @@ class olc_db final {
   [[nodiscard]] try_update_result_type try_insert(
       art_key_type k, value_type v, olc_db_leaf_unique_ptr_type& cached_leaf);
 
-  /// Build an inode chain for the first key_view insert.  Same as
-  /// db::build_chain but uses olc_node_ptr.
-  [[nodiscard]] detail::olc_node_ptr build_chain(art_key_type k,
-                                                 detail::olc_node_ptr child);
+  /// Build an inode chain encoding key bytes from start_depth to end.
+  [[nodiscard]] detail::olc_node_ptr build_chain(
+      art_key_type k, detail::olc_node_ptr child,
+      detail::tree_depth<art_key_type> start_depth = {});
 
   [[nodiscard]] try_update_result_type try_remove(art_key_type k);
 
@@ -1537,6 +1537,18 @@ olc_impl_helpers::add_or_choose_subtree(
           *node_in_parent = detail::olc_node_ptr{
               larger_node.release(), INode::larger_derived_type::type};
 
+          if constexpr (detail::olc_art_policy<Key, Value>::full_key_in_inode_path) {
+            const auto chain_start =
+                static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
+            if (chain_start < k.size()) {
+              auto* const new_inode = node_in_parent->load().template ptr<
+                  typename INode::larger_derived_type*>();
+              auto* const slot = new_inode->find_child(key_byte).second;
+              UNODB_DETAIL_ASSERT(slot != nullptr);
+              *slot = db_instance.build_chain(k, slot->load(), chain_start);
+            }
+          }
+
           UNODB_DETAIL_ASSERT(!node_write_guard.active());
         }
 
@@ -1557,6 +1569,17 @@ olc_impl_helpers::add_or_choose_subtree(
       return {};  // LCOV_EXCL_LINE
 
     inode.add_to_nonfull(std::move(cached_leaf), depth, children_count);
+
+    // For full_key_in_inode_path: wrap the bare leaf in a chain.
+    if constexpr (detail::olc_art_policy<Key, Value>::full_key_in_inode_path) {
+      const auto chain_start =
+          static_cast<tree_depth<basic_art_key<Key>>>(depth + 1);
+      if (chain_start < k.size()) {
+        auto* const slot = inode.find_child(key_byte).second;
+        UNODB_DETAIL_ASSERT(slot != nullptr);
+        *slot = db_instance.build_chain(k, slot->load(), chain_start);
+      }
+    }
   }
 
   return child_in_parent;
@@ -1882,13 +1905,15 @@ bool olc_db<Key, Value>::insert_internal(art_key_type insert_key,
 
 template <typename Key, typename Value>
 detail::olc_node_ptr olc_db<Key, Value>::build_chain(
-    art_key_type k, detail::olc_node_ptr child) {
+    art_key_type k, detail::olc_node_ptr child,
+    tree_depth_type start_depth) {
   constexpr std::size_t cap = detail::key_prefix_capacity;
   const auto full_key = k.get_key_view();
   const auto key_len = k.size();
+  const auto start = static_cast<std::size_t>(start_depth);
   auto current = child;
   std::size_t pos = key_len;
-  while (pos > cap) {
+  while (pos > start + cap) {
     const auto depth = pos - cap - 1;
     const auto dispatch = full_key[pos - 1];
     auto remaining = k;
@@ -1901,10 +1926,10 @@ detail::olc_node_ptr olc_db<Key, Value>::build_chain(
 #endif
     pos = depth;
   }
-  if (pos > 0) {
+  if (pos > start) {
     const auto dispatch = full_key[pos - 1];
-    auto chain{inode_4::create(*this, full_key, tree_depth_type{0},
-                               static_cast<detail::key_prefix_size>(pos - 1),
+    auto chain{inode_4::create(*this, full_key, tree_depth_type{start},
+                               static_cast<detail::key_prefix_size>(pos - start - 1),
                                dispatch, current)};
     current = detail::olc_node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
@@ -2028,6 +2053,19 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
                        std::move(cached_leaf));
         *node_in_parent =
             detail::olc_node_ptr{new_node.release(), node_type::I4};
+
+        if constexpr (art_policy::full_key_in_inode_path) {
+          const auto chain_start =
+              static_cast<tree_depth_type>(depth + shared + 1);
+          if (chain_start < k.size()) {
+            auto* const new_i4 =
+                node_in_parent->load().template ptr<inode_type*>();
+            auto* const slot =
+                new_i4->find_child(node_type::I4, remaining_key[shared]).second;
+            UNODB_DETAIL_ASSERT(slot != nullptr);
+            *slot = build_chain(k, slot->load(), chain_start);
+          }
+        }
       }
 #ifdef UNODB_DETAIL_WITH_STATS
       account_growing_inode<node_type::I4>();
@@ -2060,6 +2098,19 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
                        std::move(cached_leaf));
         *node_in_parent =
             detail::olc_node_ptr{new_node.release(), node_type::I4};
+
+        if constexpr (art_policy::full_key_in_inode_path) {
+          const auto chain_start =
+              static_cast<tree_depth_type>(depth + shared_prefix_length + 1);
+          if (chain_start < k.size()) {
+            auto* const new_i4 =
+                node_in_parent->load().template ptr<inode_type*>();
+            auto* const slot =
+                new_i4->find_child(node_type::I4, remaining_key[shared_prefix_length]).second;
+            UNODB_DETAIL_ASSERT(slot != nullptr);
+            *slot = build_chain(k, slot->load(), chain_start);
+          }
+        }
       }
 
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1919,7 +1919,8 @@ detail::olc_node_ptr olc_db<Key, Value>::build_chain(
     auto remaining = k;
     remaining.shift_right(depth);
     auto chain{inode_4::create(*this, full_key, remaining,
-                               tree_depth_type{depth}, dispatch, current)};
+                               tree_depth_type{static_cast<std::uint32_t>(depth)},
+                               dispatch, current)};
     current = detail::olc_node_ptr{chain.release(), node_type::I4};
 #ifdef UNODB_DETAIL_WITH_STATS
     account_growing_inode<node_type::I4>();
@@ -1928,7 +1929,8 @@ detail::olc_node_ptr olc_db<Key, Value>::build_chain(
   }
   if (pos > start) {
     const auto dispatch = full_key[pos - 1];
-    auto chain{inode_4::create(*this, full_key, tree_depth_type{start},
+    auto chain{inode_4::create(*this, full_key,
+                               tree_depth_type{static_cast<std::uint32_t>(start)},
                                static_cast<detail::key_prefix_size>(pos - start - 1),
                                dispatch, current)};
     current = detail::olc_node_ptr{chain.release(), node_type::I4};

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -8,6 +8,7 @@
 // Should be the first include
 #include "global.hpp"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstddef>
@@ -17,6 +18,7 @@
 #include <stack>
 #include <tuple>
 #include <type_traits>
+#include <vector>
 
 #include <boost/container/small_vector.hpp>
 
@@ -429,6 +431,18 @@ class olc_db final {
     /// Return true unless the stack is empty (exposed to tests)
     [[nodiscard]] bool valid() const noexcept { return !stack_.empty(); }
 
+    /// Return stack entries bottom-to-top (test only).
+    [[nodiscard]] std::vector<stack_entry> test_only_stack() const {
+      auto tmp = stack_;
+      std::vector<stack_entry> result;
+      while (!tmp.empty()) {
+        result.push_back(tmp.top());
+        tmp.pop();
+      }
+      std::reverse(result.begin(), result.end());
+      return result;
+    }
+
    protected:
     /// Compare the given key (e.g., the to_key) to the current key in the
     /// internal buffer.
@@ -492,8 +506,11 @@ class olc_db final {
       // was pushed onto the stack and the stack and the keybuf are in
       // sync with one another.  So we can just do a simple POP for
       // each of them.
-      const auto prefix_len = top().prefix.length();
-      keybuf_[keybuf_ix_].pop(prefix_len);
+      const auto& e = top();
+      const auto n = (e.node.type() != node_type::LEAF)
+                         ? e.prefix.length() + 1
+                         : 0;
+      keybuf_[keybuf_ix_].pop(n);
       stack_.pop();
     }
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -393,7 +393,7 @@ class olc_db final {
       }
       // Dump the key buffer maintained by the iterator.
       os << "keybuf=";
-      detail::dump_key(os, keybuf_.get_key_view());
+      detail::dump_key(os, keybuf_[keybuf_ix_].get_key_view());
       os << "\n";
       // Create a new stack and copy everything there.  Using the new
       // stack, print out the stack in top-bottom order.  This avoids
@@ -455,8 +455,8 @@ class olc_db final {
       // OLC where the node might be concurrently modified.
       UNODB_DETAIL_ASSERT(node.type() != node_type::LEAF);
       stack_.push({{node, key_byte, child_index, prefix}, rcs.get()});
-      keybuf_.push(prefix.get_key_view());
-      keybuf_.push(key_byte);
+      keybuf_[keybuf_ix_].push(prefix.get_key_view());
+      keybuf_[keybuf_ix_].push(key_byte);
       return true;
     }
 
@@ -493,7 +493,7 @@ class olc_db final {
       // sync with one another.  So we can just do a simple POP for
       // each of them.
       const auto prefix_len = top().prefix.length();
-      keybuf_.pop(prefix_len);
+      keybuf_[keybuf_ix_].pop(prefix_len);
       stack_.pop();
     }
 
@@ -515,7 +515,7 @@ class olc_db final {
     /// post-condition: The iterator is !valid().
     iterator& invalidate() noexcept {
       while (!stack_.empty()) stack_.pop();  // clear the stack
-      keybuf_.reset();                       // clear the key buffer
+      keybuf_[keybuf_ix_].reset();                       // clear the key buffer
       return *this;
     }
 
@@ -559,7 +559,8 @@ class olc_db final {
     /// pushed onto this buffer when we push something onto the
     /// iterator stack and popped off of this buffer when we pop
     /// something off of the iterator stack.
-    detail::key_buffer keybuf_{};
+    detail::key_buffer keybuf_[2]{};
+    unsigned keybuf_ix_{0};
   };  // class iterator
 
   //
@@ -2965,12 +2966,11 @@ key_view olc_db<Key, Value>::iterator::get_key() noexcept {
   // leaf regardless of whether the leaf has been deleted.  This is
   // part of the design semantics for the OLC ART scan.
   //
-  // TODO(thompsonbry) : variable length keys. The simplest case
-  // where this does not work today is a single root leaf.  In that
-  // case, there is no inode path and we can not properly track the
-  // key in the key_buffer.
-  //
-  // return keybuf_.get_key_view();
+  // TODO(thompsonbry) : Switch to keybuf_[keybuf_ix_].get_key_view()
+  // once D1 (no root leaf for key_view) is implemented.  With no root
+  // leaf, every leaf has an inode path and keybuf_ is always populated.
+  // The dual key_buffer (keybuf_[2] + keybuf_ix_) is already in place
+  // for OLC restart safety in next()/prior().
   const auto& e = stack_.top();
   const auto& node = e.node;
   UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);      // On a leaf.

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -810,6 +810,11 @@ class olc_db final {
   [[nodiscard]] try_update_result_type try_insert(
       art_key_type k, value_type v, olc_db_leaf_unique_ptr_type& cached_leaf);
 
+  /// Build an inode chain for the first key_view insert.  Same as
+  /// db::build_chain but uses olc_node_ptr.
+  [[nodiscard]] detail::olc_node_ptr build_chain(art_key_type k,
+                                                 detail::olc_node_ptr child);
+
   [[nodiscard]] try_update_result_type try_remove(art_key_type k);
 
   /// Stack entry for key_view remove traversal.
@@ -1876,6 +1881,40 @@ bool olc_db<Key, Value>::insert_internal(art_key_type insert_key,
 }
 
 template <typename Key, typename Value>
+detail::olc_node_ptr olc_db<Key, Value>::build_chain(
+    art_key_type k, detail::olc_node_ptr child) {
+  constexpr std::size_t cap = detail::key_prefix_capacity;
+  const auto full_key = k.get_key_view();
+  const auto key_len = k.size();
+  auto current = child;
+  std::size_t pos = key_len;
+  while (pos > cap) {
+    const auto depth = pos - cap - 1;
+    const auto dispatch = full_key[pos - 1];
+    auto remaining = k;
+    remaining.shift_right(depth);
+    auto chain{inode_4::create(*this, full_key, remaining,
+                               tree_depth_type{depth}, dispatch, current)};
+    current = detail::olc_node_ptr{chain.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+    account_growing_inode<node_type::I4>();
+#endif
+    pos = depth;
+  }
+  if (pos > 0) {
+    const auto dispatch = full_key[pos - 1];
+    auto chain{inode_4::create(*this, full_key, tree_depth_type{0},
+                               static_cast<detail::key_prefix_size>(pos - 1),
+                               dispatch, current)};
+    current = detail::olc_node_ptr{chain.release(), node_type::I4};
+#ifdef UNODB_DETAIL_WITH_STATS
+    account_growing_inode<node_type::I4>();
+#endif
+  }
+  return current;
+}
+
+template <typename Key, typename Value>
 typename olc_db<Key, Value>::try_update_result_type
 olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
                                olc_db_leaf_unique_ptr_type& cached_leaf) {
@@ -1899,7 +1938,12 @@ olc_db<Key, Value>::try_insert(art_key_type k, value_type v,
       return {};  // LCOV_EXCL_LINE
     }
 
-    root = detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF};
+    if constexpr (std::is_same_v<Key, key_view>) {
+      root = build_chain(
+          k, detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF});
+    } else {
+      root = detail::olc_node_ptr{cached_leaf.release(), node_type::LEAF};
+    }
     return true;
   }
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -515,6 +515,7 @@ class olc_db final {
     /// post-condition: The iterator is !valid().
     iterator& invalidate() noexcept {
       while (!stack_.empty()) stack_.pop();  // clear the stack
+      keybuf_.reset();                       // clear the key buffer
       return *this;
     }
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -167,9 +167,6 @@ class olc_db final {
   using leaf_type = detail::olc_leaf_type<Key, Value>;
   using db_type = olc_db<Key, Value>;
 
-  // TODO(laurynas): added temporarily during development
-  static_assert(std::is_same_v<value_type, unodb::value_view>);
-
  private:
   using art_key_type = detail::basic_art_key<Key>;
 

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -376,7 +376,9 @@ class olc_db final {
     /// the iterator.
     ///
     /// \pre The iterator MUST be valid().
-    [[nodiscard, gnu::pure]] qsbr_value_view get_val() const noexcept;
+    [[nodiscard, gnu::pure]] auto get_val() const noexcept
+        -> std::conditional_t<std::is_same_v<Value, unodb::value_view>,
+                              qsbr_value_view, value_type>;
 
     /// Debugging
     // LCOV_EXCL_START
@@ -926,7 +928,7 @@ class olc_db final {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   friend auto detail::make_db_leaf_ptr<Key, Value, olc_db>(art_key_type,
-                                                           unodb::value_view,
+                                                           value_type,
                                                            olc_db&);
 
   template <class>
@@ -1091,7 +1093,7 @@ struct olc_impl_helpers {
   template <typename Key, typename Value, class INode>
   [[nodiscard]] static std::optional<in_critical_section<olc_node_ptr>*>
   add_or_choose_subtree(
-      INode& inode, std::byte key_byte, basic_art_key<Key> k, value_view v,
+      INode& inode, std::byte key_byte, basic_art_key<Key> k, Value v,
       olc_db<Key, Value>& db_instance, tree_depth<basic_art_key<Key>> depth,
       optimistic_lock::read_critical_section& node_critical_section,
       in_critical_section<olc_node_ptr>* node_in_parent,
@@ -1476,7 +1478,7 @@ void olc_inode_48<Key, Value>::init(
 
 template <typename Key, typename Value>
 void create_leaf_if_needed(olc_db_leaf_unique_ptr<Key, Value>& cached_leaf,
-                           basic_art_key<Key> k, unodb::value_view v,
+                           basic_art_key<Key> k, Value v,
                            unodb::olc_db<Key, Value>& db_instance) {
   if (UNODB_DETAIL_LIKELY(cached_leaf == nullptr)) {
     UNODB_DETAIL_ASSERT(&cached_leaf.get_deleter().get_db() == &db_instance);
@@ -1492,7 +1494,7 @@ UNODB_DETAIL_DISABLE_MSVC_WARNING(26460)
 template <typename Key, typename Value, class INode>
 [[nodiscard]] std::optional<in_critical_section<olc_node_ptr>*>
 olc_impl_helpers::add_or_choose_subtree(
-    INode& inode, std::byte key_byte, basic_art_key<Key> k, value_view v,
+    INode& inode, std::byte key_byte, basic_art_key<Key> k, Value v,
     olc_db<Key, Value>& db_instance, tree_depth<basic_art_key<Key>> depth,
     optimistic_lock::read_critical_section& node_critical_section,
     in_critical_section<olc_node_ptr>* node_in_parent,
@@ -1805,10 +1807,10 @@ typename olc_db<Key, Value>::try_get_result_type olc_db<Key, Value>::try_get(
     if (node_type == node_type::LEAF) {
       const auto* const leaf{node.ptr<leaf_type*>()};
       if (leaf->matches(k)) {
-        const auto val_view{leaf->get_value_view()};
+        const auto val{leaf->template get_value<Value>()};
         if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
           return {};  // LCOV_EXCL_LINE
-        return qsbr_ptr_span<const std::byte>{val_view};
+        return std::make_optional<get_result>(val);
       }
       if (UNODB_DETAIL_UNLIKELY(!node_critical_section.try_read_unlock()))
         return {};  // LCOV_EXCL_LINE
@@ -2971,7 +2973,9 @@ key_view olc_db<Key, Value>::iterator::get_key() noexcept {
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
 template <typename Key, typename Value>
-qsbr_value_view olc_db<Key, Value>::iterator::get_val() const noexcept {
+auto olc_db<Key, Value>::iterator::get_val() const noexcept
+    -> std::conditional_t<std::is_same_v<Value, unodb::value_view>,
+                          qsbr_value_view, value_type> {
   // Note: If the iterator is on a leaf, we return the value for
   // that leaf regardless of whether the leaf has been deleted.
   // This is part of the design semantics for the OLC ART scan.
@@ -2980,7 +2984,10 @@ qsbr_value_view olc_db<Key, Value>::iterator::get_val() const noexcept {
   const auto& node = e.node;
   UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);      // On a leaf.
   const auto* const leaf{node.template ptr<leaf_type*>()};  // current leaf.
-  return qsbr_ptr_span{leaf->get_value_view()};
+  if constexpr (std::is_same_v<Value, unodb::value_view>)
+    return qsbr_ptr_span{leaf->get_value_view()};
+  else
+    return leaf->template get_value<Value>();
 }
 
 template <typename Key, typename Value>

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -82,10 +82,9 @@ template <typename To, typename From>
 /// Forces the compiler to re-read the object through a volatile pointer.
 /// FIXME(@laurynas-biveinis): remove when #700 is fixed.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define UNODB_DETAIL_RELOAD(obj)       \
-  (*const_cast<                        \
-      std::remove_cvref_t<decltype(obj)>*>( \
-      static_cast<volatile const      \
-          std::remove_cvref_t<decltype(obj)>*>(&(obj))))
+#define UNODB_DETAIL_RELOAD(obj)                                       \
+  (*const_cast<std::remove_cvref_t<decltype(obj)>*>(                   \
+      static_cast<volatile const std::remove_cvref_t<decltype(obj)>*>( \
+          &(obj))))
 
 #endif

--- a/portability_builtins.hpp
+++ b/portability_builtins.hpp
@@ -78,4 +78,14 @@ template <typename To, typename From>
 
 }  // namespace unodb::detail
 
+/// Workaround for #700: union type-pun causes stale reads under clang -O3.
+/// Forces the compiler to re-read the object through a volatile pointer.
+/// FIXME(@laurynas-biveinis): remove when #700 is fixed.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define UNODB_DETAIL_RELOAD(obj)       \
+  (*const_cast<                        \
+      std::remove_cvref_t<decltype(obj)>*>( \
+      static_cast<volatile const      \
+          std::remove_cvref_t<decltype(obj)>*>(&(obj))))
+
 #endif

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -188,8 +188,8 @@ void add_to_orphan_list(
 /// \param orphan_list Global orphaned request list
 /// \return Taken orphaned request list
 [[nodiscard]] detail::dealloc_vector_list_node* take_orphan_list(
-    std::atomic<detail::dealloc_vector_list_node*>& orphan_list
-    UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+    std::atomic<detail::dealloc_vector_list_node*>&
+        orphan_list UNODB_DETAIL_LIFETIMEBOUND) noexcept {
   return orphan_list.exchange(nullptr, std::memory_order_acq_rel);
 }
 

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -163,9 +163,8 @@ class [[nodiscard]] qsbr_epoch final {
 // LCOV_EXCL_START
 /// Print the epoch \a value to the output stream \a os. For debug purposes
 /// only.
-[[gnu::cold]] inline std::ostream& operator<<(std::ostream& os
-                                              UNODB_DETAIL_LIFETIMEBOUND,
-                                              qsbr_epoch value) {
+[[gnu::cold]] inline std::ostream& operator<<(
+    std::ostream& os UNODB_DETAIL_LIFETIMEBOUND, qsbr_epoch value) {
   value.dump(os);
   return os;
 }
@@ -403,8 +402,8 @@ struct qsbr_state {
   atomic_fetch_dec_threads_in_previous_epoch(std::atomic<type>& word) noexcept;
 
   /// Assert that all invariants hold for \a word.
-  static constexpr void assert_invariants(type word
-                                          UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+  static constexpr void assert_invariants(
+      type word UNODB_DETAIL_USED_IN_DEBUG) noexcept {
 #ifndef NDEBUG
     const auto thread_count = do_get_thread_count(word);
     UNODB_DETAIL_ASSERT(thread_count <= max_qsbr_threads);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,7 @@ add_db_test_target(test_art)
 target_compile_options(test_art PRIVATE "$<${is_msvc}:/bigobj>")
 
 add_db_test_target(test_art_key_view)
+add_db_test_target(test_art_key_view_full_chain)
 add_db_test_target(test_art_iter)
 add_db_test_target(test_art_scan)
 add_db_test_target(test_art_concurrency)

--- a/test/db_test_utils.cpp
+++ b/test/db_test_utils.cpp
@@ -28,6 +28,10 @@ template class unodb::db<unodb::key_view, unodb::value_view>;
 template class unodb::mutex_db<unodb::key_view, unodb::value_view>;
 template class unodb::olc_db<unodb::key_view, unodb::value_view>;
 
+template class unodb::db<unodb::key_view, std::uint64_t>;
+template class unodb::mutex_db<unodb::key_view, std::uint64_t>;
+template class unodb::olc_db<unodb::key_view, std::uint64_t>;
+
 }  // namespace unodb
 
 namespace unodb::test {
@@ -43,6 +47,10 @@ template class tree_verifier<u64_olc_db>;
 template class tree_verifier<key_view_db>;
 template class tree_verifier<key_view_mutex_db>;
 template class tree_verifier<key_view_olc_db>;
+
+template class tree_verifier<key_view_u64val_db>;
+template class tree_verifier<key_view_u64val_mutex_db>;
+template class tree_verifier<key_view_u64val_olc_db>;
 
 }  // namespace unodb::test
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -636,22 +636,21 @@ class [[nodiscard]] tree_verifier final {
     UNODB_DETAIL_PAUSE_HEAP_TRACKING_GUARD();
     std::size_t n{0};
     bool first = true;
-    unodb::key_view prev{};
+    std::vector<std::byte> prev_copy{};
     auto fn =
         [&n, &first,
-         &prev](const unodb::visitor<typename Db::iterator>& visitor) noexcept {
-          // We can't tell cheap and expensive to copy types apart in an
-          // useful way here
+         &prev_copy](const unodb::visitor<typename Db::iterator>& visitor) {
           UNODB_DETAIL_DISABLE_MSVC_WARNING(26445)
-          const auto& kv = visitor.get_key();
+          const auto kv = static_cast<unodb::key_view>(visitor.get_key());
           UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
           if (UNODB_DETAIL_UNLIKELY(first)) {
-            prev = kv;
+            prev_copy.assign(kv.begin(), kv.end());
             first = false;
           } else {
+            const unodb::key_view prev{prev_copy};
             UNODB_EXPECT_LT(unodb::detail::compare(prev, kv), 0);
-            prev = kv;
+            prev_copy.assign(kv.begin(), kv.end());
           }
           n++;
           return false;

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -47,6 +47,10 @@ extern template class unodb::db<unodb::key_view, unodb::value_view>;
 extern template class unodb::mutex_db<unodb::key_view, unodb::value_view>;
 extern template class unodb::olc_db<unodb::key_view, unodb::value_view>;
 
+extern template class unodb::db<unodb::key_view, std::uint64_t>;
+extern template class unodb::mutex_db<unodb::key_view, std::uint64_t>;
+extern template class unodb::olc_db<unodb::key_view, std::uint64_t>;
+
 namespace unodb::test {
 
 template <class TestDb>
@@ -84,6 +88,18 @@ constexpr std::array<unodb::value_view, 6> test_values = {
     unodb::value_view{empty_test_value}  // [5] {                 }
 };
 
+constexpr std::array<std::uint64_t, 6> test_values_u64 = {
+    0, 1, 2, 3, 4, 5};
+
+/// Return a test value appropriate for the db's value type.
+template <class Db>
+constexpr typename Db::value_type get_test_value(std::size_t i) {
+  if constexpr (std::is_same_v<typename Db::value_type, unodb::value_view>)
+    return test_values[i % test_values.size()];
+  else
+    return test_values_u64[i % test_values_u64.size()];
+}
+
 namespace detail {
 
 UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wused-but-marked-unused")
@@ -91,14 +107,20 @@ UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wunused-parameter")
 
 template <class Db>
 void assert_value_eq(const typename Db::get_result& result,
-                     unodb::value_view expected) noexcept {
+                     typename Db::value_type expected) noexcept {
   if constexpr (is_mutex_db<Db>) {
     UNODB_DETAIL_ASSERT(result.second.owns_lock());
     UNODB_DETAIL_ASSERT(result.first.has_value());
-    UNODB_ASSERT_TRUE(std::ranges::equal(*result.first, expected));
+    if constexpr (std::is_same_v<typename Db::value_type, unodb::value_view>)
+      UNODB_ASSERT_TRUE(std::ranges::equal(*result.first, expected));
+    else
+      UNODB_ASSERT_EQ(*result.first, expected);
   } else {
     UNODB_DETAIL_ASSERT(result.has_value());
-    UNODB_ASSERT_TRUE(std::ranges::equal(*result, expected));
+    if constexpr (std::is_same_v<typename Db::value_type, unodb::value_view>)
+      UNODB_ASSERT_TRUE(std::ranges::equal(*result, expected));
+    else
+      UNODB_ASSERT_EQ(*result, expected);
   }
 }
 
@@ -114,7 +136,7 @@ void assert_not_found(const typename Db::get_result& result) noexcept {
 
 template <class Db>
 void do_assert_result_eq(const Db& db, typename Db::key_type key,
-                         unodb::value_view expected, const char* file,
+                         typename Db::value_type expected, const char* file,
                          int line) {
   std::ostringstream msg;
   unodb::detail::dump_key(msg, key);
@@ -136,7 +158,7 @@ UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 template <class Db>
 void assert_result_eq(const Db& db, typename Db::key_type key,
-                      unodb::value_view expected, const char* file, int line) {
+                      typename Db::value_type expected, const char* file, int line) {
   if constexpr (is_olc_db<Db>) {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     do_assert_result_eq<Db>(db, key, expected, file, line);
@@ -271,13 +293,13 @@ class [[nodiscard]] tree_verifier final {
   // NOLINTBEGIN(modernize-use-constraints)
   template <class Db2 = Db>
   std::enable_if_t<!is_olc_db<Db2>, void> do_insert(key_type k,
-                                                    unodb::value_view v) {
+                                                    value_type v) {
     UNODB_ASSERT_TRUE(test_db.insert(k, v));
   }
 
   template <class Db2 = Db>
   std::enable_if_t<is_olc_db<Db2>, void> do_insert(key_type k,
-                                                   unodb::value_view v) {
+                                                   value_type v) {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     UNODB_ASSERT_TRUE(test_db.insert(k, v));
   }
@@ -362,7 +384,7 @@ class [[nodiscard]] tree_verifier final {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   // cppcheck-suppress passedByValue
-  void insert_internal(key_type k, unodb::value_view v,
+  void insert_internal(key_type k, value_type v,
                        bool bypass_verifier = false) {
     const auto empty_before = test_db.empty();
 #ifdef UNODB_DETAIL_WITH_STATS
@@ -434,11 +456,11 @@ class [[nodiscard]] tree_verifier final {
       unodb::key_encoder enc;
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
         insert(enc.reset().encode(key).get_key_view(),
-               test_values[key % test_values.size()], bypass_verifier);
+               get_test_value<Db>(key), bypass_verifier);
       }
     } else {
       for (auto key = start_key; key < start_key + count; ++key) {
-        insert(key, test_values[key % test_values.size()], bypass_verifier);
+        insert(key, get_test_value<Db>(key), bypass_verifier);
       }
     }
   }
@@ -457,7 +479,7 @@ class [[nodiscard]] tree_verifier final {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   template <typename T>
-  void insert(T k, unodb::value_view v, bool bypass_verifier = false) {
+  void insert(T k, value_type v, bool bypass_verifier = false) {
     insert_internal(coerce_key(k), v, bypass_verifier);
   }
 
@@ -468,7 +490,7 @@ class [[nodiscard]] tree_verifier final {
   }
 
   template <typename T>
-  bool try_insert(T k, unodb::value_view v) {
+  bool try_insert(T k, value_type v) {
     return test_db.insert(coerce_key(k), v);
   }
 
@@ -483,14 +505,14 @@ class [[nodiscard]] tree_verifier final {
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
         auto tmp = to_ikey(enc.reset().encode(key).get_key_view());
         const auto [pos, insert_succeeded] =
-            values.try_emplace(tmp, test_values[key % test_values.size()]);
+            values.try_emplace(tmp, get_test_value<Db>(key));
         (void)pos;
         UNODB_ASSERT_TRUE(insert_succeeded);
       }
     } else {
       for (auto key = start_key; key < start_key + count; ++key) {
         const auto [pos, insert_succeeded] = values.try_emplace(
-            to_ikey(key), test_values[key % test_values.size()]);
+            to_ikey(key), get_test_value<Db>(key));
         (void)pos;
         UNODB_ASSERT_TRUE(insert_succeeded);
       }
@@ -507,11 +529,11 @@ class [[nodiscard]] tree_verifier final {
       unodb::key_encoder enc;
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
         do_insert(enc.reset().encode(key).get_key_view(),
-                  test_values[key % test_values.size()]);
+                  get_test_value<Db>(key));
       }
     } else {
       for (auto key = start_key; key < start_key + count; ++key) {
-        do_insert(key, test_values[key % test_values.size()]);
+        do_insert(key, get_test_value<Db>(key));
       }
     }
   }
@@ -772,7 +794,7 @@ class [[nodiscard]] tree_verifier final {
   /// \note The `std::map` and `std::unordered_map` do not support non-owned
   /// unodb::key_view objects as keys.  To handle this, unodb::key_view keys are
   /// wrapped as an owning type.
-  std::map<ikey_type<Db>, unodb::value_view, comparator> values;
+  std::map<ikey_type<Db>, value_type, comparator> values;
 
   const bool parallel_test;
 
@@ -788,6 +810,10 @@ using key_view_db = unodb::db<unodb::key_view, unodb::value_view>;
 using key_view_mutex_db = unodb::mutex_db<unodb::key_view, unodb::value_view>;
 using key_view_olc_db = unodb::olc_db<unodb::key_view, unodb::value_view>;
 
+using key_view_u64val_db = unodb::db<unodb::key_view, std::uint64_t>;
+using key_view_u64val_mutex_db = unodb::mutex_db<unodb::key_view, std::uint64_t>;
+using key_view_u64val_olc_db = unodb::olc_db<unodb::key_view, std::uint64_t>;
+
 extern template class tree_verifier<u64_db>;
 extern template class tree_verifier<u64_mutex_db>;
 extern template class tree_verifier<u64_olc_db>;
@@ -795,6 +821,10 @@ extern template class tree_verifier<u64_olc_db>;
 extern template class tree_verifier<key_view_db>;
 extern template class tree_verifier<key_view_mutex_db>;
 extern template class tree_verifier<key_view_olc_db>;
+
+extern template class tree_verifier<key_view_u64val_db>;
+extern template class tree_verifier<key_view_u64val_mutex_db>;
+extern template class tree_verifier<key_view_u64val_olc_db>;
 
 }  // namespace unodb::test
 

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -88,8 +88,7 @@ constexpr std::array<unodb::value_view, 6> test_values = {
     unodb::value_view{empty_test_value}  // [5] {                 }
 };
 
-constexpr std::array<std::uint64_t, 6> test_values_u64 = {
-    0, 1, 2, 3, 4, 5};
+constexpr std::array<std::uint64_t, 6> test_values_u64 = {0, 1, 2, 3, 4, 5};
 
 /// Return a test value appropriate for the db's value type.
 template <class Db>
@@ -158,7 +157,8 @@ UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 template <class Db>
 void assert_result_eq(const Db& db, typename Db::key_type key,
-                      typename Db::value_type expected, const char* file, int line) {
+                      typename Db::value_type expected, const char* file,
+                      int line) {
   if constexpr (is_olc_db<Db>) {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     do_assert_result_eq<Db>(db, key, expected, file, line);
@@ -292,14 +292,12 @@ class [[nodiscard]] tree_verifier final {
   // mangled names.
   // NOLINTBEGIN(modernize-use-constraints)
   template <class Db2 = Db>
-  std::enable_if_t<!is_olc_db<Db2>, void> do_insert(key_type k,
-                                                    value_type v) {
+  std::enable_if_t<!is_olc_db<Db2>, void> do_insert(key_type k, value_type v) {
     UNODB_ASSERT_TRUE(test_db.insert(k, v));
   }
 
   template <class Db2 = Db>
-  std::enable_if_t<is_olc_db<Db2>, void> do_insert(key_type k,
-                                                   value_type v) {
+  std::enable_if_t<is_olc_db<Db2>, void> do_insert(key_type k, value_type v) {
     const quiescent_state_on_scope_exit qsbr_after_get{};
     UNODB_ASSERT_TRUE(test_db.insert(k, v));
   }
@@ -384,8 +382,7 @@ class [[nodiscard]] tree_verifier final {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   // cppcheck-suppress passedByValue
-  void insert_internal(key_type k, value_type v,
-                       bool bypass_verifier = false) {
+  void insert_internal(key_type k, value_type v, bool bypass_verifier = false) {
     const auto empty_before = test_db.empty();
 #ifdef UNODB_DETAIL_WITH_STATS
     const auto mem_use_before =
@@ -455,8 +452,8 @@ class [[nodiscard]] tree_verifier final {
       dec.decode(start_key_dec);
       unodb::key_encoder enc;
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
-        insert(enc.reset().encode(key).get_key_view(),
-               get_test_value<Db>(key), bypass_verifier);
+        insert(enc.reset().encode(key).get_key_view(), get_test_value<Db>(key),
+               bypass_verifier);
       }
     } else {
       for (auto key = start_key; key < start_key + count; ++key) {
@@ -511,8 +508,8 @@ class [[nodiscard]] tree_verifier final {
       }
     } else {
       for (auto key = start_key; key < start_key + count; ++key) {
-        const auto [pos, insert_succeeded] = values.try_emplace(
-            to_ikey(key), get_test_value<Db>(key));
+        const auto [pos, insert_succeeded] =
+            values.try_emplace(to_ikey(key), get_test_value<Db>(key));
         (void)pos;
         UNODB_ASSERT_TRUE(insert_succeeded);
       }
@@ -637,24 +634,23 @@ class [[nodiscard]] tree_verifier final {
     std::size_t n{0};
     bool first = true;
     std::vector<std::byte> prev_copy{};
-    auto fn =
-        [&n, &first,
-         &prev_copy](const unodb::visitor<typename Db::iterator>& visitor) {
-          UNODB_DETAIL_DISABLE_MSVC_WARNING(26445)
-          const auto kv = static_cast<unodb::key_view>(visitor.get_key());
-          UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+    auto fn = [&n, &first, &prev_copy](
+                  const unodb::visitor<typename Db::iterator>& visitor) {
+      UNODB_DETAIL_DISABLE_MSVC_WARNING(26445)
+      const auto kv = static_cast<unodb::key_view>(visitor.get_key());
+      UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-          if (UNODB_DETAIL_UNLIKELY(first)) {
-            prev_copy.assign(kv.begin(), kv.end());
-            first = false;
-          } else {
-            const unodb::key_view prev{prev_copy};
-            UNODB_EXPECT_LT(unodb::detail::compare(prev, kv), 0);
-            prev_copy.assign(kv.begin(), kv.end());
-          }
-          n++;
-          return false;
-        };
+      if (UNODB_DETAIL_UNLIKELY(first)) {
+        prev_copy.assign(kv.begin(), kv.end());
+        first = false;
+      } else {
+        const unodb::key_view prev{prev_copy};
+        UNODB_EXPECT_LT(unodb::detail::compare(prev, kv), 0);
+        prev_copy.assign(kv.begin(), kv.end());
+      }
+      n++;
+      return false;
+    };
     const_cast<Db&>(test_db).scan(fn);
     // FIXME(thompsonbry) variable length keys - enable this assert.
     // 3 OOM tests are failing (for each Db type) when this is enabled
@@ -810,7 +806,8 @@ using key_view_mutex_db = unodb::mutex_db<unodb::key_view, unodb::value_view>;
 using key_view_olc_db = unodb::olc_db<unodb::key_view, unodb::value_view>;
 
 using key_view_u64val_db = unodb::db<unodb::key_view, std::uint64_t>;
-using key_view_u64val_mutex_db = unodb::mutex_db<unodb::key_view, std::uint64_t>;
+using key_view_u64val_mutex_db =
+    unodb::mutex_db<unodb::key_view, std::uint64_t>;
 using key_view_u64val_olc_db = unodb::olc_db<unodb::key_view, std::uint64_t>;
 
 extern template class tree_verifier<u64_db>;

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -428,8 +428,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeAttemptDeleteAbsent) {
 
   verifier.insert(2, unodb::test::test_values[1]);
 
-  unodb::test::must_not_allocate(
-      [&verifier] { verifier.attempt_remove_missing_keys({1, 3, 0xFF02}); });
+  unodb::test::must_not_allocate([&verifier] {
+    verifier.attempt_remove_missing_keys({1, 3, 0xFF02});
+  });
 
   verifier.check_present_values();
   verifier.check_absent_keys({1, 3, 0xFF02});
@@ -891,8 +892,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, MissingKeyMatchingInodePath) {
   verifier.insert(0x0100, unodb::test::test_values[0]);
   verifier.insert(0x0200, unodb::test::test_values[1]);
 
-  unodb::test::must_not_allocate(
-      [&verifier] { verifier.attempt_remove_missing_keys({0x0101, 0x0202}); });
+  unodb::test::must_not_allocate([&verifier] {
+    verifier.attempt_remove_missing_keys({0x0101, 0x0202});
+  });
 }
 
 #ifdef UNODB_DETAIL_WITH_STATS

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -48,8 +48,11 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeEmptyValue) {
   verifier.check_absent_keys({0});
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-  verifier.assert_growing_inodes({0, 0, 0, 0});
+  constexpr std::uint64_t C =
+      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
+      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+  verifier.assert_node_counts({1, C, 0, 0, 0});
+  verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -61,8 +64,11 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeNonemptyValue) {
   verifier.check_absent_keys({0, 2});
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-  verifier.assert_growing_inodes({0, 0, 0, 0});
+  constexpr std::uint64_t C =
+      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
+      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+  verifier.assert_node_counts({1, C, 0, 0, 0});
+  verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -92,8 +98,11 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
   verifier.insert(0, unodb::test::test_values[1]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-  verifier.assert_growing_inodes({0, 0, 0, 0});
+  constexpr std::uint64_t C =
+      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
+      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+  verifier.assert_node_counts({1, C, 0, 0, 0});
+  verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 
   verifier.insert(1, unodb::test::test_values[2]);
@@ -113,7 +122,10 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
   verifier.insert(0, unodb::test::test_values[0]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  constexpr std::uint64_t C =
+      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
+      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+  verifier.assert_node_counts({1, C, 0, 0, 0});
 
   const auto mem_use_before = verifier.get_db().get_current_memory_use();
 #endif  // UNODB_DETAIL_WITH_STATS
@@ -127,8 +139,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
 #ifdef UNODB_DETAIL_WITH_STATS
   UNODB_ASSERT_EQ(mem_use_before, verifier.get_db().get_current_memory_use());
 
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-  verifier.assert_growing_inodes({0, 0, 0, 0});
+  verifier.assert_node_counts({1, C, 0, 0, 0});
+  verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -435,7 +447,10 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeAttemptDeleteAbsent) {
   verifier.check_absent_keys({1, 3, 0xFF02});
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  constexpr std::uint64_t C =
+      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
+      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+  verifier.assert_node_counts({1, C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -937,7 +952,10 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node48InsertIntoDeletedSlot) {
   verifier.check_present_values();
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({18, 0, 0, 1, 0});
+  constexpr std::uint64_t C =
+      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
+      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+  verifier.assert_node_counts({18, C, 0, 1, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -48,10 +48,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeEmptyValue) {
   verifier.check_absent_keys({0});
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t C =
-      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
-  verifier.assert_node_counts({1, C, 0, 0, 0});
-  verifier.assert_growing_inodes({C, 0, 0, 0});
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -63,10 +61,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeNonemptyValue) {
   verifier.check_absent_keys({0, 2});
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t C =
-      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
-  verifier.assert_node_counts({1, C, 0, 0, 0});
-  verifier.assert_growing_inodes({C, 0, 0, 0});
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -96,10 +92,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
   verifier.insert(0, unodb::test::test_values[1]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t C =
-      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
-  verifier.assert_node_counts({1, C, 0, 0, 0});
-  verifier.assert_growing_inodes({C, 0, 0, 0});
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 
   verifier.insert(1, unodb::test::test_values[2]);
@@ -119,9 +113,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
   verifier.insert(0, unodb::test::test_values[0]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t C =
-      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
-  verifier.assert_node_counts({1, C, 0, 0, 0});
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
 
   const auto mem_use_before = verifier.get_db().get_current_memory_use();
 #endif  // UNODB_DETAIL_WITH_STATS
@@ -135,8 +127,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
 #ifdef UNODB_DETAIL_WITH_STATS
   UNODB_ASSERT_EQ(mem_use_before, verifier.get_db().get_current_memory_use());
 
-  verifier.assert_node_counts({1, C, 0, 0, 0});
-  verifier.assert_growing_inodes({C, 0, 0, 0});
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -443,9 +435,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeAttemptDeleteAbsent) {
   verifier.check_absent_keys({1, 3, 0xFF02});
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t C =
-      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
-  verifier.assert_node_counts({1, C, 0, 0, 0});
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -947,9 +937,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node48InsertIntoDeletedSlot) {
   verifier.check_present_values();
 
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t C =
-      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
-  verifier.assert_node_counts({18, C, 0, 1, 0});
+  verifier.assert_node_counts({18, 0, 0, 1, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -49,8 +49,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeEmptyValue) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr std::uint64_t C =
-      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
-      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
   verifier.assert_node_counts({1, C, 0, 0, 0});
   verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
@@ -65,8 +64,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeNonemptyValue) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr std::uint64_t C =
-      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
-      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
   verifier.assert_node_counts({1, C, 0, 0, 0});
   verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
@@ -99,8 +97,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr std::uint64_t C =
-      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
-      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
   verifier.assert_node_counts({1, C, 0, 0, 0});
   verifier.assert_growing_inodes({C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
@@ -123,8 +120,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr std::uint64_t C =
-      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
-      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
   verifier.assert_node_counts({1, C, 0, 0, 0});
 
   const auto mem_use_before = verifier.get_db().get_current_memory_use();
@@ -448,8 +444,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeAttemptDeleteAbsent) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr std::uint64_t C =
-      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
-      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
   verifier.assert_node_counts({1, C, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
@@ -953,8 +948,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node48InsertIntoDeletedSlot) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr std::uint64_t C =
-      (std::is_same_v<typename TypeParam::key_type, unodb::key_view> &&
-      !unodb::test::is_olc_db<TypeParam>) ? 1 : 0;
+      std::is_same_v<typename TypeParam::key_type, unodb::key_view> ? 1 : 0;
   verifier.assert_node_counts({18, C, 0, 1, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -1133,4 +1133,197 @@ UNODB_TEST(OLCChainCut, DISABLED_DeepChainStressHeavy) {
   deep_chain_stress(cores, 100000, 10);
 }
 
+// ===================================================================
+// RT tests: verify remove_or_choose_subtree OLC guards under
+// concurrent modification.  These validate that the version checks
+// inside remove_or_choose_subtree correctly detect concurrent
+// mutations — the precondition for making matches() unconditional
+// for keyless key_view leaves.
+//
+// Sync point: sync_before_remove_write_guard fires after leaf match
+// confirmed and is_min_size read, before write guard acquisition.
+// ===================================================================
+
+#ifndef NDEBUG
+
+// RT1: T1 removes key_a.  T2 inserts a new key into the same inode
+// between T1's match check and write guard acquisition.  T1's write
+// guard upgrade should detect the version change and restart.
+UNODB_TEST(OLCRemoveChooseSubtree, ConcurrentInsertIntoSameInode) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  // 9-byte keys with same tag → same chain → same bottom inode.
+  // Insert 3 keys so the bottom inode is I4(3), above min_size.
+  std::array<std::byte, 9> buf_a{};
+  std::array<std::byte, 9> buf_b{};
+  std::array<std::byte, 9> buf_c{};
+  std::array<std::byte, 9> buf_new{};
+  const auto key_a = make_chain_key(enc, 0x10, 1, buf_a);
+  const auto key_b = make_chain_key(enc, 0x10, 2, buf_b);
+  const auto key_c = make_chain_key(enc, 0x10, 3, buf_c);
+  const auto new_key = make_chain_key(enc, 0x10, 4, buf_new);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val));
+  UNODB_ASSERT_TRUE(db.insert(key_c, val));
+
+  const sync_point_guard guard{unodb::detail::sync_before_remove_write_guard};
+  unodb::detail::sync_before_remove_write_guard.arm([&]() {
+    unodb::detail::sync_before_remove_write_guard.disarm();
+    unodb::detail::thread_syncs[0].notify();
+    unodb::detail::thread_syncs[1].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[0].wait();
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.insert(new_key, val);
+    unodb::detail::thread_syncs[1].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  const unodb::quiescent_state_on_scope_exit q{};
+  UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+  UNODB_ASSERT_TRUE(db.get(key_b).has_value());
+  UNODB_ASSERT_TRUE(db.get(key_c).has_value());
+  UNODB_ASSERT_TRUE(db.get(new_key).has_value());
+}
+
+// RT2: T1 removes key_a from an I4 at min_size (2 children).
+// T2 removes key_b (the other child) concurrently.  One thread
+// succeeds, the other restarts and finds the key gone.
+UNODB_TEST(OLCRemoveChooseSubtree, ConcurrentRemoveFromMinSizeI4) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes = std::array<std::byte, 1>{std::byte{0x42}};
+  const auto val = unodb::value_view{val_bytes};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  // 9-byte keys: 2 keys with same tag → chain + I4(2) at bottom.
+  // Plus a sibling with different tag so the chain has a parent.
+  std::array<std::byte, 9> buf_a{};
+  std::array<std::byte, 9> buf_b{};
+  std::array<std::byte, 9> buf_sib{};
+  const auto key_a = make_chain_key(enc, 0x10, 1, buf_a);
+  const auto key_b = make_chain_key(enc, 0x10, 2, buf_b);
+  const auto sibling = make_chain_key(enc, 0x20, 1, buf_sib);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val));
+  UNODB_ASSERT_TRUE(db.insert(sibling, val));
+
+  const sync_point_guard guard{unodb::detail::sync_before_remove_write_guard};
+  unodb::detail::sync_before_remove_write_guard.arm([&]() {
+    unodb::detail::sync_before_remove_write_guard.disarm();
+    unodb::detail::thread_syncs[0].notify();
+    unodb::detail::thread_syncs[1].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[0].wait();
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_b);
+    unodb::detail::thread_syncs[1].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  const unodb::quiescent_state_on_scope_exit q{};
+  UNODB_ASSERT_FALSE(db.get(key_a).has_value());
+  UNODB_ASSERT_FALSE(db.get(key_b).has_value());
+  UNODB_ASSERT_TRUE(db.get(sibling).has_value());
+}
+
+// RT3: T1 removes key_a.  T2 replaces key_a's leaf by removing and
+// re-inserting it with a different value.  T1's child version check
+// should detect the change.
+UNODB_TEST(OLCRemoveChooseSubtree, ConcurrentLeafReplacement) {
+  using db_type = unodb::olc_db<unodb::key_view, unodb::value_view>;
+  constexpr auto val_bytes1 = std::array<std::byte, 1>{std::byte{0x42}};
+  constexpr auto val_bytes2 = std::array<std::byte, 1>{std::byte{0x99}};
+  const auto val1 = unodb::value_view{val_bytes1};
+  const auto val2 = unodb::value_view{val_bytes2};
+
+  db_type db;
+  unodb::key_encoder enc;
+
+  std::array<std::byte, 9> buf_a{};
+  std::array<std::byte, 9> buf_b{};
+  std::array<std::byte, 9> buf_c{};
+  const auto key_a = make_chain_key(enc, 0x10, 1, buf_a);
+  const auto key_b = make_chain_key(enc, 0x10, 2, buf_b);
+  const auto key_c = make_chain_key(enc, 0x10, 3, buf_c);
+
+  UNODB_ASSERT_TRUE(db.insert(key_a, val1));
+  UNODB_ASSERT_TRUE(db.insert(key_b, val1));
+  UNODB_ASSERT_TRUE(db.insert(key_c, val1));
+
+  const sync_point_guard guard{unodb::detail::sync_before_remove_write_guard};
+  unodb::detail::sync_before_remove_write_guard.arm([&]() {
+    unodb::detail::sync_before_remove_write_guard.disarm();
+    unodb::detail::thread_syncs[0].notify();
+    unodb::detail::thread_syncs[1].wait();
+  });
+
+  unodb::this_thread().qsbr_pause();
+
+  auto t2 = unodb::qsbr_thread([&] {
+    unodb::detail::thread_syncs[0].wait();
+    {
+      const unodb::quiescent_state_on_scope_exit q{};
+      std::ignore = db.remove(key_a);
+    }
+    {
+      const unodb::quiescent_state_on_scope_exit q{};
+      std::ignore = db.insert(key_a, val2);
+    }
+    unodb::detail::thread_syncs[1].notify();
+  });
+
+  auto t1 = unodb::qsbr_thread([&] {
+    const unodb::quiescent_state_on_scope_exit q{};
+    std::ignore = db.remove(key_a);
+  });
+
+  t1.join();
+  t2.join();
+  unodb::this_thread().qsbr_resume();
+  unodb::this_thread().quiescent();
+
+  // key_a may or may not exist depending on who won the race.
+  // The important thing is no crash, no hang, no corruption.
+  const unodb::quiescent_state_on_scope_exit q2{};
+  UNODB_ASSERT_TRUE(db.get(key_b).has_value());
+  UNODB_ASSERT_TRUE(db.get(key_c).has_value());
+}
+
+#endif  // NDEBUG
+
 }  // namespace

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -1601,4 +1601,28 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanChainMixedLengths) {
 
 #endif  // UNODB_DETAIL_WITH_STATS
 
+// -------------------------------------------------------------------
+// Zero-length key
+// -------------------------------------------------------------------
+
+/// A zero-length key_view should work as a root leaf (no prefix bytes
+/// to encode in an inode chain).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ZeroLengthKey) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  const auto empty_key = unodb::key_view{};
+  constexpr auto val = unodb::test::test_values[0];
+
+  verifier.insert(empty_key, val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+#endif
+
+  verifier.remove(empty_key);
+  verifier.assert_empty();
+#ifdef UNODB_DETAIL_WITH_STATS
+  verifier.assert_node_counts({0, 0, 0, 0, 0});
+#endif
+}
+
 }  // namespace

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -546,8 +546,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MixedLengthKeysLongPrefix) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  // chain I4 + bottom I4 (2 children) + 2 leaves
-  verifier.assert_node_counts({2, 2, 0, 0, 0});
+  constexpr std::uint64_t I = unodb::test::is_olc_db<TypeParam> ? 2 : 3;
+  verifier.assert_node_counts({2, I, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -727,12 +727,14 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI4) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.insert(make_short_key(enc, 0x01), val);
   // root I4(2: 0x42→chain, 0x01→leaf) + chain I4 + bottom I4 + 3 leaves
-  verifier.assert_node_counts({3, 3, 0, 0, 0});
+  constexpr std::uint64_t I3 = unodb::test::is_olc_db<TypeParam> ? 3 : 2;
+  verifier.assert_node_counts({3, I3, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
   // Root I4 still has 2 children.
-  verifier.assert_node_counts({2, 2, 0, 0, 0});
+  constexpr std::uint64_t I2 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({2, I2, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 2));
   verifier.check_present_values();
@@ -752,8 +754,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI16) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  // root I16(5) + chain I4 + bottom I4 + 6 leaves
-  verifier.assert_node_counts({6, 2, 1, 0, 0});
+  constexpr std::uint64_t IC16 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({6, IC16, 1, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -774,8 +776,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI48) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  // root I48(17) + chain I4 + bottom I4 + 18 leaves
-  verifier.assert_node_counts({18, 2, 0, 1, 0});
+  constexpr std::uint64_t IC48 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({18, IC48, 0, 1, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -795,8 +797,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI256) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  // root I256(49) + chain I4 + bottom I4 + 50 leaves
-  verifier.assert_node_counts({50, 2, 0, 0, 1});
+  constexpr std::uint64_t IC256 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({50, IC256, 0, 0, 1});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -887,8 +889,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI4ToI16) {
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  // root I16(5: 0x42→chain, 0x01..0x04→leaves) + chain-I4 + bottom-I4
-  verifier.assert_node_counts({6, 2, 1, 0, 0});
+  constexpr std::uint64_t IG16 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({6, IG16, 1, 0, 0});
 }
 
 /// Parent I16→I48 growth with a chain child.
@@ -902,8 +904,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI16ToI48) {
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  // root I48(17) + chain-I4 + bottom-I4
-  verifier.assert_node_counts({18, 2, 0, 1, 0});
+  constexpr std::uint64_t IG48 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({18, IG48, 0, 1, 0});
 }
 
 /// Parent I48→I256 growth with a chain child.
@@ -917,8 +919,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI48ToI256) {
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  // root I256(49) + chain-I4 + bottom-I4
-  verifier.assert_node_counts({50, 2, 0, 0, 1});
+  constexpr std::uint64_t IG256 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  verifier.assert_node_counts({50, IG256, 0, 0, 1});
 }
 
 // -------------------------------------------------------------------

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -546,7 +546,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MixedLengthKeysLongPrefix) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t I = unodb::test::is_olc_db<TypeParam> ? 2 : 3;
+  constexpr std::uint64_t I = 3;
   verifier.assert_node_counts({2, I, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
@@ -727,13 +727,13 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI4) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.insert(make_short_key(enc, 0x01), val);
   // root I4(2: 0x42→chain, 0x01→leaf) + chain I4 + bottom I4 + 3 leaves
-  constexpr std::uint64_t I3 = unodb::test::is_olc_db<TypeParam> ? 3 : 2;
+  constexpr std::uint64_t I3 = 2;
   verifier.assert_node_counts({3, I3, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
   // Root I4 still has 2 children.
-  constexpr std::uint64_t I2 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t I2 = 1;
   verifier.assert_node_counts({2, I2, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 2));
@@ -754,7 +754,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI16) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  constexpr std::uint64_t IC16 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t IC16 = 1;
   verifier.assert_node_counts({6, IC16, 1, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
@@ -776,7 +776,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI48) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  constexpr std::uint64_t IC48 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t IC48 = 1;
   verifier.assert_node_counts({18, IC48, 0, 1, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
@@ -797,7 +797,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI256) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  constexpr std::uint64_t IC256 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t IC256 = 1;
   verifier.assert_node_counts({50, IC256, 0, 0, 1});
 
   verifier.remove(make_key(enc, 0x42, 1));
@@ -889,7 +889,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI4ToI16) {
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  constexpr std::uint64_t IG16 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t IG16 = 1;
   verifier.assert_node_counts({6, IG16, 1, 0, 0});
 }
 
@@ -904,7 +904,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI16ToI48) {
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  constexpr std::uint64_t IG48 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t IG48 = 1;
   verifier.assert_node_counts({18, IG48, 0, 1, 0});
 }
 
@@ -919,7 +919,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI48ToI256) {
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  constexpr std::uint64_t IG256 = unodb::test::is_olc_db<TypeParam> ? 2 : 1;
+  constexpr std::uint64_t IG256 = 1;
   verifier.assert_node_counts({50, IG256, 0, 0, 1});
 }
 

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -1625,4 +1625,156 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ZeroLengthKey) {
 #endif
 }
 
+// -------------------------------------------------------------------
+// build_chain correctness tests (no stats assertions).
+//
+// Verify that the first key_view insert creates a correct inode chain
+// for various key lengths.  key_prefix_capacity = 7, so each chain I4
+// consumes up to 7 prefix + 1 dispatch = 8 bytes.
+//
+// Key lengths tested: 1, 7, 8, 9, 15, 16, 17, 18
+// (0-byte key already tested in ZeroLengthKey above)
+// -------------------------------------------------------------------
+
+namespace {
+
+/// Build a raw key of \a len bytes.  All bytes are 0x42 except the
+/// last byte which is \a last.  \a buf must have at least \a len bytes.
+inline unodb::key_view make_raw_key(std::byte* buf, std::size_t len,
+                                    std::byte last = std::byte{0x01}) {
+  std::fill_n(buf, len, std::byte{0x42});
+  if (len > 0) buf[len - 1] = last;
+  return unodb::key_view{buf, len};
+}
+
+}  // namespace
+
+// T1: Single key insert/get/remove for each key length.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainSingleKey) {
+  constexpr auto val = unodb::test::test_values[0];
+  constexpr std::size_t lengths[] = {1, 7, 8, 9, 15, 16, 17, 18};
+  for (auto len : lengths) {
+    unodb::test::tree_verifier<TypeParam> verifier;
+    std::array<std::byte, 32> buf{};
+    const auto k = make_raw_key(buf.data(), len);
+    verifier.insert(k, val);
+    verifier.check_present_values();
+    // Duplicate insert must fail.
+    UNODB_ASSERT_FALSE(verifier.get_db().insert(k, val));
+    verifier.remove(k);
+    verifier.assert_empty();
+  }
+}
+
+// T2: Two keys diverging at the last byte.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainTwoKeysDivergeAtEnd) {
+  constexpr auto val = unodb::test::test_values[0];
+  constexpr std::size_t lengths[] = {1, 8, 9, 16, 17, 18};
+  for (auto len : lengths) {
+    unodb::test::tree_verifier<TypeParam> verifier;
+    std::array<std::byte, 32> buf_a{};
+    std::array<std::byte, 32> buf_b{};
+    const auto ka = make_raw_key(buf_a.data(), len, std::byte{0x01});
+    const auto kb = make_raw_key(buf_b.data(), len, std::byte{0x02});
+    verifier.insert(ka, val);
+    verifier.insert(kb, val);
+    verifier.check_present_values();
+    verifier.remove(ka);
+    verifier.check_present_values();
+    verifier.remove(kb);
+    verifier.assert_empty();
+  }
+}
+
+// T3: Two keys diverging at an intermediate byte (byte 0).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainDivergeAtStart) {
+  constexpr auto val = unodb::test::test_values[0];
+  constexpr std::size_t lengths[] = {9, 17, 18};
+  for (auto len : lengths) {
+    unodb::test::tree_verifier<TypeParam> verifier;
+    std::array<std::byte, 32> buf_a{};
+    std::array<std::byte, 32> buf_b{};
+    const auto ka = make_raw_key(buf_a.data(), len, std::byte{0x01});
+    // Diverge at byte 0.
+    std::fill_n(buf_b.data(), len, std::byte{0x42});
+    buf_b[0] = std::byte{0x10};
+    buf_b[len - 1] = std::byte{0x01};
+    const auto kb = unodb::key_view{buf_b.data(), len};
+    verifier.insert(ka, val);
+    verifier.insert(kb, val);
+    verifier.check_present_values();
+    verifier.remove(ka);
+    verifier.remove(kb);
+    verifier.assert_empty();
+  }
+}
+
+// T4: Scan over chain keys.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainScan) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  constexpr auto val = unodb::test::test_values[0];
+  std::array<std::byte, 9> buf1{}, buf2{}, buf3{};
+  const auto k1 = make_raw_key(buf1.data(), 9, std::byte{0x01});
+  const auto k2 = make_raw_key(buf2.data(), 9, std::byte{0x02});
+  const auto k3 = make_raw_key(buf3.data(), 9, std::byte{0x03});
+  verifier.insert(k1, val);
+  verifier.insert(k2, val);
+  verifier.insert(k3, val);
+
+  // Forward scan — collect keys.
+  std::vector<std::vector<std::byte>> keys;
+  verifier.get_db().scan([&keys](auto visitor) {
+    auto kv = visitor.get_key();
+    keys.emplace_back(kv.begin(), kv.end());
+    return false;  // continue
+  });
+  UNODB_ASSERT_EQ(keys.size(), 3U);
+  // Keys should be in lexicographic order.
+  UNODB_ASSERT_TRUE(keys[0] < keys[1]);
+  UNODB_ASSERT_TRUE(keys[1] < keys[2]);
+}
+
+// T5: Chain + non-chain sibling (different first byte).
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainWithSibling) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  constexpr auto val = unodb::test::test_values[0];
+  // 9-byte chain key.
+  std::array<std::byte, 9> buf_chain{};
+  const auto k_chain = make_raw_key(buf_chain.data(), 9, std::byte{0x01});
+  // 8-byte key with different first byte.
+  std::array<std::byte, 8> buf_short{};
+  std::fill(buf_short.begin(), buf_short.end(), std::byte{0x10});
+  const auto k_short = unodb::key_view{buf_short.data(), 8};
+  verifier.insert(k_chain, val);
+  verifier.insert(k_short, val);
+  verifier.check_present_values();
+  verifier.remove(k_chain);
+  verifier.check_present_values();
+  verifier.remove(k_short);
+  verifier.assert_empty();
+}
+
+// T6: Prefix overflow on I4 collapse after chain removal.
+UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainPrefixOverflow) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  constexpr auto val = unodb::test::test_values[0];
+  unodb::key_encoder enc;
+  // Two 9-byte keys under tag=0x10.
+  verifier.insert(make_key(enc, 0x10, 1), val);
+  verifier.insert(make_key(enc, 0x10, 2), val);
+  // Two 9-byte keys under tag=0x20.
+  verifier.insert(make_key(enc, 0x20, 1), val);
+  verifier.insert(make_key(enc, 0x20, 2), val);
+  verifier.check_present_values();
+  // Remove both tag=0x10 keys.
+  verifier.remove(make_key(enc, 0x10, 1));
+  verifier.remove(make_key(enc, 0x10, 2));
+  // tag=0x20 keys must still be accessible.
+  verifier.check_present_values();
+  // Remove remaining.
+  verifier.remove(make_key(enc, 0x20, 1));
+  verifier.remove(make_key(enc, 0x20, 2));
+  verifier.assert_empty();
+}
+
 }  // namespace

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -546,8 +546,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MixedLengthKeysLongPrefix) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  constexpr std::uint64_t I = 3;
-  verifier.assert_node_counts({2, I, 0, 0, 0});
+  // chain I4 + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -727,14 +727,12 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI4) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.insert(make_short_key(enc, 0x01), val);
   // root I4(2: 0x42→chain, 0x01→leaf) + chain I4 + bottom I4 + 3 leaves
-  constexpr std::uint64_t I3 = 2;
-  verifier.assert_node_counts({3, I3, 0, 0, 0});
+  verifier.assert_node_counts({3, 3, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
   // Root I4 still has 2 children.
-  constexpr std::uint64_t I2 = 1;
-  verifier.assert_node_counts({2, I2, 0, 0, 0});
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 2));
   verifier.check_present_values();
@@ -754,8 +752,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI16) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  constexpr std::uint64_t IC16 = 1;
-  verifier.assert_node_counts({6, IC16, 1, 0, 0});
+  // root I16(5) + chain I4 + bottom I4 + 6 leaves
+  verifier.assert_node_counts({6, 2, 1, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -776,8 +774,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI48) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  constexpr std::uint64_t IC48 = 1;
-  verifier.assert_node_counts({18, IC48, 0, 1, 0});
+  // root I48(17) + chain I4 + bottom I4 + 18 leaves
+  verifier.assert_node_counts({18, 2, 0, 1, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -797,8 +795,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI256) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
-  constexpr std::uint64_t IC256 = 1;
-  verifier.assert_node_counts({50, IC256, 0, 0, 1});
+  // root I256(49) + chain I4 + bottom I4 + 50 leaves
+  verifier.assert_node_counts({50, 2, 0, 0, 1});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -889,8 +887,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI4ToI16) {
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  constexpr std::uint64_t IG16 = 1;
-  verifier.assert_node_counts({6, IG16, 1, 0, 0});
+  // root I16(5: 0x42→chain, 0x01..0x04→leaves) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({6, 2, 1, 0, 0});
 }
 
 /// Parent I16→I48 growth with a chain child.
@@ -904,8 +902,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI16ToI48) {
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  constexpr std::uint64_t IG48 = 1;
-  verifier.assert_node_counts({18, IG48, 0, 1, 0});
+  // root I48(17) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({18, 2, 0, 1, 0});
 }
 
 /// Parent I48→I256 growth with a chain child.
@@ -919,8 +917,8 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI48ToI256) {
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  constexpr std::uint64_t IG256 = 1;
-  verifier.assert_node_counts({50, IG256, 0, 0, 1});
+  // root I256(49) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({50, 2, 0, 0, 1});
 }
 
 // -------------------------------------------------------------------
@@ -1602,181 +1600,5 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanChainMixedLengths) {
 }
 
 #endif  // UNODB_DETAIL_WITH_STATS
-
-// -------------------------------------------------------------------
-// Zero-length key
-// -------------------------------------------------------------------
-
-/// A zero-length key_view should work as a root leaf (no prefix bytes
-/// to encode in an inode chain).
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ZeroLengthKey) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-  const auto empty_key = unodb::key_view{};
-  constexpr auto val = unodb::test::test_values[0];
-
-  verifier.insert(empty_key, val);
-  verifier.check_present_values();
-#ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
-#endif
-
-  verifier.remove(empty_key);
-  verifier.assert_empty();
-#ifdef UNODB_DETAIL_WITH_STATS
-  verifier.assert_node_counts({0, 0, 0, 0, 0});
-#endif
-}
-
-// -------------------------------------------------------------------
-// build_chain correctness tests (no stats assertions).
-//
-// Verify that the first key_view insert creates a correct inode chain
-// for various key lengths.  key_prefix_capacity = 7, so each chain I4
-// consumes up to 7 prefix + 1 dispatch = 8 bytes.
-//
-// Key lengths tested: 1, 7, 8, 9, 15, 16, 17, 18
-// (0-byte key already tested in ZeroLengthKey above)
-// -------------------------------------------------------------------
-
-namespace {
-
-/// Build a raw key of \a len bytes.  All bytes are 0x42 except the
-/// last byte which is \a last.  \a buf must have at least \a len bytes.
-inline unodb::key_view make_raw_key(std::byte* buf, std::size_t len,
-                                    std::byte last = std::byte{0x01}) {
-  std::fill_n(buf, len, std::byte{0x42});
-  if (len > 0) buf[len - 1] = last;
-  return unodb::key_view{buf, len};
-}
-
-}  // namespace
-
-// T1: Single key insert/get/remove for each key length.
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainSingleKey) {
-  constexpr auto val = unodb::test::test_values[0];
-  constexpr std::size_t lengths[] = {1, 7, 8, 9, 15, 16, 17, 18};
-  for (auto len : lengths) {
-    unodb::test::tree_verifier<TypeParam> verifier;
-    std::array<std::byte, 32> buf{};
-    const auto k = make_raw_key(buf.data(), len);
-    verifier.insert(k, val);
-    verifier.check_present_values();
-    // Duplicate insert must fail.
-    UNODB_ASSERT_FALSE(verifier.get_db().insert(k, val));
-    verifier.remove(k);
-    verifier.assert_empty();
-  }
-}
-
-// T2: Two keys diverging at the last byte.
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainTwoKeysDivergeAtEnd) {
-  constexpr auto val = unodb::test::test_values[0];
-  constexpr std::size_t lengths[] = {1, 8, 9, 16, 17, 18};
-  for (auto len : lengths) {
-    unodb::test::tree_verifier<TypeParam> verifier;
-    std::array<std::byte, 32> buf_a{};
-    std::array<std::byte, 32> buf_b{};
-    const auto ka = make_raw_key(buf_a.data(), len, std::byte{0x01});
-    const auto kb = make_raw_key(buf_b.data(), len, std::byte{0x02});
-    verifier.insert(ka, val);
-    verifier.insert(kb, val);
-    verifier.check_present_values();
-    verifier.remove(ka);
-    verifier.check_present_values();
-    verifier.remove(kb);
-    verifier.assert_empty();
-  }
-}
-
-// T3: Two keys diverging at an intermediate byte (byte 0).
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainDivergeAtStart) {
-  constexpr auto val = unodb::test::test_values[0];
-  constexpr std::size_t lengths[] = {9, 17, 18};
-  for (auto len : lengths) {
-    unodb::test::tree_verifier<TypeParam> verifier;
-    std::array<std::byte, 32> buf_a{};
-    std::array<std::byte, 32> buf_b{};
-    const auto ka = make_raw_key(buf_a.data(), len, std::byte{0x01});
-    // Diverge at byte 0.
-    std::fill_n(buf_b.data(), len, std::byte{0x42});
-    buf_b[0] = std::byte{0x10};
-    buf_b[len - 1] = std::byte{0x01};
-    const auto kb = unodb::key_view{buf_b.data(), len};
-    verifier.insert(ka, val);
-    verifier.insert(kb, val);
-    verifier.check_present_values();
-    verifier.remove(ka);
-    verifier.remove(kb);
-    verifier.assert_empty();
-  }
-}
-
-// T4: Scan over chain keys.
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainScan) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-  constexpr auto val = unodb::test::test_values[0];
-  std::array<std::byte, 9> buf1{}, buf2{}, buf3{};
-  const auto k1 = make_raw_key(buf1.data(), 9, std::byte{0x01});
-  const auto k2 = make_raw_key(buf2.data(), 9, std::byte{0x02});
-  const auto k3 = make_raw_key(buf3.data(), 9, std::byte{0x03});
-  verifier.insert(k1, val);
-  verifier.insert(k2, val);
-  verifier.insert(k3, val);
-
-  // Forward scan — collect keys.
-  std::vector<std::vector<std::byte>> keys;
-  verifier.get_db().scan([&keys](auto visitor) {
-    auto kv = visitor.get_key();
-    keys.emplace_back(kv.begin(), kv.end());
-    return false;  // continue
-  });
-  UNODB_ASSERT_EQ(keys.size(), 3U);
-  // Keys should be in lexicographic order.
-  UNODB_ASSERT_TRUE(keys[0] < keys[1]);
-  UNODB_ASSERT_TRUE(keys[1] < keys[2]);
-}
-
-// T5: Chain + non-chain sibling (different first byte).
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainWithSibling) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-  constexpr auto val = unodb::test::test_values[0];
-  // 9-byte chain key.
-  std::array<std::byte, 9> buf_chain{};
-  const auto k_chain = make_raw_key(buf_chain.data(), 9, std::byte{0x01});
-  // 8-byte key with different first byte.
-  std::array<std::byte, 8> buf_short{};
-  std::fill(buf_short.begin(), buf_short.end(), std::byte{0x10});
-  const auto k_short = unodb::key_view{buf_short.data(), 8};
-  verifier.insert(k_chain, val);
-  verifier.insert(k_short, val);
-  verifier.check_present_values();
-  verifier.remove(k_chain);
-  verifier.check_present_values();
-  verifier.remove(k_short);
-  verifier.assert_empty();
-}
-
-// T6: Prefix overflow on I4 collapse after chain removal.
-UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, BuildChainPrefixOverflow) {
-  unodb::test::tree_verifier<TypeParam> verifier;
-  constexpr auto val = unodb::test::test_values[0];
-  unodb::key_encoder enc;
-  // Two 9-byte keys under tag=0x10.
-  verifier.insert(make_key(enc, 0x10, 1), val);
-  verifier.insert(make_key(enc, 0x10, 2), val);
-  // Two 9-byte keys under tag=0x20.
-  verifier.insert(make_key(enc, 0x20, 1), val);
-  verifier.insert(make_key(enc, 0x20, 2), val);
-  verifier.check_present_values();
-  // Remove both tag=0x10 keys.
-  verifier.remove(make_key(enc, 0x10, 1));
-  verifier.remove(make_key(enc, 0x10, 2));
-  // tag=0x20 keys must still be accessible.
-  verifier.check_present_values();
-  // Remove remaining.
-  verifier.remove(make_key(enc, 0x20, 1));
-  verifier.remove(make_key(enc, 0x20, 2));
-  verifier.assert_empty();
-}
 
 }  // namespace

--- a/test/test_art_key_view_full_chain.cpp
+++ b/test/test_art_key_view_full_chain.cpp
@@ -1,0 +1,1605 @@
+// Copyright 2025 UnoDB contributors
+
+// Should be the first include
+#include "global.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_include <__cstddef/byte.h>
+// IWYU pragma: no_include <array>
+// IWYU pragma: no_include <span>
+// IWYU pragma: no_include <string>
+// IWYU pragma: no_include <string_view>
+
+#include <cstddef>  // IWYU pragma: keep
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <tuple>
+
+#include <gtest/gtest.h>
+
+#include "art_common.hpp"
+#include "db_test_utils.hpp"
+#include "gtest_utils.hpp"
+
+namespace {
+
+template <class Db>
+class ARTKeyViewFullChainTest : public ::testing::Test {
+ public:
+  using Test::Test;
+};
+
+using ARTTypes =
+    ::testing::Types<unodb::test::key_view_u64val_db,
+                     unodb::test::key_view_u64val_mutex_db,
+                     unodb::test::key_view_u64val_olc_db>;
+
+UNODB_TYPED_TEST_SUITE(ARTKeyViewFullChainTest, ARTTypes)
+
+/// Unit test of correct rejection of a key which is too large to be
+/// stored in the tree.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, TooLongKey) {
+  constexpr std::byte fake_val{0x00};
+  const unodb::key_view too_long{
+      &fake_val,
+      static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) +
+          1U};
+
+  unodb::test::tree_verifier<TypeParam> verifier;
+
+  UNODB_ASSERT_THROW(std::ignore = verifier.get_db().insert(too_long, {}),
+                     std::length_error);
+
+  verifier.assert_empty();
+
+#ifdef UNODB_DETAIL_WITH_STATS
+  verifier.assert_growing_inodes({0, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Unit test inserts several string keys with proper encoding and
+/// validates the tree.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, EncodedTextKeys) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+  verifier.insert(enc.reset().encode_text("").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("a").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("abba").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("banana").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("camel").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("yellow").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("ostritch").get_key_view(), val);
+  verifier.insert(enc.reset().encode_text("zebra").get_key_view(), val);
+  verifier.check_present_values();  // checks keys and key ordering.
+}
+
+// ===================================================================
+// key_view tests for the dispatch byte collision bug.
+//
+// key_prefix_capacity is 7 bytes.  When two key_view keys share more
+// than 7 bytes of common prefix, the leaf-to-inode4 split must create
+// a chain of internal nodes rather than a single inode4, because the
+// dispatch byte (the byte immediately after the stored prefix) is the
+// same for both keys.
+//
+// Keys are 9 bytes: (uint8_t tag, uint64_t value).  Same tag + small
+// values → 8 shared bytes, triggering the bug.  10-byte keys
+// (uint8_t tag, uint64_t value, uint8_t suffix) are used for
+// mixed-length tests.  Both lengths exceed key_prefix_capacity + 1.
+//
+// Test plan groups:
+//   0. Bug reproduction — minimal cases
+//   1. Prefix boundary cases — validate various shared-prefix lengths
+//   2. Node growth — inode4 -> inode16 -> inode48 -> inode256
+//   3. Removal & shrinkage — chained inodes collapse correctly
+//   4. Mixed key lengths — different-length keys with long shared prefix
+//   5. Duplicate & edge cases — duplicate insert, get-missing
+//   6. Stats verification — node counts at intermediate states
+//     6a. Insert stats — verify chain structure after insert
+//     6b. Partial remove — bottom inode shrinks, chain preserved
+//         I16→I4, I48→I16, I256→I48
+//     6c. Full remove — remove all keys through each bottom inode size
+//         I4, I16, I48, I256
+//     6d. Cascade — chain under parent at min_size, removing chain
+//         triggers parent shrinkage: I4→leaf, I16→I4, I48→I16, I256→I48
+//     6e. Multi-level chain — 17-byte keys, 2 chain levels
+// ===================================================================
+
+// Helper: encode a 9-byte key (uint8 + uint64).
+// Same tag byte → 8 shared bytes when uint64 values are small.
+inline unodb::key_view make_key(unodb::key_encoder& enc, std::uint8_t tag,
+                                std::uint64_t v) {
+  return enc.reset().encode(tag).encode(v).get_key_view();
+}
+
+// Helper: encode a 1-byte key (uint8 only).
+// Diverges at byte 0 from any key with a different first byte.
+// Used in cascade tests where we need direct-leaf children of the root
+// alongside a chain subtree.
+[[maybe_unused]] inline unodb::key_view make_short_key(unodb::key_encoder& enc,
+                                                       std::uint8_t tag) {
+  return enc.reset().encode(tag).get_key_view();
+}
+
+// Helper: encode a 10-byte key (uint8 + uint64 + uint8).
+// When used with the same tag and v as make_key, the 9-byte key is a
+// prefix of this 10-byte key — which ART does not support.  Use
+// different v values to avoid prefix relationships.
+// Both lengths (9 and 10) exceed key_prefix_capacity + 1 = 8.
+inline unodb::key_view make_long_key(unodb::key_encoder& enc, std::uint8_t tag,
+                                     std::uint64_t v, std::uint8_t suffix) {
+  return enc.reset().encode(tag).encode(v).encode(suffix).get_key_view();
+}
+
+// -------------------------------------------------------------------
+// Group 0: Original bug reproduction tests
+// -------------------------------------------------------------------
+
+/// Two 9-byte keys sharing 8 bytes — dispatch byte collision.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysLongSharedPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 (prefix=7, 1 child) + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Three keys with the same tag byte and small uint64 values.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ThreeCompoundKeysLongSharedPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + bottom I4 (3 children) + 3 leaves
+  verifier.assert_node_counts({3, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// 9-byte keys sharing 8 bytes — minimal collision case.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, NineByteCompoundKeysLongPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 1: Prefix boundary cases
+// -------------------------------------------------------------------
+
+/// Keys identical except last byte — maximum chaining depth for 9-byte keys.
+/// 9-byte keys sharing 8 bytes, differing only at byte 8.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
+                 CompoundKeysIdenticalExceptLastByte) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.insert(make_key(enc, 0x42, 4), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + bottom I4 (4 children, at capacity) + 4 leaves
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Two 17-byte keys sharing 16 bytes — forces two consecutive chain
+/// nodes (depth 0→8 and depth 8→16) before the normal 2-child split.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // 17 bytes: 0xAA × 16, then 0x01 vs 0x02.
+  auto make17 = [&](std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+  verifier.insert(make17(0x01), val);
+  verifier.insert(make17(0x02), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // 2 chain I4s (depth 0→8, 8→16) + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 3, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Three 17-byte keys: A and B share 16 bytes, C diverges at byte 10.
+/// After inserting A and B (two chain levels), inserting C splits the
+/// second chain node mid-prefix.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
+                 InsertDivergingAtIntermediateChainDepth) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make17 = [&](std::uint8_t byte10, std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 10; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(byte10);
+    for (unsigned i = 11; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+  // A and B share 16 bytes (byte10=0xAA), differ at byte 16.
+  verifier.insert(make17(0xAA, 0x01), val);
+  verifier.insert(make17(0xAA, 0x02), val);
+  // C diverges at byte 10 — splits the second chain node.
+  verifier.insert(make17(0xBB, 0x03), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 (bytes 0-7) + split I4 (at byte 10) + chain I4 (bytes 11-15)
+  // + bottom I4 (A,B) + 3 leaves
+  verifier.assert_node_counts({3, 4, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 2: Node growth (inode4 -> inode16 -> inode48 -> inode256)
+// -------------------------------------------------------------------
+
+/// 5 keys with same 8-byte prefix — forces inode4 -> inode16 growth.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysFiveChildren) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + I16 (5 children) + 5 leaves
+  verifier.assert_node_counts({5, 1, 1, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// 17 keys — forces inode16 -> inode48 growth.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysSeventeenChildren) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 17; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + I48 (17 children) + 17 leaves
+  verifier.assert_node_counts({17, 1, 0, 1, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// 50 keys — forces inode48 -> inode256 growth.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysFiftyChildren) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 50; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + I256 (50 children) + 50 leaves
+  verifier.assert_node_counts({50, 1, 0, 0, 1});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 3: Removal & shrinkage
+// -------------------------------------------------------------------
+
+// Group 3a: Chain collapse scenarios
+
+/// Insert 2 colliding keys, remove one, verify the other is still found.
+/// The chain of inode_4s should collapse to a single leaf.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysInsertThenRemove) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Bottom I4 collapsed via leave_last_child.  Chain I4 remains with
+  // 1 child (the surviving leaf).
+  verifier.assert_node_counts({1, 1, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 3 keys: two sharing 8 bytes, one diverging earlier.
+/// Remove one of the 8-byte-shared pair.  The surviving structure
+/// should be an inode with 2 children (the remaining keys).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveFromChainLeavesInode) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Keys 1 and 2 share 8 bytes; key 3 diverges at byte 5.
+  // key3 uint64 = 0x0000000100000000 differs at byte 5 (overall).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 0x0000000100000000ULL), val);
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Root I4 (2 children: key3 leaf + chain) + chain I4 + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 3 colliding keys, remove in reverse order, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveAllFromChainReverseOrder) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.remove(make_key(enc, 0x42, 3));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.assert_empty();
+}
+
+/// Insert 3 colliding keys, remove in forward order, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveAllFromChainForwardOrder) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_key(enc, 0x42, 3), val);
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.remove(make_key(enc, 0x42, 3));
+  verifier.assert_empty();
+}
+
+// Group 3b: Shrinkage at chain terminal
+
+/// Insert 5 keys (-> inode16 at chain terminal), remove 3 (-> inode4).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ShrinkInode16InChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.remove(make_key(enc, 0x42, 3));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // I16(5) shrinks to I4(4) on first remove, then 2 more removes → I4(2).
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 17 keys (-> inode48), remove 13 (-> shrink to inode4).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ShrinkInode48InChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 17; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  for (std::uint64_t i = 1; i <= 13; ++i) {
+    verifier.remove(make_key(enc, 0x42, i));
+  }
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // I48(17) shrinks to I16(16) on first remove, then I16(5) shrinks
+  // to I4(4) on 13th remove.
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Insert 5 keys (-> inode16), remove all 5, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ShrinkToEmptyFromInode16InChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.insert(make_key(enc, 0x42, i), val);
+  }
+  for (std::uint64_t i = 1; i <= 5; ++i) {
+    verifier.remove(make_key(enc, 0x42, i));
+  }
+  verifier.assert_empty();
+}
+
+// Group 3c: Mixed-depth removal
+
+/// Insert a 10-byte and 9-byte key sharing 8 bytes (same tag, different
+/// uint64 values).  Remove the 10-byte key, verify 9-byte key.  Then
+/// remove it too, assert empty.
+///
+/// Note: the two keys must NOT be in a prefix relationship — ART does
+/// not support one key being a prefix of another.  Using different
+/// uint64 values ensures they diverge within the shared bytes.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveMixedLengthFromChain) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_long_key(enc, 0x42, 1, 0xFF), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_long_key(enc, 0x42, 1, 0xFF));
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Chain I4 + 1 surviving leaf
+  verifier.assert_node_counts({1, 1, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.assert_empty();
+}
+
+// Group 3d: Stress removal
+
+/// Insert 24 keys (divergence at positions 7..18), remove every other
+/// key, verify remaining.  Then remove all, assert empty.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StressInsertRemoveAtEveryPosition) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  constexpr unsigned key_len = 20;
+  constexpr unsigned prefix_cap = 7;
+
+  // Insert all 24 keys: for each divergence position d (7..18), two
+  for (unsigned d = prefix_cap; d < key_len - 1; ++d) {
+    for (unsigned variant = 1; variant <= 2; ++variant) {
+      enc.reset();
+      enc.encode(static_cast<std::uint8_t>(d));
+      for (unsigned i = 1; i < key_len; ++i) {
+        if (i < prefix_cap) {
+          enc.encode(std::uint8_t{0xAA});
+        } else if (i == d) {
+          enc.encode(static_cast<std::uint8_t>(variant));
+        } else {
+          enc.encode(std::uint8_t{0x00});
+        }
+      }
+      verifier.insert(enc.get_key_view(), val);
+    }
+  }
+  verifier.check_present_values();
+
+  // Remove variant=1 keys (one from each pair).
+  for (unsigned d = prefix_cap; d < key_len - 1; ++d) {
+    enc.reset();
+    enc.encode(static_cast<std::uint8_t>(d));
+    for (unsigned i = 1; i < key_len; ++i) {
+      if (i < prefix_cap) {
+        enc.encode(std::uint8_t{0xAA});
+      } else if (i == d) {
+        enc.encode(std::uint8_t{1});
+      } else {
+        enc.encode(std::uint8_t{0x00});
+      }
+    }
+    verifier.remove(enc.get_key_view());
+  }
+  verifier.check_present_values();
+
+  // Remove remaining variant=2 keys.
+  for (unsigned d = prefix_cap; d < key_len - 1; ++d) {
+    enc.reset();
+    enc.encode(static_cast<std::uint8_t>(d));
+    for (unsigned i = 1; i < key_len; ++i) {
+      if (i < prefix_cap) {
+        enc.encode(std::uint8_t{0xAA});
+      } else if (i == d) {
+        enc.encode(std::uint8_t{2});
+      } else {
+        enc.encode(std::uint8_t{0x00});
+      }
+    }
+    verifier.remove(enc.get_key_view());
+  }
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 4: Mixed key lengths
+// -------------------------------------------------------------------
+
+/// A 10-byte key and a 9-byte key sharing 8 bytes (same tag, different
+/// uint64 values).  The keys must not be in a prefix relationship.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MixedLengthKeysLongPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_long_key(enc, 0x42, 1, 0xFF), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  // chain I4 + bottom I4 (2 children) + 2 leaves
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+}
+
+// -------------------------------------------------------------------
+// Group 5: Duplicate & edge cases
+// -------------------------------------------------------------------
+
+/// Inserting the same 9-byte key twice returns false on the second insert.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeyDuplicateInsert) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  // Second insert of same key should fail.
+  UNODB_ASSERT_FALSE(verifier.get_db().insert(make_key(enc, 0x42, 1), val));
+  verifier.check_present_values();
+}
+
+/// Get with a key sharing 8 bytes but differing at the last byte
+/// should return empty when only one key is present.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeyGetMissing) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  const auto result = verifier.get_db().get(make_key(enc, 0x42, 2));
+  UNODB_ASSERT_FALSE(TypeParam::key_found(result));
+  verifier.check_present_values();
+}
+
+#ifdef UNODB_DETAIL_WITH_STATS
+
+// ===================================================================
+// Group 6: Stats verification — node counts at intermediate states
+//
+// These tests verify that the tree's internal bookkeeping (node counts,
+// memory use) is correct after insert and remove operations involving
+// single-child chain I4 nodes.
+//
+// Inode size thresholds:
+//   I4:   min=2, capacity=4   (shrinks via leave_last_child)
+//   I16:  min=5, capacity=16  (shrinks to I4)
+//   I48:  min=17, capacity=48 (shrinks to I16)
+//   I256: min=49, capacity=256 (shrinks to I48)
+//
+// For keys make_key(enc, 0x42, v) with small v:
+//   9 bytes: [0x42, 0,0,0,0,0,0, 0, v]
+//   All share 8 bytes, differ only at byte 8.
+//   Tree: chain I4 (prefix=7, dispatch=0x00) → bottom inode (children
+//   keyed by v).
+// ===================================================================
+
+// -------------------------------------------------------------------
+// Group 6b: Partial remove — bottom inode shrinks, chain preserved
+// -------------------------------------------------------------------
+
+/// Insert 3 keys, remove 1.  Chain I4 + bottom I4 (2 children).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainPartialRemoveI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 3; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({3, 2, 0, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I4(3) → remove → I4(2).  Chain I4 unchanged.
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+}
+
+/// Insert 5 keys (→I16), remove 1 (I16 at min_size → shrink to I4).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainShrinkI16ToI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 5; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({5, 1, 1, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I16(5) at min_size → shrink to I4(4).  Chain I4 + bottom I4.
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+  verifier.assert_shrinking_inodes({0, 1, 0, 0});
+}
+
+/// Insert 17 keys (→I48), remove 1 (I48 at min_size → shrink to I16).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainShrinkI48ToI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 17; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({17, 1, 0, 1, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I48(17) at min_size → shrink to I16(16).  Chain I4 + I16.
+  verifier.assert_node_counts({16, 1, 1, 0, 0});
+  verifier.assert_shrinking_inodes({0, 0, 1, 0});
+}
+
+/// Insert 49 keys (→I256), remove 1 (I256 at min_size → shrink to I48).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainShrinkI256ToI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 49; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({49, 1, 0, 0, 1});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+  // I256(49) at min_size → shrink to I48(48).  Chain I4 + I48.
+  verifier.assert_node_counts({48, 1, 0, 1, 0});
+  verifier.assert_shrinking_inodes({0, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------
+// Group 6c: Full remove — all keys removed through each bottom inode
+// -------------------------------------------------------------------
+
+/// Insert 17 keys into chain (bottom I48), remove all.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainRemoveAllFromI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 17; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  for (std::uint64_t i = 1; i <= 17; ++i)
+    verifier.remove(make_key(enc, 0x42, i));
+  verifier.assert_empty();
+}
+
+/// Insert 49 keys into chain (bottom I256), remove all.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainRemoveAllFromI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  for (std::uint64_t i = 1; i <= 49; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  for (std::uint64_t i = 1; i <= 49; ++i)
+    verifier.remove(make_key(enc, 0x42, i));
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 6d: Cascade — chain under parent at min_size, removing chain
+// triggers parent shrinkage
+//
+// Each test creates a parent inode at its min_size, where one child
+// slot points to a chain (2 keys with tag=0x42 sharing 8 bytes) and
+// the remaining slots are direct leaves (distinct tag bytes).
+// Removing both chain keys should: reclaim the chain, then shrink
+// the parent through the normal shrinkage path.
+// -------------------------------------------------------------------
+
+/// Chain under I4(2 children).  Remove chain → I4 collapses via
+/// leave_last_child → root becomes the surviving leaf.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Insert chain keys first so the chain forms at root level, then
+  // insert a short key that splits the root prefix → parent I4.
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_short_key(enc, 0x01), val);
+  // root I4(2: 0x42→chain, 0x01→leaf) + chain I4 + bottom I4 + 3 leaves
+  verifier.assert_node_counts({3, 3, 0, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
+  // Root I4 still has 2 children.
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain fully reclaimed.  Root I4 at min_size(2) loses a child →
+  // leave_last_child → root becomes the surviving leaf.
+  verifier.assert_node_counts({1, 0, 0, 0, 0});
+}
+
+/// Chain under I16(5 children).  Remove chain → I16 shrinks to I4.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Chain keys first, then 4 short keys → root I16(5 children).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x04; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  // root I16(5) + chain I4 + bottom I4 + 6 leaves
+  verifier.assert_node_counts({6, 2, 1, 0, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain reclaimed.  I16(5) → remove chain slot → is_min_size →
+  // shrink to I4(4).
+  verifier.assert_node_counts({4, 1, 0, 0, 0});
+}
+
+/// Chain under I48(17 children).  Remove chain → I48 shrinks to I16.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Chain keys first, then 16 short keys → root I48(17 children).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x10; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  // root I48(17) + chain I4 + bottom I4 + 18 leaves
+  verifier.assert_node_counts({18, 2, 0, 1, 0});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain reclaimed.  I48(17) → remove chain slot → shrink to I16(16).
+  verifier.assert_node_counts({16, 0, 1, 0, 0});
+}
+
+/// Chain under I256(49 children).  Remove chain → I256 shrinks to I48.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Chain keys first, then 48 short keys → root I256(49 children).
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x30; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  // root I256(49) + chain I4 + bottom I4 + 50 leaves
+  verifier.assert_node_counts({50, 2, 0, 0, 1});
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+  // Chain reclaimed.  I256(49) → remove chain slot → shrink to I48(48).
+  verifier.assert_node_counts({48, 0, 0, 1, 0});
+}
+
+// Chain under I48(18 children, above min_size).  Remove chain child
+// via remove_child_entry (no shrink).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainRemoveFromI48AboveMin) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x11; ++t)  // 17 short keys → I48(18)
+    verifier.insert(make_short_key(enc, t), val);
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+}
+
+// Chain under I256(50 children, above min_size).  Remove chain child
+// via remove_child_entry (no shrink).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainRemoveFromI256AboveMin) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x31; ++t)  // 49 short keys → I256(50)
+    verifier.insert(make_short_key(enc, t), val);
+
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.remove(make_key(enc, 0x42, 2));
+  verifier.check_present_values();
+}
+
+// -------------------------------------------------------------------
+// Group 6e: Multi-level chain removal
+// -------------------------------------------------------------------
+
+/// Two 17-byte keys (2 chain I4s + bottom I4), remove both.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChainRemoveAll) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make17 = [&](std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+  verifier.insert(make17(0x01), val);
+  verifier.insert(make17(0x02), val);
+  verifier.assert_node_counts({2, 3, 0, 0, 0});
+
+  verifier.remove(make17(0x01));
+  // Bottom I4 collapsed.  Two chain I4s remain, last one has 1 child (leaf).
+  verifier.assert_node_counts({1, 2, 0, 0, 0});
+
+  verifier.remove(make17(0x02));
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 7: Parent inode growth with chain children (GAP A)
+//
+// The root inode grows I4→I16→I48→I256 where one child is a chain
+// subtree.  Existing cascade tests (6d) only cover parent shrinkage.
+// -------------------------------------------------------------------
+
+/// Parent I4→I16 growth with a chain child.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainParentGrowthI4ToI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Chain subtree under tag=0x42.
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  // 4 short keys to grow parent past I4 capacity.
+  for (std::uint8_t t = 0x01; t <= 0x04; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  verifier.check_present_values();
+  // root I16(5: 0x42→chain, 0x01..0x04→leaves) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({6, 2, 1, 0, 0});
+}
+
+/// Parent I16→I48 growth with a chain child.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainParentGrowthI16ToI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x10; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  verifier.check_present_values();
+  // root I48(17) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({18, 2, 0, 1, 0});
+}
+
+/// Parent I48→I256 growth with a chain child.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainParentGrowthI48ToI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  for (std::uint8_t t = 0x01; t <= 0x30; ++t)
+    verifier.insert(make_short_key(enc, t), val);
+  verifier.check_present_values();
+  // root I256(49) + chain-I4 + bottom-I4
+  verifier.assert_node_counts({50, 2, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------
+// Group 8: Bottom inode growth with cumulative stats (GAP C)
+// -------------------------------------------------------------------
+
+/// Verify growing_inodes through I4→I16→I48→I256 under a chain.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainBottomGrowthStats) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Insert 4 keys: chain-I4 + bottom-I4(4).
+  for (std::uint64_t i = 1; i <= 4; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+  // chain-I4 creation + bottom-I4 creation = 2 I4 grows.
+  verifier.assert_growing_inodes({2, 0, 0, 0});
+
+  // 5th key: bottom I4→I16.
+  verifier.insert(make_key(enc, 0x42, 5), val);
+  verifier.assert_node_counts({5, 1, 1, 0, 0});
+  verifier.assert_growing_inodes({2, 1, 0, 0});
+
+  // 17th key: bottom I16→I48.
+  for (std::uint64_t i = 6; i <= 17; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({17, 1, 0, 1, 0});
+  verifier.assert_growing_inodes({2, 1, 1, 0});
+
+  // 49th key: bottom I48→I256.
+  for (std::uint64_t i = 18; i <= 49; ++i)
+    verifier.insert(make_key(enc, 0x42, i), val);
+  verifier.assert_node_counts({49, 1, 0, 0, 1});
+  verifier.assert_growing_inodes({2, 1, 1, 1});
+
+  verifier.check_present_values();
+}
+
+// -------------------------------------------------------------------
+// Group 9: Multi-level chain with fat bottom inode (GAP D)
+// -------------------------------------------------------------------
+
+/// Two chain levels + I16 at bottom (5 keys, 17 bytes each).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChainFatBottom) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make17 = [&](std::uint8_t last) {
+    enc.reset();
+    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+    enc.encode(last);
+    return enc.get_key_view();
+  };
+
+  for (std::uint8_t i = 1; i <= 5; ++i) verifier.insert(make17(i), val);
+  verifier.check_present_values();
+  // 2 chain-I4s + bottom I16(5) + 5 leaves
+  verifier.assert_node_counts({5, 2, 1, 0, 0});
+  verifier.assert_growing_inodes({3, 1, 0, 0});
+
+  // Remove 1 → I16 at min_size → shrink to I4.
+  verifier.remove(make17(1));
+  verifier.assert_node_counts({4, 3, 0, 0, 0});
+  verifier.assert_shrinking_inodes({0, 1, 0, 0});
+
+  // Remove remaining → chains collapse.
+  for (std::uint8_t i = 2; i <= 5; ++i) verifier.remove(make17(i));
+  verifier.assert_empty();
+}
+
+// -------------------------------------------------------------------
+// Group 10: Mid-level inode between chain levels (GAP B)
+//
+// 18-byte keys: encode(u64).encode(u8_mid).encode(u64).encode(u8)
+// = 8+1+8+1 = 18 bytes.
+// All keys share bytes[0..7] → chain at depth 0.
+// byte[8] = mid → mid-level inode at depth 8.
+// Within each mid group, bytes[9..16] shared → chain at depth 9.
+// byte[17] = bottom → bottom inode at depth 17.
+// Structure: chain(0) → mid-inode(8) → {chain(9) → bottom-inode(17)}*
+// -------------------------------------------------------------------
+
+/// Mid-level inode growth with chains above and below.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MidLevelInodeGrowth) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 5 mid groups × 2 bottom keys = 10 keys.
+  // Mid-inode at depth 8 grows to I16(5).
+  for (std::uint8_t m = 1; m <= 5; ++m)
+    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+  verifier.check_present_values();
+  // chain(0) → mid-I16(5) → 5×(chain(9) → bottom-I4(2) → 2 leaves)
+  // I4: 1 top-chain + 5 depth-9-chains + 5 bottoms = 11
+  verifier.assert_node_counts({10, 11, 1, 0, 0});
+}
+
+/// Mid-level inode shrinkage with chains above and below.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MidLevelInodeShrink) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 5 mid groups × 2 bottom keys = 10 keys → mid I16(5).
+  for (std::uint8_t m = 1; m <= 5; ++m)
+    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+
+  // Remove both keys for mid=1 → bottom-I4(2) collapses (I4 shrink),
+  // chain(9) collapses (I4 shrink), mid-I16(5) at min_size → I4(4)
+  // (I16 shrink).
+  verifier.remove(make18(1, 1));
+  verifier.remove(make18(1, 2));
+  verifier.check_present_values();
+  // chain(0) → mid-I4(4) → 4×(chain(9) → bottom-I4(2) → 2 leaves)
+  // I4: 1 top-chain + 4 depth-9-chains + 4 bottoms + 1 mid = 10
+  verifier.assert_node_counts({8, 10, 0, 0, 0});
+  verifier.assert_shrinking_inodes({2, 1, 0, 0});
+}
+
+// -------------------------------------------------------------------
+// Group 10a: Chain remove — key not found / mismatch coverage
+// -------------------------------------------------------------------
+
+// Remove non-existent key where chain I4's find_child returns nullptr.
+// The chain has one child at dispatch byte 0x01; we try dispatch 0x03.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainRemoveKeyNotFound) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_key(enc, 0x42, 2));
+  // Chain I4 has 1 child at dispatch 0x01.  v=3 → dispatch 0x03.
+  UNODB_ASSERT_FALSE(verifier.get_db().remove(make_key(enc, 0x42, 3)));
+  verifier.check_present_values();
+}
+
+// Remove non-existent key when root is a single leaf.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveMissRootIsLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  UNODB_ASSERT_FALSE(verifier.get_db().remove(make_key(enc, 0x42, 2)));
+  verifier.check_present_values();
+}
+
+// Remove key where chain I4's child is a leaf that doesn't match.
+// Use a 10-byte key that shares the chain prefix and dispatch byte
+// but differs at the leaf level.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainRemoveLeafMismatch) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.remove(make_key(enc, 0x42, 2));
+  // Chain I4 child is leaf with key [0x42, 0,...,0x01] (9 bytes).
+  // Try removing a 10-byte key with same first 9 bytes + suffix.
+  // This matches prefix and dispatch but leaf->matches() fails.
+  UNODB_ASSERT_FALSE(
+      verifier.get_db().remove(make_long_key(enc, 0x42, 1, 0xFF)));
+  verifier.check_present_values();
+}
+
+// -------------------------------------------------------------------
+// Group 10b: Atomic chain cut — structural gap tests
+// -------------------------------------------------------------------
+
+// T5: I4(2) collapse with CD=1 chain, remaining child is leaf.
+// Tree: root-I4(2: chain→chain→leaf(A), leaf(C))
+// Remove A → chain cut, I4 collapses, root becomes leaf(C).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1CollapseToLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // A and B share tag + 8 bytes → chain at depth 0, chain at depth 8.
+  // C has different tag → sibling at root.
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  verifier.insert(make18(0x02, 0x00, 0x01), val);  // C
+  verifier.check_present_values();
+
+  // Remove B: bottom I4(2→1), chain extends.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=1). Root I4(2→1) collapses to leaf(C).
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+
+  // Remove C: tree empty.
+  verifier.remove(make18(0x02, 0x00, 0x01));
+  verifier.assert_empty();
+}
+
+// T7: I4(2) collapse with CD=0 chain, remaining child is inode.
+// Remove A → chain cut, I4 collapses, remaining child promoted.
+// Use 1-byte keys for B,C so remaining child has short prefix.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD0CollapseToInode) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // A: 9-byte key with tag=0x10 → chain at depth 0.
+  // B,C: 1-byte keys with tag=0x20, 0x30 → I4(2) at root, no prefix.
+  // Root: I4(3: 0x10→chain→leaf(A), 0x20→leaf(B), 0x30→leaf(C))
+  // Wait — that's I4(3), not I4(2). For I4(2) collapse we need
+  // exactly 2 children. Use B as a subtree:
+  // B1,B2: 1-byte keys → but 1-byte keys can't form a subtree.
+  //
+  // Simpler: use 2-byte keys for B,C sharing first byte.
+  // B: [0x20, 0x01], C: [0x20, 0x02] → I4(2: leaf(B), leaf(C))
+  // under dispatch 0x20. Root: I4(2: 0x10→chain, 0x20→I4(2: B, C))
+  // Root prefix is empty. Remaining child I4(B,C) has empty prefix.
+  // Merge: 0 + 1 + 0 = 1 byte → fits.
+  verifier.insert(make_key(enc, 0x10, 1), val);  // A (9 bytes)
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x20})
+                      .encode(std::uint8_t{0x01})
+                      .get_key_view(),
+                  val);  // B (2 bytes)
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x20})
+                      .encode(std::uint8_t{0x02})
+                      .get_key_view(),
+                  val);  // C (2 bytes)
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=0). Root I4(2→1) collapses.
+  verifier.remove(make_key(enc, 0x10, 1));
+  verifier.check_present_values();
+}
+
+// T8: I4(2) collapse with CD=1 chain, remaining child is inode.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1CollapseToInode) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // A,B share tag=0x01 + 8 bytes → depth-1 chain → I4(2: A, B).
+  // D,E have tag=0x02 → I4(2: D, E) subtree.
+  // Root: I4(2: 0x01→chain→chain→I4(A,B), 0x02→chain→I4(D,E))
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
+  verifier.insert(make18(0x02, 0x00, 0x02), val);  // E
+  verifier.check_present_values();
+
+  // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
+  // Remaining child is the tag=0x02 subtree — prefix merge needed.
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+}
+
+// T12: I4(3) with CD=1 chain, just remove entry.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1RemoveFromI4) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 3 tag groups: 0x01 (chain target), 0x02, 0x03.
+  // Root: I4(3: chain→...A, leaf(D), leaf(E))
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
+  verifier.insert(make18(0x03, 0x00, 0x01), val);  // E
+  verifier.check_present_values();
+
+  // Remove B, then A: chain cut from I4(3→2).
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+}
+
+// T8b: I4(2) collapse with CD=1 chain, remaining child is inode,
+// prefix merge fits.  Uses 2-byte sibling keys so the remaining
+// child has empty prefix → merge = 0 + 1 + 0 = 1 ≤ 7.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
+                 ChainCutCD1CollapseToInodeShortPrefix) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // A,B: tag=0x01, 18-byte keys → depth-1 chain → I4(2: A, B).
+  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
+  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  // C,D: tag=0x02, 2-byte keys → I4(2: C, D) with empty prefix.
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x02})
+                      .encode(std::uint8_t{0x01})
+                      .get_key_view(),
+                  val);  // C
+  verifier.insert(enc.reset()
+                      .encode(std::uint8_t{0x02})
+                      .encode(std::uint8_t{0x02})
+                      .get_key_view(),
+                  val);  // D
+  verifier.check_present_values();
+
+  // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.check_present_values();
+
+  // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
+  // Remaining child is I4(C,D) with empty prefix.
+  // Merge: root prefix(0) + dispatch(0x02) + child prefix(0) = 1 ≤ 7.
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+}
+
+// T6: I4(2) collapse with CD=2 chain, remaining child is leaf.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD2CollapseToLeaf) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // 26-byte keys: tag + uint64 + uint64 + uint64 + uint8.
+  // Two keys sharing 25 bytes → 3 chain levels (depth 0,8,16).
+  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  verifier.insert(make26(0x01, 0x01), val);  // A
+  verifier.insert(make26(0x01, 0x02), val);  // B
+  verifier.insert(make26(0x02, 0x01), val);  // sibling
+  verifier.check_present_values();
+
+  // Remove B → chain extends. Remove A → CD=2 chain cut.
+  verifier.remove(make26(0x01, 0x02));
+  verifier.check_present_values();
+  verifier.remove(make26(0x01, 0x01));
+  verifier.check_present_values();
+
+  // Sibling subtree remains: chain(depth 0)→chain(depth 8)→chain(depth 16)
+  //   →I4(2: leaf(sib_01), leaf(sib_02))... but we only inserted one sibling.
+  // Actually just: root single-child I4 → chain → chain → leaf(sib).
+  // Prefix overflow prevents collapse at each level.
+
+  // Remove sibling → empty.
+  verifier.remove(make26(0x02, 0x01));
+  verifier.assert_empty();
+}
+
+// T9: I4(2) collapse with CD=0, prefix merge overflows.
+// The I4 should NOT collapse — remains as single-child I4.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD0PrefixOverflow) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Both children are 9-byte keys with different tags.
+  // Root I4 has empty prefix. Each child chain has 7-byte prefix.
+  // Collapse would need 0 + 1 + 7 = 8 bytes → overflow.
+  verifier.insert(make_key(enc, 0x10, 1), val);  // A (chain→leaf)
+  verifier.insert(make_key(enc, 0x10, 2), val);  // B (chain→I4(A,B))
+  verifier.insert(make_key(enc, 0x20, 1), val);  // C (chain→leaf)
+  verifier.insert(make_key(enc, 0x20, 2), val);  // D (chain→I4(C,D))
+  verifier.check_present_values();
+
+  // Remove B → chain under 0x10 extends to leaf(A).
+  verifier.remove(make_key(enc, 0x10, 2));
+  verifier.check_present_values();
+
+  // Remove A → chain cut. Root I4(2→1). Remaining child is 0x20 chain
+  // with 7-byte prefix. Prefix merge overflows → no collapse.
+  verifier.remove(make_key(enc, 0x10, 1));
+  verifier.check_present_values();
+
+  // C and D still accessible.
+  verifier.remove(make_key(enc, 0x20, 1));
+  verifier.remove(make_key(enc, 0x20, 2));
+  verifier.assert_empty();
+}
+
+// T10: I4(2) collapse with CD=1, prefix merge overflows.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1PrefixOverflow) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // tag=0x01: 2 keys sharing 10 bytes → CD=1 chain.
+  // tag=0x02: 2 keys → chain with 7-byte prefix.
+  // Root I4 has empty prefix. 0x02 child has 7-byte prefix.
+  // Collapse: 0 + 1 + 7 = 8 → overflow.
+  verifier.insert(make18(0x01, 0x00, 0x01), val);
+  verifier.insert(make18(0x01, 0x00, 0x02), val);
+  verifier.insert(make18(0x02, 0x00, 0x01), val);
+  verifier.insert(make18(0x02, 0x00, 0x02), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+
+  // tag=0x02 keys still accessible.
+  verifier.remove(make18(0x02, 0x00, 0x01));
+  verifier.remove(make18(0x02, 0x00, 0x02));
+  verifier.assert_empty();
+}
+
+// T14: I16(min) shrink with CD=1 chain.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI16) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 5 tag groups → I16(5) at root level (after chain at depth 0).
+  // Under tag=0x01: 2 keys → CD=1 chain.
+  for (std::uint8_t t = 1; t <= 5; ++t)
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make18(t, 0x00, b), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut from I16(5→4) → I4.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+  // 8 leaves, 4 tag groups each with chain(depth 0)→chain(depth 8)→I4(2).
+  // Top-level I4(4) + 4×(chain + bottom-I4) = 1 + 8 = 9 I4s.
+  verifier.assert_node_counts({8, 9, 0, 0, 0});
+  verifier.assert_shrinking_inodes({2, 1, 0, 0});
+}
+
+// T16: I48(min) shrink with CD=1 chain.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI48) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 17 tag groups → I48(17).
+  for (std::uint8_t t = 1; t <= 17; ++t)
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make18(t, 0x00, b), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut from I48(17→16) → I16.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+  // 32 leaves, 16 tag groups each with chain→chain→I4(2).
+  // Top-level I16(16) + 16×(chain + bottom-I4) = 0 + 32 = 32 I4s.
+  verifier.assert_node_counts({32, 32, 1, 0, 0});
+  verifier.assert_shrinking_inodes({2, 0, 1, 0});
+}
+
+// T18: I256(min) shrink with CD=1 chain.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI256) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(mid)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  // 49 tag groups → I256(49).
+  for (std::uint8_t t = 1; t <= 49; ++t)
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make18(t, 0x00, b), val);
+  verifier.check_present_values();
+
+  // Remove both under tag=0x01 → CD=1 chain cut from I256(49→48) → I48.
+  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.check_present_values();
+  // 96 leaves, 48 tag groups each with chain→chain→I4(2).
+  // Top-level I48(48) + 48×(chain + bottom-I4) = 0 + 96 = 96 I4s.
+  verifier.assert_node_counts({96, 96, 0, 1, 0});
+  verifier.assert_shrinking_inodes({2, 0, 0, 1});
+}
+
+// -------------------------------------------------------------------
+// Verify tree structures used by concurrent chain cut tests (CT1-CT4).
+// These confirm the chain depth and that insert/remove work correctly
+// on these key patterns before we add concurrency.
+
+// CT1/CT3 tree: 26-byte keys, 3 chain levels after removing B.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ConcurrentTestTree26Byte) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(std::uint64_t{0x4242424242424242ULL})
+        .encode(std::uint64_t{0})
+        .encode(std::uint64_t{0})
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  verifier.insert(make26(0x10, 0x01), val);  // A
+  verifier.insert(make26(0x10, 0x02), val);  // B
+  verifier.insert(make26(0x20, 0x01), val);  // sib
+  verifier.check_present_values();
+
+  verifier.remove(make26(0x10, 0x02));  // remove B
+  verifier.check_present_values();
+
+  verifier.remove(make26(0x10, 0x01));  // remove A (chain cut)
+  verifier.check_present_values();
+
+  // Insert a new key at root level (what CT1's T2 does).
+  verifier.insert(make26(0x30, 0x01), val);
+  verifier.check_present_values();
+}
+
+// CT2/CT4 tree: 34-byte keys, 4 chain levels after removing B.
+// Also verify that inserting a key diverging at chain[0] works.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ConcurrentTestTree34Byte) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
+  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
+
+  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
+    return enc.reset()
+        .encode(tag)
+        .encode(v1)
+        .encode(X)
+        .encode(X)
+        .encode(X)
+        .encode(bottom)
+        .get_key_view();
+  };
+
+  verifier.insert(make34(0x10, X, 0x01), val);  // A
+  verifier.insert(make34(0x10, X, 0x02), val);  // B
+  verifier.insert(make34(0x20, X, 0x01), val);  // sib
+  verifier.check_present_values();
+
+  verifier.remove(make34(0x10, X, 0x02));  // remove B
+  verifier.check_present_values();
+
+  // Insert T2's key (diverges at chain[0] level, different v1).
+  verifier.insert(make34(0x10, Z, 0x01), val);
+  verifier.check_present_values();
+
+  // Remove A (chain cut with T2's key already in tree).
+  verifier.remove(make34(0x10, X, 0x01));
+  verifier.check_present_values();
+}
+
+// Group 11: Scan through chain with mixed-length keys (GAP E)
+// -------------------------------------------------------------------
+
+/// Iterator walks through chain subtree with 9-byte and 10-byte keys.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ScanChainMixedLengths) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // 9-byte and 10-byte keys in the same chain subtree.
+  // make_key(0x42, v) = 9 bytes.  make_long_key(0x42, v, s) = 10 bytes.
+  // Keys must not be in a prefix relationship — use different v values.
+  verifier.insert(make_key(enc, 0x42, 1), val);
+  verifier.insert(make_key(enc, 0x42, 2), val);
+  verifier.insert(make_long_key(enc, 0x42, 3, 0x01), val);
+  verifier.insert(make_long_key(enc, 0x42, 4, 0x01), val);
+  // check_present_values does a full scan + per-key probe.
+  verifier.check_present_values();
+  verifier.assert_node_counts({4, 2, 0, 0, 0});
+
+  // Remove a 10-byte key, verify scan still works.
+  verifier.remove(make_long_key(enc, 0x42, 3, 0x01));
+  verifier.check_present_values();
+
+  // Remove a 9-byte key.
+  verifier.remove(make_key(enc, 0x42, 1));
+  verifier.check_present_values();
+}
+
+#endif  // UNODB_DETAIL_WITH_STATS
+
+}  // namespace

--- a/test/test_art_key_view_full_chain.cpp
+++ b/test/test_art_key_view_full_chain.cpp
@@ -252,8 +252,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
   // chain I4 (bytes 0-7) + split I4 (at byte 10) + chain I4 (bytes 11-15)
-  // + bottom I4 (A,B) + 3 leaves
-  verifier.assert_node_counts({3, 4, 0, 0, 0});
+  // + bottom I4 (A,B) + chain I4 for C's suffix + 3 leaves
+  verifier.assert_node_counts({3, 5, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -349,8 +349,9 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveFromChainLeavesInode) {
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  // Root I4 (2 children: key3 leaf + chain) + chain I4 + 2 leaves
-  verifier.assert_node_counts({2, 2, 0, 0, 0});
+  // Root I4 (2 children: key3 chain + key2 chain) + chain I4 for key3
+  // suffix + chain I4 for shared prefix + 2 leaves
+  verifier.assert_node_counts({2, 3, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -547,8 +548,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MixedLengthKeysLongPrefix) {
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  // chain I4 + bottom I4 (2 children) + 2 leaves
-  verifier.assert_node_counts({2, 2, 0, 0, 0});
+  // chain I4 + divergence I4 + chain I4 for shorter key's suffix + 2 leaves
+  verifier.assert_node_counts({2, 3, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -727,13 +728,14 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI4) {
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
   verifier.insert(make_short_key(enc, 0x01), val);
-  // root I4(2: 0x42→chain, 0x01→leaf) + chain I4 + bottom I4 + 3 leaves
-  verifier.assert_node_counts({3, 3, 0, 0, 0});
+  // root I4(2: 0x42→chain, 0x01→bare leaf) + chain I4 + bottom I4 + 3 leaves
+  // Short key (1 byte) has no suffix → no chain wrapper.
+  verifier.assert_node_counts({3, 2, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
   // Root I4 still has 2 children.
-  verifier.assert_node_counts({2, 2, 0, 0, 0});
+  verifier.assert_node_counts({2, 1, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 2));
   verifier.check_present_values();
@@ -754,7 +756,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI16) {
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
   // root I16(5) + chain I4 + bottom I4 + 6 leaves
-  verifier.assert_node_counts({6, 2, 1, 0, 0});
+  // Short keys (1 byte) have no suffix → no chain wrappers → I4=1 not 2.
+  verifier.assert_node_counts({6, 1, 1, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -776,7 +779,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI48) {
   for (std::uint8_t t = 0x01; t <= 0x10; ++t)
     verifier.insert(make_short_key(enc, t), val);
   // root I48(17) + chain I4 + bottom I4 + 18 leaves
-  verifier.assert_node_counts({18, 2, 0, 1, 0});
+  verifier.assert_node_counts({18, 1, 0, 1, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -797,7 +800,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI256) {
   for (std::uint8_t t = 0x01; t <= 0x30; ++t)
     verifier.insert(make_short_key(enc, t), val);
   // root I256(49) + chain I4 + bottom I4 + 50 leaves
-  verifier.assert_node_counts({50, 2, 0, 0, 1});
+  verifier.assert_node_counts({50, 1, 0, 0, 1});
 
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.remove(make_key(enc, 0x42, 2));
@@ -888,8 +891,9 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainParentGrowthI4ToI16) {
   for (std::uint8_t t = 0x01; t <= 0x04; ++t)
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
-  // root I16(5: 0x42→chain, 0x01..0x04→leaves) + chain-I4 + bottom-I4
-  verifier.assert_node_counts({6, 2, 1, 0, 0});
+  // root I16(5: 0x42→chain, 0x01..0x04→bare leaves) + chain-I4 + bottom-I4
+  // Short keys have no suffix → no chain wrappers → I4=1.
+  verifier.assert_node_counts({6, 1, 1, 0, 0});
 }
 
 /// Parent I16→I48 growth with a chain child.
@@ -904,7 +908,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainParentGrowthI16ToI48) {
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
   // root I48(17) + chain-I4 + bottom-I4
-  verifier.assert_node_counts({18, 2, 0, 1, 0});
+  verifier.assert_node_counts({18, 1, 0, 1, 0});
 }
 
 /// Parent I48→I256 growth with a chain child.
@@ -919,7 +923,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainParentGrowthI48ToI256) {
     verifier.insert(make_short_key(enc, t), val);
   verifier.check_present_values();
   // root I256(49) + chain-I4 + bottom-I4
-  verifier.assert_node_counts({50, 2, 0, 0, 1});
+  verifier.assert_node_counts({50, 1, 0, 0, 1});
 }
 
 // -------------------------------------------------------------------
@@ -1589,7 +1593,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ScanChainMixedLengths) {
   verifier.insert(make_long_key(enc, 0x42, 4, 0x01), val);
   // check_present_values does a full scan + per-key probe.
   verifier.check_present_values();
-  verifier.assert_node_counts({4, 2, 0, 0, 0});
+  // Chain I4 (prefix) + divergence I4 + chain I4s for each key's suffix
+  verifier.assert_node_counts({4, 4, 0, 0, 0});
 
   // Remove a 10-byte key, verify scan still works.
   verifier.remove(make_long_key(enc, 0x42, 3, 0x01));

--- a/test/test_art_key_view_full_chain.cpp
+++ b/test/test_art_key_view_full_chain.cpp
@@ -9,11 +9,13 @@
 // IWYU pragma: no_include <string>
 // IWYU pragma: no_include <string_view>
 
+#include <algorithm>
 #include <cstddef>  // IWYU pragma: keep
 #include <cstdint>
 #include <limits>
 #include <stdexcept>
 #include <tuple>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -1606,5 +1608,176 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ScanChainMixedLengths) {
 }
 
 #endif  // UNODB_DETAIL_WITH_STATS
+
+// ===================================================================
+// Stack structure validation tests (D5).
+//
+// Verify that the iterator stack encodes the full key in the inode
+// path for can_eliminate_leaf trees (Mode 3).  At each leaf position,
+// the concatenation of (prefix + dispatch_byte) across inode entries
+// must equal the full encoded key.
+// ===================================================================
+
+template <class Db>
+void verify_stack(typename Db::iterator& it, unodb::key_view expected_key) {
+  ASSERT_TRUE(it.valid());
+  auto stk = it.test_only_stack();
+  ASSERT_GE(stk.size(), 1U) << "Stack must have at least a leaf";
+
+  EXPECT_EQ(stk.back().node.type(), unodb::node_type::LEAF)
+      << "Top of stack must be a leaf";
+
+  for (std::size_t i = 0; i + 1 < stk.size(); ++i) {
+    EXPECT_NE(stk[i].node.type(), unodb::node_type::LEAF)
+        << "Entry " << i << " should be an inode";
+  }
+
+  // Reconstruct key from inode prefix+dispatch bytes.
+  std::vector<std::byte> reconstructed;
+  for (std::size_t i = 0; i + 1 < stk.size(); ++i) {
+    auto prefix = stk[i].prefix.get_key_view();
+    for (std::size_t j = 0; j < prefix.size(); ++j)
+      reconstructed.push_back(prefix[j]);
+    reconstructed.push_back(stk[i].key_byte);
+  }
+  ASSERT_EQ(reconstructed.size(), expected_key.size())
+      << "Reconstructed key length mismatch";
+  for (std::size_t i = 0; i < reconstructed.size(); ++i) {
+    EXPECT_EQ(reconstructed[i], expected_key[i])
+        << "Key byte mismatch at position " << i;
+  }
+}
+
+/// Two keys sharing a long prefix (chain structure).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureTwoChainKeys) {
+  TypeParam db;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  std::array<std::byte, 9> buf_a{};
+  std::array<std::byte, 9> buf_b{};
+  auto kv = enc.reset().encode(std::uint8_t{0x01})
+                .encode(std::uint64_t{100}).get_key_view();
+  std::ranges::copy(kv, buf_a.begin());
+  kv = enc.reset().encode(std::uint8_t{0x01})
+           .encode(std::uint64_t{200}).get_key_view();
+  std::ranges::copy(kv, buf_b.begin());
+
+  const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
+  const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
+
+  db.insert(key_a, val);
+  db.insert(key_b, val);
+
+  auto it = db.test_only_iterator();
+  it.first();
+  verify_stack<TypeParam>(it, it.get_key());
+  it.next();
+  if (it.valid()) verify_stack<TypeParam>(it, it.get_key());
+}
+
+/// Three keys with different first bytes (wide I4, no chain).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureWideNode) {
+  TypeParam db;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  std::array<std::byte, 1> ba{}, bb{}, bc{};
+  auto kv = enc.reset().encode(std::uint8_t{0x10}).get_key_view();
+  std::ranges::copy(kv, ba.begin());
+  kv = enc.reset().encode(std::uint8_t{0x20}).get_key_view();
+  std::ranges::copy(kv, bb.begin());
+  kv = enc.reset().encode(std::uint8_t{0x30}).get_key_view();
+  std::ranges::copy(kv, bc.begin());
+
+  const auto ka = unodb::key_view{ba.data(), ba.size()};
+  const auto kb = unodb::key_view{bb.data(), bb.size()};
+  const auto kc = unodb::key_view{bc.data(), bc.size()};
+
+  db.insert(ka, val);
+  db.insert(kb, val);
+  db.insert(kc, val);
+
+  auto it = db.test_only_iterator();
+  for (it.first(); it.valid(); it.next())
+    verify_stack<TypeParam>(it, it.get_key());
+}
+
+/// Second insert with different tag must also create a full chain.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureSecondInsertChain) {
+  TypeParam db;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  std::array<std::byte, 9> buf_a{};
+  std::array<std::byte, 9> buf_b{};
+  auto kv = enc.reset().encode(std::uint8_t{0x01})
+                .encode(std::uint64_t{0}).get_key_view();
+  std::ranges::copy(kv, buf_a.begin());
+  kv = enc.reset().encode(std::uint8_t{0x02})
+           .encode(std::uint64_t{0}).get_key_view();
+  std::ranges::copy(kv, buf_b.begin());
+
+  const auto ka = unodb::key_view{buf_a.data(), buf_a.size()};
+  const auto kb = unodb::key_view{buf_b.data(), buf_b.size()};
+
+  db.insert(ka, val);
+  db.insert(kb, val);
+
+  auto it = db.test_only_iterator();
+  for (it.first(); it.valid(); it.next())
+    verify_stack<TypeParam>(it, it.get_key());
+}
+
+/// Forward and reverse scan, verify stack at every position.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureFullScan) {
+  TypeParam db;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  struct kh {
+    std::array<std::byte, 18> buf{};
+    unodb::key_view kv;
+  };
+  auto make = [&](std::uint8_t tag, std::uint64_t v) {
+    kh h;
+    auto k = enc.reset().encode(tag).encode(v).get_key_view();
+    std::ranges::copy(k, h.buf.begin());
+    h.kv = unodb::key_view{h.buf.data(), k.size()};
+    return h;
+  };
+
+  auto k1 = make(0x01, 100);
+  auto k2 = make(0x01, 200);
+  auto k3 = make(0x02, 300);
+  auto k4 = make(0x03, 0);
+
+  db.insert(k1.kv, val);
+  db.insert(k2.kv, val);
+  db.insert(k3.kv, val);
+  db.insert(k4.kv, val);
+
+  // Forward scan.
+  {
+    auto it = db.test_only_iterator();
+    int count = 0;
+    for (it.first(); it.valid(); it.next()) {
+      verify_stack<TypeParam>(it, it.get_key());
+      ++count;
+    }
+    EXPECT_EQ(count, 4);
+  }
+
+  // Reverse scan.
+  {
+    auto it = db.test_only_iterator();
+    int count = 0;
+    for (it.last(); it.valid(); it.prior()) {
+      verify_stack<TypeParam>(it, it.get_key());
+      ++count;
+    }
+    EXPECT_EQ(count, 4);
+  }
+}
 
 }  // namespace

--- a/test/test_art_key_view_full_chain.cpp
+++ b/test/test_art_key_view_full_chain.cpp
@@ -31,10 +31,9 @@ class ARTKeyViewFullChainTest : public ::testing::Test {
   using Test::Test;
 };
 
-using ARTTypes =
-    ::testing::Types<unodb::test::key_view_u64val_db,
-                     unodb::test::key_view_u64val_mutex_db,
-                     unodb::test::key_view_u64val_olc_db>;
+using ARTTypes = ::testing::Types<unodb::test::key_view_u64val_db,
+                                  unodb::test::key_view_u64val_mutex_db,
+                                  unodb::test::key_view_u64val_olc_db>;
 
 UNODB_TYPED_TEST_SUITE(ARTKeyViewFullChainTest, ARTTypes)
 
@@ -57,6 +56,39 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, TooLongKey) {
 #ifdef UNODB_DETAIL_WITH_STATS
   verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
+}
+
+/// Minimal reproducer: two text keys into a keyless-leaf tree.
+/// Dumps the tree after each insert to diagnose CANNOT_HAPPEN.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, TwoKeyMinimalRepro) {
+  TypeParam db;
+  unodb::key_encoder enc;
+
+  auto k1 = enc.reset().encode_text("").get_key_view();
+  UNODB_ASSERT_TRUE(db.insert(k1, 100));
+
+  // Dump after first insert.
+  {
+    std::ostringstream oss;
+    db.dump(oss);
+    std::cerr << "=== After k1 (empty string), k1.size()=" << k1.size()
+              << " ===\n"
+              << oss.str();
+  }
+
+  auto k2 = enc.reset().encode_text("a").get_key_view();
+  std::cerr << "k2.size()=" << k2.size() << " bytes:";
+  for (std::size_t i = 0; i < k2.size(); ++i)
+    std::cerr << " " << static_cast<unsigned>(k2[i]);
+  std::cerr << "\n";
+
+  UNODB_ASSERT_TRUE(db.insert(k2, 200));
+
+  {
+    std::ostringstream oss;
+    db.dump(oss);
+    std::cerr << "=== After k2 (\"a\") ===\n" << oss.str();
+  }
 }
 
 /// Unit test inserts several string keys with proper encoding and
@@ -189,8 +221,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, NineByteCompoundKeysLongPrefix) {
 
 /// Keys identical except last byte — maximum chaining depth for 9-byte keys.
 /// 9-byte keys sharing 8 bytes, differing only at byte 8.
-UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
-                 CompoundKeysIdenticalExceptLastByte) {
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysIdenticalExceptLastByte) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
   const auto val = unodb::test::get_test_value<TypeParam>(0);
@@ -329,9 +360,9 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeysInsertThenRemove) {
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  // Bottom I4 collapsed via leave_last_child.  Chain I4 remains with
-  // 1 child (the surviving leaf).
-  verifier.assert_node_counts({1, 1, 0, 0, 0});
+  // For keyless leaves, the chain I4 above the leaf is NOT collapsed
+  // (collapsing would lose key bytes from the inode path).
+  verifier.assert_node_counts({1, 2, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -351,9 +382,10 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveFromChainLeavesInode) {
   verifier.remove(make_key(enc, 0x42, 1));
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  // Root I4 (2 children: key3 chain + key2 chain) + chain I4 for key3
-  // suffix + chain I4 for shared prefix + 2 leaves
-  verifier.assert_node_counts({2, 3, 0, 0, 0});
+  // Root I4 (2 children: key3 chain + key2 chain) + chain I4s for
+  // each key's suffix + 2 leaves.  Extra I4 because keyless leaf
+  // prevents collapse of the chain node above key2's leaf.
+  verifier.assert_node_counts({2, 4, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
@@ -462,8 +494,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, RemoveMixedLengthFromChain) {
   verifier.remove(make_long_key(enc, 0x42, 1, 0xFF));
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
-  // Chain I4 + 1 surviving leaf
-  verifier.assert_node_counts({1, 1, 0, 0, 0});
+  // Chain I4 + 1 surviving leaf.  Extra I4 for keyless leaf no-collapse.
+  verifier.assert_node_counts({1, 2, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
   verifier.remove(make_key(enc, 0x42, 2));
   verifier.assert_empty();
@@ -735,15 +767,13 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CascadeChainUnderI4) {
   verifier.assert_node_counts({3, 2, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 1));
-  // Bottom I4 collapsed via leave_last_child.  Chain I4 has 1 child (leaf).
-  // Root I4 still has 2 children.
-  verifier.assert_node_counts({2, 1, 0, 0, 0});
+  // Keyless leaf prevents collapse.  Chain I4 above surviving leaf stays.
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
 
   verifier.remove(make_key(enc, 0x42, 2));
   verifier.check_present_values();
-  // Chain fully reclaimed.  Root I4 at min_size(2) loses a child →
-  // leave_last_child → root becomes the surviving leaf.
-  verifier.assert_node_counts({1, 0, 0, 0, 0});
+  // Short key's leaf is under its own chain I4 (keyless, no collapse).
+  verifier.assert_node_counts({1, 1, 0, 0, 0});
 }
 
 /// Chain under I16(5 children).  Remove chain → I16 shrinks to I4.
@@ -866,8 +896,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChainRemoveAll) {
   verifier.assert_node_counts({2, 3, 0, 0, 0});
 
   verifier.remove(make17(0x01));
-  // Bottom I4 collapsed.  Two chain I4s remain, last one has 1 child (leaf).
-  verifier.assert_node_counts({1, 2, 0, 0, 0});
+  // Keyless leaf prevents collapse.  Three chain I4s remain.
+  verifier.assert_node_counts({1, 3, 0, 0, 0});
 
   verifier.remove(make17(0x02));
   verifier.assert_empty();
@@ -1147,9 +1177,15 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1CollapseToLeaf) {
   verifier.remove(make18(0x01, 0x00, 0x02));
   verifier.check_present_values();
 
-  // Remove A: chain cut (CD=1). Root I4(2→1) collapses to leaf(C).
+  // Remove A: chain cut (CD=1). Root I4(2→1).
+  // Surviving child is chain-I4 with 7-byte prefix.  Merge would be
+  // 0 + 1 + 7 = 8 > 7 → prefix overflow, no collapse.
+  // Tree: root-I4(1) → chain-I4 → leaf(C).
   verifier.remove(make18(0x01, 0x00, 0x01));
   verifier.check_present_values();
+#ifdef UNODB_DETAIL_WITH_STATS
+  verifier.assert_node_counts({1, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
 
   // Remove C: tree empty.
   verifier.remove(make18(0x02, 0x00, 0x01));
@@ -1502,6 +1538,113 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI256) {
   verifier.assert_shrinking_inodes({2, 0, 0, 1});
 }
 
+// T14: Keyless leaf no-collapse guard.
+// I4(2) where surviving child is a keyless leaf → collapse blocked.
+// Tree: root-I4(2: 0x01→chain→leaf(A), 0x02→chain→leaf(B))
+// Remove A → root-I4(2→1).  Surviving child is chain-I4 (inode),
+// but that chain's only child is a keyless leaf(B).  The chain-I4
+// itself is an inode, so can_collapse checks prefix overflow, not
+// the keyless guard.  However, the chain-I4 above leaf(B) is also
+// I4(1), and if IT were collapsed, the leaf would become root —
+// losing key bytes.  The no-collapse guard fires at the chain-I4
+// level, not at root.
+//
+// To test the guard directly: need I4(2) where one child is removed
+// and the other is directly a keyless leaf.  This requires a 1-byte
+// key (dispatch byte only, no chain above the leaf).
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, KeylessLeafNoCollapseGuard) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // Two 1-byte keys with different dispatch bytes.
+  std::array<std::byte, 1> buf_a{};
+  std::array<std::byte, 1> buf_b{};
+  auto kv = enc.reset().encode(std::uint8_t{0x01}).get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_a.begin());
+  kv = enc.reset().encode(std::uint8_t{0x02}).get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_b.begin());
+  const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
+  const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
+
+  verifier.insert(key_a, val);
+  verifier.insert(key_b, val);
+  verifier.check_present_values();
+
+#ifdef UNODB_DETAIL_WITH_STATS
+  // 2 leaves + root-I4.  1-byte keys have no prefix bytes, so no
+  // chain I4s are created — leaves go directly into root.
+  verifier.assert_node_counts({2, 1, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+
+  // Remove A.  Root-I4(2→1).  Surviving child is leaf(B) (keyless).
+  // can_collapse returns false (keyless leaf guard).  Root-I4(1) stays.
+  verifier.remove(key_a);
+  verifier.check_present_values();
+
+#ifdef UNODB_DETAIL_WITH_STATS
+  // Root-I4(1) + 1 leaf.  No collapse.
+  verifier.assert_node_counts({1, 1, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+
+  verifier.remove(key_b);
+  verifier.assert_empty();
+}
+
+// T15: Merge allowed when surviving child is an inode (not keyless leaf).
+// I4(2) where one child is a chain subtree, the other is an inode subtree.
+// Remove the chain → I4(2→1), surviving child is inode → collapse allowed.
+UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CollapseToInodeAllowed) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  unodb::key_encoder enc;
+  const auto val = unodb::test::get_test_value<TypeParam>(0);
+
+  // A: 9-byte key tag=0x01.
+  // B,C: 9-byte keys tag=0x02, different suffixes → I4(2) under 0x02.
+  std::array<std::byte, 9> buf_a{};
+  std::array<std::byte, 9> buf_b{};
+  std::array<std::byte, 9> buf_c{};
+  auto kv = enc.reset()
+                .encode(std::uint8_t{0x01})
+                .encode(std::uint64_t{0})
+                .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_a.begin());
+  kv = enc.reset()
+           .encode(std::uint8_t{0x02})
+           .encode(std::uint64_t{0})
+           .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_b.begin());
+  kv = enc.reset()
+           .encode(std::uint8_t{0x02})
+           .encode(std::uint64_t{1})
+           .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_c.begin());
+  const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
+  const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
+  const auto key_c = unodb::key_view{buf_c.data(), buf_c.size()};
+
+  verifier.insert(key_a, val);
+  verifier.insert(key_b, val);
+  verifier.insert(key_c, val);
+  verifier.check_present_values();
+
+  // Remove A.  Root-I4(2→1).  Surviving child under 0x02 is an I4(2)
+  // (inode, not leaf).  Prefix merge fits → collapse allowed.
+  verifier.remove(key_a);
+  verifier.check_present_values();
+
+#ifdef UNODB_DETAIL_WITH_STATS
+  // After collapse: root-I4 merged into chain-I4 (prefix overflow
+  // prevents further collapse into bottom-I4).
+  // Root-chain-I4(1 child) + bottom-I4(2 children) + 2 leaves.
+  verifier.assert_node_counts({2, 2, 0, 0, 0});
+#endif  // UNODB_DETAIL_WITH_STATS
+
+  verifier.remove(key_b);
+  verifier.remove(key_c);
+  verifier.assert_empty();
+}
+
 // -------------------------------------------------------------------
 // Verify tree structures used by concurrent chain cut tests (CT1-CT4).
 // These confirm the chain depth and that insert/remove work correctly
@@ -1656,24 +1799,28 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureTwoChainKeys) {
 
   std::array<std::byte, 9> buf_a{};
   std::array<std::byte, 9> buf_b{};
-  auto kv = enc.reset().encode(std::uint8_t{0x01})
-                .encode(std::uint64_t{100}).get_key_view();
-  std::ranges::copy(kv, buf_a.begin());
-  kv = enc.reset().encode(std::uint8_t{0x01})
-           .encode(std::uint64_t{200}).get_key_view();
-  std::ranges::copy(kv, buf_b.begin());
+  auto kv = enc.reset()
+                .encode(std::uint8_t{0x01})
+                .encode(std::uint64_t{100})
+                .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_a.begin());
+  kv = enc.reset()
+           .encode(std::uint8_t{0x01})
+           .encode(std::uint64_t{200})
+           .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_b.begin());
 
   const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
   const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
 
-  db.insert(key_a, val);
-  db.insert(key_b, val);
+  std::ignore = db.insert(key_a, val);
+  std::ignore = db.insert(key_b, val);
 
   auto it = db.test_only_iterator();
   it.first();
-  verify_stack<TypeParam>(it, it.get_key());
+  verify_stack<TypeParam>(it, it.get_key().view());
   it.next();
-  if (it.valid()) verify_stack<TypeParam>(it, it.get_key());
+  if (it.valid()) verify_stack<TypeParam>(it, it.get_key().view());
 }
 
 /// Three keys with different first bytes (wide I4, no chain).
@@ -1684,23 +1831,23 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureWideNode) {
 
   std::array<std::byte, 1> ba{}, bb{}, bc{};
   auto kv = enc.reset().encode(std::uint8_t{0x10}).get_key_view();
-  std::ranges::copy(kv, ba.begin());
+  std::ignore = std::ranges::copy(kv, ba.begin());
   kv = enc.reset().encode(std::uint8_t{0x20}).get_key_view();
-  std::ranges::copy(kv, bb.begin());
+  std::ignore = std::ranges::copy(kv, bb.begin());
   kv = enc.reset().encode(std::uint8_t{0x30}).get_key_view();
-  std::ranges::copy(kv, bc.begin());
+  std::ignore = std::ranges::copy(kv, bc.begin());
 
   const auto ka = unodb::key_view{ba.data(), ba.size()};
   const auto kb = unodb::key_view{bb.data(), bb.size()};
   const auto kc = unodb::key_view{bc.data(), bc.size()};
 
-  db.insert(ka, val);
-  db.insert(kb, val);
-  db.insert(kc, val);
+  std::ignore = db.insert(ka, val);
+  std::ignore = db.insert(kb, val);
+  std::ignore = db.insert(kc, val);
 
   auto it = db.test_only_iterator();
   for (it.first(); it.valid(); it.next())
-    verify_stack<TypeParam>(it, it.get_key());
+    verify_stack<TypeParam>(it, it.get_key().view());
 }
 
 /// Second insert with different tag must also create a full chain.
@@ -1711,22 +1858,26 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureSecondInsertChain) {
 
   std::array<std::byte, 9> buf_a{};
   std::array<std::byte, 9> buf_b{};
-  auto kv = enc.reset().encode(std::uint8_t{0x01})
-                .encode(std::uint64_t{0}).get_key_view();
-  std::ranges::copy(kv, buf_a.begin());
-  kv = enc.reset().encode(std::uint8_t{0x02})
-           .encode(std::uint64_t{0}).get_key_view();
-  std::ranges::copy(kv, buf_b.begin());
+  auto kv = enc.reset()
+                .encode(std::uint8_t{0x01})
+                .encode(std::uint64_t{0})
+                .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_a.begin());
+  kv = enc.reset()
+           .encode(std::uint8_t{0x02})
+           .encode(std::uint64_t{0})
+           .get_key_view();
+  std::ignore = std::ranges::copy(kv, buf_b.begin());
 
   const auto ka = unodb::key_view{buf_a.data(), buf_a.size()};
   const auto kb = unodb::key_view{buf_b.data(), buf_b.size()};
 
-  db.insert(ka, val);
-  db.insert(kb, val);
+  std::ignore = db.insert(ka, val);
+  std::ignore = db.insert(kb, val);
 
   auto it = db.test_only_iterator();
   for (it.first(); it.valid(); it.next())
-    verify_stack<TypeParam>(it, it.get_key());
+    verify_stack<TypeParam>(it, it.get_key().view());
 }
 
 /// Forward and reverse scan, verify stack at every position.
@@ -1737,13 +1888,16 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureFullScan) {
 
   struct kh {
     std::array<std::byte, 18> buf{};
-    unodb::key_view kv;
+    std::size_t len{};
+    [[nodiscard]] unodb::key_view kv() const {
+      return {buf.data(), len};
+    }
   };
   auto make = [&](std::uint8_t tag, std::uint64_t v) {
     kh h;
     auto k = enc.reset().encode(tag).encode(v).get_key_view();
-    std::ranges::copy(k, h.buf.begin());
-    h.kv = unodb::key_view{h.buf.data(), k.size()};
+    std::ignore = std::ranges::copy(k, h.buf.begin());
+    h.len = k.size();
     return h;
   };
 
@@ -1752,17 +1906,17 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureFullScan) {
   auto k3 = make(0x02, 300);
   auto k4 = make(0x03, 0);
 
-  db.insert(k1.kv, val);
-  db.insert(k2.kv, val);
-  db.insert(k3.kv, val);
-  db.insert(k4.kv, val);
+  std::ignore = db.insert(k1.kv(), val);
+  std::ignore = db.insert(k2.kv(), val);
+  std::ignore = db.insert(k3.kv(), val);
+  std::ignore = db.insert(k4.kv(), val);
 
   // Forward scan.
   {
     auto it = db.test_only_iterator();
     int count = 0;
     for (it.first(); it.valid(); it.next()) {
-      verify_stack<TypeParam>(it, it.get_key());
+      verify_stack<TypeParam>(it, it.get_key().view());
       ++count;
     }
     EXPECT_EQ(count, 4);
@@ -1773,7 +1927,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureFullScan) {
     auto it = db.test_only_iterator();
     int count = 0;
     for (it.last(); it.valid(); it.prior()) {
-      verify_stack<TypeParam>(it, it.get_key());
+      verify_stack<TypeParam>(it, it.get_key().view());
       ++count;
     }
     EXPECT_EQ(count, 4);

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -49,8 +49,8 @@ class allocation_failure_injector final {
   ///
   /// \note Do not call directly: use UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION()
   /// instead.
-  static void fail_on_nth_allocation(std::uint64_t n
-                                     UNODB_DETAIL_USED_IN_DEBUG) noexcept {
+  static void fail_on_nth_allocation(
+      std::uint64_t n UNODB_DETAIL_USED_IN_DEBUG) noexcept {
     fail_on_nth_allocation_.store(n, std::memory_order_release);
   }
 


### PR DESCRIPTION
When the key is a key_view, this PR ensures that the full key is present in the inode path to the leaf and no longer stores the key in the leaf.  

https://github.com/unodb-dev/unodb/issues/612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for variable-length keys with in-tree chain encoding; keyless/value-only leaf option
  * Added transient_key_view for scoped non-owning key access
  * Public chain-construction helper to encode long keys in the tree
* **API Changes**
  * Query results now return value_type instead of value_view
  * Iterator get_key()/get_val() signatures updated for key-view/keyless modes; test_only_stack() added
* **Benchmarks & Tests**
  * Expanded key_view benchmark suite; new tests and test targets for full-chain and concurrency
* **Other**
  * Added UNODB_DETAIL_RELOAD macro
<!-- end of auto-generated comment: release notes by coderabbit.ai -->