### PR TITLE
refactor(#837): decouple allocator from QSBR, make art_allocator.hpp header-only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -509,7 +509,10 @@ jobs:
       - name: Benchmark correctness test
         working-directory: ${{github.workspace}}/build
         run: make -k quick_benchmarks
-        if: env.STATIC_ANALYSIS != 'ON'
+        # TODO(#853): split benchmarks into phases instead of skipping
+        if: >
+          env.STATIC_ANALYSIS != 'ON' &&
+          env.SANITIZE_ADDRESS != 'ON'
 
       - name: DeepState 1 minute fuzzing
         working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,6 +712,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     "$<${use_boost_stacktrace}:UNODB_DETAIL_BOOST_STACKTRACE>"
     "$<${with_stats}:UNODB_DETAIL_WITH_STATS>"
     "$<${coverage_on}:UNODB_COVERAGE>"
+    "$<${is_not_release_genex}:UNODB_DETAIL_QSBR_DEBUG>"
     "UNODB_SPINLOCK_LOOP_VALUE=${SPINLOCK_LOOP_VALUE}")
   target_compile_options(${TARGET} PUBLIC
     # Architecture
@@ -823,7 +824,8 @@ if(LIBFUZZER_AVAILABLE)
   target_link_libraries(unodb_qsbr_lf PUBLIC unodb_util Threads::Threads)
 endif()
 
-add_unodb_library(unodb art.hpp art_common.hpp mutex_art.hpp optimistic_lock.hpp
+add_unodb_library(unodb art.hpp art_common.hpp art_allocator.hpp
+  mutex_art.hpp optimistic_lock.hpp
   art_internal_impl.hpp olc_art.hpp art_internal.hpp art_internal.cpp
   node_type.hpp duckdb_encode_decode.hpp)
 target_link_libraries(unodb PUBLIC unodb_util unodb_qsbr)

--- a/art.hpp
+++ b/art.hpp
@@ -25,6 +25,7 @@
 
 #include <boost/container/small_vector.hpp>
 
+#include "art_allocator.hpp"
 #include "art_common.hpp"
 #include "art_internal.hpp"
 #include "art_internal_impl.hpp"
@@ -130,12 +131,9 @@ class db final {
   /// The type of the value associated with the keys in the index.
   using value_type = Value;
 
-  /// View type for values stored in the index.
-  using value_view = unodb::value_view;
-
   /// Result type for get operations.
   ///
-  /// Contains value_view if key was found, otherwise empty.
+  /// Contains the value if key was found, otherwise empty.
   using get_result = std::optional<value_type>;
 
   /// Base class type for internal nodes.
@@ -206,8 +204,15 @@ class db final {
  public:
   // Creation and destruction
 
-  /// Construct empty ART index.
+  /// Construct empty ART index with default allocator.
   db() noexcept = default;
+
+  /// Construct empty ART index with a custom allocator.
+  constexpr explicit db(const allocator_type& alloc) noexcept
+      : allocator_{alloc} {
+    UNODB_DETAIL_ASSERT(allocator_.alloc != nullptr);
+    UNODB_DETAIL_ASSERT(allocator_.dealloc != nullptr);
+  }
 
   /// Destroy ART index, freeing all tree nodes.
   ~db() noexcept;
@@ -240,6 +245,11 @@ class db final {
   /// Return true iff the index is empty.
   [[nodiscard, gnu::pure]] bool empty() const noexcept {
     return root == nullptr;
+  }
+
+  /// Return the allocator used by this tree.
+  [[nodiscard]] constexpr const allocator_type& get_allocator() const noexcept {
+    return allocator_;
   }
 
   /// Insert a value under a key iff there is no entry for that key.
@@ -923,6 +933,9 @@ class db final {
 
   /// Root of the tree (nullptr if empty).
   detail::node_ptr root{nullptr};
+
+  /// Allocator for tree nodes.
+  allocator_type allocator_{detail::default_allocator};
 
 #ifdef UNODB_DETAIL_WITH_STATS
 

--- a/art_allocator.hpp
+++ b/art_allocator.hpp
@@ -1,0 +1,87 @@
+// Copyright 2026 UnoDB contributors
+#ifndef UNODB_DETAIL_ART_ALLOCATOR_HPP
+#define UNODB_DETAIL_ART_ALLOCATOR_HPP
+
+/// \file
+/// Pluggable allocator for ART trees (header-only, no QSBR dependency).
+///
+/// Trees accept an allocator_type at construction time.  The default
+/// allocator uses the built-in aligned heap (heap.hpp) with immediate
+/// deferred free.  OLC trees override defer_dealloc with a QSBR-based
+/// implementation.  External integrators can supply their own allocator
+/// to route allocations through a custom heap and deferred free through
+/// an external epoch-based GC system.
+///
+/// \see https://github.com/unodb-dev/unodb/issues/837
+
+// Should be the first include
+#include "global.hpp"
+
+#include <cstddef>
+
+#include "heap.hpp"
+
+namespace unodb {
+
+/// Callback invoked when a deferred deallocation is safe to execute.
+using destroy_callback_type = void (*)(void* ptr, std::size_t size, void* ctx);
+
+/// Pluggable allocator for ART trees.
+///
+/// All three function pointers must be non-null.  \a ctx is forwarded
+/// to every callback and may be nullptr.
+///
+/// \a defer_dealloc is called when a node is removed and cannot be freed
+/// immediately (concurrent readers may hold pointers).  For single-threaded
+/// trees the default calls \a destroy_callback immediately.  OLC trees
+/// replace this with QSBR-based deferred reclamation.
+struct allocator_type {
+  /// Allocate `size` bytes with the given `alignment`. May throw on failure.
+  void* (*alloc)(std::size_t size, std::size_t alignment, void* ctx);
+  /// Free a previously allocated block of `size` bytes at `ptr`.
+  void (*dealloc)(void* ptr, std::size_t size, void* ctx);
+  /// Schedule deferred deallocation of `ptr` (`size` bytes). Calls
+  /// `destroy_callback` when reclamation is safe.
+  void (*defer_dealloc)(void* ptr, std::size_t size,
+                        destroy_callback_type destroy_callback, void* ctx);
+  /// Opaque context forwarded to all callbacks.
+  void* ctx;
+};
+
+namespace detail {
+
+/// Default alloc: delegates to allocate_aligned (heap.hpp).
+inline void* default_alloc(std::size_t size, std::size_t alignment,
+                           void* /*ctx*/) {
+  return allocate_aligned(size, alignment);
+}
+
+/// Default dealloc: delegates to free_aligned (heap.hpp).
+inline void default_dealloc(void* ptr, std::size_t /*size*/,
+                            void* /*ctx*/) noexcept {
+  free_aligned(ptr);
+}
+
+/// Default defer_dealloc: immediate free via destroy_callback.
+/// Safe for db and mutex_db where no concurrent readers exist.
+inline void default_defer_dealloc(void* ptr, std::size_t size,
+                                  destroy_callback_type destroy_callback,
+                                  void* ctx) noexcept {
+  destroy_callback(ptr, size, ctx);
+}
+
+/// Default destroy callback: frees via default_dealloc.
+/// Passed as the destroy_callback argument to defer_dealloc.
+inline void default_destroy(void* ptr, std::size_t size, void* ctx) noexcept {
+  default_dealloc(ptr, size, ctx);
+}
+
+/// The default allocator instance (no QSBR, immediate free).
+inline constexpr allocator_type default_allocator{
+    &default_alloc, &default_dealloc, nullptr, nullptr};
+
+}  // namespace detail
+
+}  // namespace unodb
+
+#endif  // UNODB_DETAIL_ART_ALLOCATOR_HPP

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -38,6 +38,7 @@
 #include <arm_neon.h>
 #endif
 
+#include "art_allocator.hpp"
 #include "art_common.hpp"
 #include "art_internal.hpp"
 #include "assert.hpp"
@@ -318,16 +319,12 @@ class [[nodiscard]] basic_leaf final : public Header {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-#ifdef UNODB_DETAIL_WITH_STATS
-
   /// Return byte size of leaf data structure.
   ///
   /// \return Size in bytes
   [[nodiscard, gnu::pure]] constexpr auto get_size() const noexcept {
     return compute_size(key_size, value_size);
   }
-
-#endif  // UNODB_DETAIL_WITH_STATS
 
   /// Dump leaf contents to stream for debugging.
   ///
@@ -429,11 +426,10 @@ class [[nodiscard]] basic_leaf<no_key_tag, Header> final : public Header {
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
-#ifdef UNODB_DETAIL_WITH_STATS
+  /// Return byte size of keyless leaf data structure.
   [[nodiscard, gnu::pure]] constexpr auto get_size() const noexcept {
     return compute_size(value_size);
   }
-#endif
 
   /// Dump keyless leaf contents to stream for debugging.
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os,
@@ -523,8 +519,8 @@ template <typename Key, typename Value, template <typename, typename> class Db>
             leaf_val_bytes.size_bytes()));
   }
 
-  auto* const leaf_mem = static_cast<std::byte*>(
-      allocate_aligned(size, alignment_for_new<leaf_type>()));
+  auto* const leaf_mem = static_cast<std::byte*>(db.get_allocator().alloc(
+      size, alignment_for_new<leaf_type>(), db.get_allocator().ctx));
 
 #ifdef UNODB_DETAIL_WITH_STATS
   db.increment_leaf_count(size);
@@ -586,11 +582,9 @@ struct basic_inode_def final {
 template <class Db>
 inline void basic_db_leaf_deleter<Db>::operator()(
     leaf_type* to_delete) const noexcept {
-#ifdef UNODB_DETAIL_WITH_STATS
   const auto leaf_size = to_delete->get_size();
-#endif  // UNODB_DETAIL_WITH_STATS
-
-  free_aligned(to_delete);
+  const auto& alloc = db.get_allocator();
+  alloc.dealloc(to_delete, leaf_size, alloc.ctx);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   db.decrement_leaf_count(leaf_size);
@@ -602,7 +596,8 @@ inline void basic_db_inode_deleter<INode, Db>::operator()(
     INode* inode_ptr) noexcept {
   static_assert(std::is_trivially_destructible_v<INode>);
 
-  free_aligned(inode_ptr);
+  const auto& alloc = db.get_allocator();
+  alloc.dealloc(inode_ptr, sizeof(INode), alloc.ctx);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   db.template decrement_inode_count<INode>();
@@ -852,8 +847,10 @@ struct basic_art_policy final {
   [[nodiscard]] static auto make_db_inode_unique_ptr(db_type& db_instance
                                                      UNODB_DETAIL_LIFETIMEBOUND,
                                                      Args&&... args) {
-    auto* const inode_mem = static_cast<std::byte*>(
-        allocate_aligned(sizeof(INode), alignment_for_new<INode>()));
+    auto* const inode_mem =
+        static_cast<std::byte*>(db_instance.get_allocator().alloc(
+            sizeof(INode), alignment_for_new<INode>(),
+            db_instance.get_allocator().ctx));
 
 #ifdef UNODB_DETAIL_WITH_STATS
     db_instance.template increment_inode_count<INode>();

--- a/assert.hpp
+++ b/assert.hpp
@@ -168,6 +168,15 @@ assert_failure(const char* file, int line, const char* func,
 
 #endif  // !defined(NDEBUG)
 
+/// Assert that is only active when QSBR debug checking is enabled.
+/// Use for assertions that reference QSBR state (qsbr::instance(), etc.)
+/// which may not be available in builds without QSBR linked.
+#ifdef UNODB_DETAIL_QSBR_DEBUG
+#define UNODB_DETAIL_QSBR_ASSERT(condition) UNODB_DETAIL_ASSERT(condition)
+#else
+#define UNODB_DETAIL_QSBR_ASSERT(condition) ((void)0)
+#endif
+
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 }  // namespace unodb::detail

--- a/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
+++ b/fuzz_deepstate/test_qsbr_fuzz_deepstate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 Laurynas Biveinis
+// Copyright 2021-2026 UnoDB contributors
 
 #include "global.hpp"
 
@@ -200,6 +200,11 @@ void check_qsbr_pointer_on_dealloc(const void* ptr) noexcept {
 }
 #endif
 
+void fuzz_destroy_callback(void* ptr, std::size_t /*size*/,
+                           void* /*ctx*/) noexcept {
+  unodb::detail::free_aligned(ptr);
+}
+
 void deallocate_pointer(std::uint64_t* ptr) {
   ASSERT(!unodb::this_thread().is_qsbr_paused());
   ASSERT(*ptr == object_mem);
@@ -221,13 +226,9 @@ void deallocate_pointer(std::uint64_t* ptr) {
     bool op_completed;
     try {
       unodb::this_thread().on_next_epoch_deallocate(
-          ptr
-#ifdef UNODB_DETAIL_WITH_STATS
-          ,
-          sizeof(object_mem)
-#endif
+          ptr, sizeof(object_mem), &fuzz_destroy_callback, nullptr
 #ifndef NDEBUG
-              ,
+          ,
           check_qsbr_pointer_on_dealloc
 #endif
       );

--- a/mutex_art.hpp
+++ b/mutex_art.hpp
@@ -26,7 +26,6 @@ class mutex_db final {
   using key_type = Key;
   /// The type of the value associated with the keys in the index.
   using value_type = Value;
-  using value_view = unodb::value_view;
 
   /// If the search key was found, that is, the first pair member has a value,
   /// then the second member is a locked tree mutex which must be released ASAP
@@ -66,7 +65,18 @@ class mutex_db final {
 
  public:
   // Creation and destruction
+
+  /// Construct empty mutex-protected ART index with default allocator.
   mutex_db() noexcept = default;
+
+  /// Construct empty mutex-protected ART index with a custom allocator.
+  constexpr explicit mutex_db(const allocator_type& alloc) noexcept
+      : db_{alloc} {}
+
+  /// Return the allocator used by this tree.
+  [[nodiscard]] constexpr const allocator_type& get_allocator() const noexcept {
+    return db_.get_allocator();
+  }
 
   /// Query for a value associated with a key.
   ///

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -22,6 +22,7 @@
 
 #include <boost/container/small_vector.hpp>
 
+#include "art_allocator.hpp"
 #include "art_common.hpp"
 #include "art_internal.hpp"
 #include "art_internal_impl.hpp"
@@ -30,7 +31,6 @@
 #include "optimistic_lock.hpp"
 #include "portability_arch.hpp"
 #include "qsbr.hpp"
-#include "qsbr_ptr.hpp"
 #include "sync.hpp"
 
 namespace unodb {
@@ -39,6 +39,9 @@ template <typename Key, typename Value>
 class olc_db;
 
 namespace detail {
+
+/// OLC allocator with QSBR-based deferred reclamation (defined in qsbr.cpp).
+extern const allocator_type olc_default_allocator;
 
 /// Sync point: fires after chain locked, before acquiring cut_point_parent.
 inline sync_point sync_after_chain_locked;
@@ -157,8 +160,6 @@ using olc_leaf_unique_ptr =
 
 }  // namespace detail
 
-using qsbr_value_view = qsbr_ptr_span<const std::byte>;
-
 /// A thread-safe Adaptive Radix Tree that is synchronized using optimistic lock
 /// coupling. At any time, at most two directly-related tree nodes can be
 /// write-locked by the insert algorithm and three by the delete algorithm. The
@@ -172,10 +173,7 @@ class olc_db final {
   using key_type = Key;
   /// The type of the value associated with the key in the index.
   using value_type = Value;
-  using value_view = unodb::qsbr_value_view;
-  using get_result =
-      std::optional<std::conditional_t<std::is_same_v<Value, unodb::value_view>,
-                                       unodb::qsbr_value_view, value_type>>;
+  using get_result = std::optional<value_type>;
   using inode_base = detail::olc_inode_base<Key, Value>;
   using leaf_type = detail::olc_leaf_type<Key, Value>;
   using db_type = olc_db<Key, Value>;
@@ -204,7 +202,17 @@ class olc_db final {
 
  public:
   // Creation and destruction
+
+  /// Construct empty OLC ART index with default allocator.
   olc_db() noexcept = default;
+
+  /// Construct empty OLC ART index with a custom allocator.
+  constexpr explicit olc_db(const allocator_type& alloc) noexcept
+      : allocator_{alloc} {
+    UNODB_DETAIL_ASSERT(allocator_.alloc != nullptr);
+    UNODB_DETAIL_ASSERT(allocator_.dealloc != nullptr);
+    UNODB_DETAIL_ASSERT(allocator_.defer_dealloc != nullptr);
+  }
 
   ~olc_db() noexcept;
 
@@ -221,6 +229,11 @@ class olc_db final {
 
   /// Return true iff the tree is empty (no root leaf).
   [[nodiscard]] auto empty() const noexcept { return root == nullptr; }
+
+  /// Return the allocator used by this tree.
+  [[nodiscard]] constexpr const allocator_type& get_allocator() const noexcept {
+    return allocator_;
+  }
 
   /// Insert a value under a binary comparable key iff there is no entry for
   /// that key.
@@ -400,7 +413,7 @@ class olc_db final {
     /// \pre The iterator MUST be valid().
     [[nodiscard, gnu::pure]] auto get_val() const noexcept
         -> std::conditional_t<std::is_same_v<Value, unodb::value_view>,
-                              qsbr_value_view, value_type>;
+                              unodb::value_view, value_type>;
 
     /// Debugging
     // LCOV_EXCL_START
@@ -950,6 +963,10 @@ class olc_db final {
   static_assert(sizeof(root_pointer_lock) + sizeof(root) <=
                 detail::hardware_constructive_interference_size);
 
+  /// Allocator for tree nodes (cold — read only at deallocation time).
+  alignas(detail::hardware_destructive_interference_size)
+      allocator_type allocator_{detail::olc_default_allocator};
+
 #ifdef UNODB_DETAIL_WITH_STATS
 
   // Current logically allocated memory that is not scheduled to be reclaimed.
@@ -1022,16 +1039,8 @@ class db_inode_qsbr_deleter
   void operator()(INode* inode_ptr) noexcept {
     static_assert(std::is_trivially_destructible_v<INode>);
 
-    this_thread().on_next_epoch_deallocate(inode_ptr
-#ifdef UNODB_DETAIL_WITH_STATS
-                                           ,
-                                           sizeof(INode)
-#endif
-#ifndef NDEBUG
-                                               ,
-                                           olc_node_header::check_on_dealloc
-#endif
-    );
+    const auto& alloc = this->get_db().get_allocator();
+    alloc.defer_dealloc(inode_ptr, sizeof(INode), &default_destroy, alloc.ctx);
 
 #ifdef UNODB_DETAIL_WITH_STATS
     this->get_db().template decrement_inode_count<INode>();
@@ -1055,20 +1064,9 @@ class db_leaf_qsbr_deleter {
 
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
   void operator()(leaf_type* to_delete) const noexcept {
-#ifdef UNODB_DETAIL_WITH_STATS
     const auto leaf_size = to_delete->get_size();
-#endif  // UNODB_DETAIL_WITH_STATS
-
-    this_thread().on_next_epoch_deallocate(to_delete
-#ifdef UNODB_DETAIL_WITH_STATS
-                                           ,
-                                           leaf_size
-#endif  // UNODB_DETAIL_WITH_STATS
-#ifndef NDEBUG
-                                           ,
-                                           olc_node_header::check_on_dealloc
-#endif
-    );
+    const auto& alloc = db_instance.get_allocator();
+    alloc.defer_dealloc(to_delete, leaf_size, &default_destroy, alloc.ctx);
 
 #ifdef UNODB_DETAIL_WITH_STATS
     db_instance.decrement_leaf_count(leaf_size);
@@ -2054,7 +2052,7 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 template <typename Key, typename Value>
 olc_db<Key, Value>::~olc_db() noexcept {
-  UNODB_DETAIL_ASSERT(
+  UNODB_DETAIL_QSBR_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
 
   delete_root_subtree();
@@ -2062,7 +2060,7 @@ olc_db<Key, Value>::~olc_db() noexcept {
 
 template <typename Key, typename Value>
 void olc_db<Key, Value>::delete_root_subtree() noexcept {
-  UNODB_DETAIL_ASSERT(
+  UNODB_DETAIL_QSBR_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
 
   if (root != nullptr) art_policy::delete_subtree(root, *this);
@@ -2077,7 +2075,7 @@ void olc_db<Key, Value>::delete_root_subtree() noexcept {
 
 template <typename Key, typename Value>
 void olc_db<Key, Value>::clear() noexcept {
-  UNODB_DETAIL_ASSERT(
+  UNODB_DETAIL_QSBR_ASSERT(
       qsbr_state::single_thread_mode(qsbr::instance().get_state()));
 
   delete_root_subtree();
@@ -3730,7 +3728,7 @@ UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 template <typename Key, typename Value>
 auto olc_db<Key, Value>::iterator::get_val() const noexcept
     -> std::conditional_t<std::is_same_v<Value, unodb::value_view>,
-                          qsbr_value_view, value_type> {
+                          unodb::value_view, value_type> {
   // Note: If the iterator is on a leaf, we return the value for
   // that leaf regardless of whether the leaf has been deleted.
   // This is part of the design semantics for the OLC ART scan.
@@ -3746,7 +3744,7 @@ auto olc_db<Key, Value>::iterator::get_val() const noexcept
     UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);      // On a leaf.
     const auto* const leaf{node.template ptr<leaf_type*>()};  // current leaf.
     if constexpr (std::is_same_v<Value, unodb::value_view>)
-      return qsbr_ptr_span{leaf->get_value_view()};
+      return leaf->get_value_view();
     else
       return leaf->template get_value<Value>();
   }

--- a/qsbr.cpp
+++ b/qsbr.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2025 UnoDB contributors
+// Copyright 2019-2026 UnoDB contributors
 
 /// \file
 /// QSBR implementation details.
@@ -15,6 +15,7 @@
 // IWYU pragma: no_include <__hash_table>
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <iostream>
@@ -22,6 +23,7 @@
 #include <new>  // IWYU pragma: keep
 #include <utility>
 
+#include "art_allocator.hpp"
 #include "qsbr.hpp"
 
 #ifdef UNODB_DETAIL_WITH_STATS
@@ -124,7 +126,7 @@ UNODB_DETAIL_DISABLE_GCC_WARNING("-Wsuggest-attribute=cold")
 
 UNODB_DETAIL_RESTORE_GCC_WARNINGS()
 
-#ifndef NDEBUG
+#ifdef UNODB_DETAIL_QSBR_DEBUG
 
 namespace detail {
 
@@ -132,6 +134,10 @@ namespace detail {
 constinit std::atomic<std::uint64_t> deallocation_request::instance_count{0};
 
 }  // namespace detail
+
+#endif  // UNODB_DETAIL_QSBR_DEBUG
+
+#ifndef NDEBUG
 
 void qsbr_per_thread::register_active_ptr(const void* ptr) {
   UNODB_DETAIL_ASSERT(ptr != nullptr);
@@ -533,3 +539,34 @@ qsbr_epoch qsbr::change_epoch(qsbr_epoch current_global_epoch,
 }
 
 }  // namespace unodb
+
+// OLC default allocator — defined here so that olc_art.hpp does not pull
+// QSBR link dependencies into TUs that use olc_db with a custom allocator.
+
+namespace unodb::detail {
+
+namespace {
+
+void qsbr_defer_dealloc(void* ptr, std::size_t size,
+                        destroy_callback_type destroy_callback,
+                        void* ctx) noexcept(false) {
+  this_thread().on_next_epoch_deallocate(ptr, size, destroy_callback, ctx
+#ifndef NDEBUG
+                                         ,
+                                         nullptr
+#endif
+  );
+}
+
+}  // namespace
+
+// Declared in olc_art.hpp, defined here to keep QSBR out of art_allocator.hpp.
+extern const allocator_type olc_default_allocator;
+
+extern const allocator_type olc_default_allocator{
+    .alloc = &default_alloc,
+    .dealloc = &default_dealloc,
+    .defer_dealloc = &qsbr_defer_dealloc,
+    .ctx = nullptr};
+
+}  // namespace unodb::detail

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2025 UnoDB contributors
+// Copyright 2019-2026 UnoDB contributors
 #ifndef UNODB_DETAIL_QSBR_HPP
 #define UNODB_DETAIL_QSBR_HPP
 
@@ -450,6 +450,10 @@ struct qsbr_state {
 
 namespace detail {
 
+/// Function type for destroy callbacks invoked when deferred deallocation is
+/// safe.  Matches the signature in art_allocator.hpp.
+using destroy_callback_type = void (*)(void* ptr, std::size_t size, void* ctx);
+
 /// Pending deallocation request for QSBR-managed memory.
 class [[nodiscard]] deallocation_request final {
  public:
@@ -459,24 +463,31 @@ class [[nodiscard]] deallocation_request final {
   using debug_callback = std::function<void(const void*)>;
 #endif
 
-  /// Create a new deallocation request for \a pointer_. In debug builds also
-  /// pass \a request_epoch_ and \a dealloc_callback_ to be executed during
-  /// deallocation.
-  explicit deallocation_request(void* pointer_ UNODB_DETAIL_LIFETIMEBOUND
+  /// Create a new deallocation request for \a pointer_. Also stores the
+  /// \a destroy_callback_, \a size_, and \a ctx_ needed to perform the actual
+  /// deallocation when the epoch advances. In debug builds also pass
+  /// \a request_epoch_ and \a dealloc_callback_ for diagnostics.
+  explicit deallocation_request(void* pointer_ UNODB_DETAIL_LIFETIMEBOUND,
+                                std::size_t size_,
+                                destroy_callback_type destroy_callback_,
+                                void* ctx_
 #ifndef NDEBUG
                                 ,
                                 qsbr_epoch request_epoch_,
                                 debug_callback dealloc_callback_
 #endif
                                 ) noexcept
-      : pointer{pointer_}
+      : pointer{pointer_},
+        size{size_},
+        destroy_callback{destroy_callback_},
+        ctx{ctx_}
 #ifndef NDEBUG
         ,
         dealloc_callback{std::move(dealloc_callback_)},
         request_epoch{request_epoch_}
 #endif
   {
-#ifndef NDEBUG
+#ifdef UNODB_DETAIL_QSBR_DEBUG
     instance_count.fetch_add(1, std::memory_order_relaxed);
 #endif
   }
@@ -511,7 +522,7 @@ class [[nodiscard]] deallocation_request final {
   /// Move assignment is disabled.
   deallocation_request& operator=(deallocation_request&&) = delete;
 
-#ifndef NDEBUG
+#ifdef UNODB_DETAIL_QSBR_DEBUG
   /// Assert that no instances of this class exist, indicating unhandled
   /// requests.
   static void assert_zero_instances() noexcept {
@@ -524,6 +535,18 @@ class [[nodiscard]] deallocation_request final {
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   void* const pointer;
 
+  /// Size of the allocation.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  const std::size_t size;
+
+  /// Callback to invoke when deallocation is safe.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  const destroy_callback_type destroy_callback;
+
+  /// Allocator context passed to destroy_callback.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  void* const ctx;
+
 #ifndef NDEBUG
   /// Debug build only: callback to execute during deallocation.
   // Non-const to support move
@@ -532,8 +555,10 @@ class [[nodiscard]] deallocation_request final {
   /// Debug build only: epoch when this deallocation request was created.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const qsbr_epoch request_epoch;
+#endif
 
-  /// Debug build only: global count of active deallocation request instances.
+#ifdef UNODB_DETAIL_QSBR_DEBUG
+  /// QSBR debug only: global count of active deallocation request instances.
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static std::atomic<std::uint64_t> instance_count;
 #endif
@@ -722,18 +747,15 @@ class [[nodiscard]] qsbr_per_thread final {
   /// Request deallocation of \a pointer when it is safe to do so.
   ///
   /// \param pointer Memory to deallocate
-#ifdef UNODB_DETAIL_WITH_STATS
-  /// \param size Size of the memory, for statistics
-#endif
+  /// \param size Size of the allocation
+  /// \param destroy_callback Callback to invoke when deallocation is safe
+  /// \param ctx Allocator context for the callback
 #ifndef NDEBUG
   /// \param dealloc_callback Debug callback to execute during deallocation
 #endif
   void on_next_epoch_deallocate(
-      void* pointer
-#ifdef UNODB_DETAIL_WITH_STATS
-      ,
-      std::size_t size
-#endif
+      void* pointer, std::size_t size,
+      detail::destroy_callback_type destroy_callback, void* ctx
 #ifndef NDEBUG
       ,
       detail::deallocation_request::debug_callback dealloc_callback
@@ -1076,7 +1098,9 @@ class qsbr final {
     // last thread a couple more times at the end.
     UNODB_DETAIL_ASSERT(previous_interval_orphaned_requests_empty());
     UNODB_DETAIL_ASSERT(current_interval_orphaned_requests_empty());
+#ifdef UNODB_DETAIL_QSBR_DEBUG
     detail::deallocation_request::assert_zero_instances();
+#endif
 #endif
   }
 
@@ -1110,7 +1134,8 @@ class qsbr final {
   /// In debug builds, call \a debug_callback at the actual deallocation time.
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26447)
   static void deallocate(
-      void* pointer
+      void* pointer, std::size_t size,
+      detail::destroy_callback_type destroy_callback, void* ctx
 #ifndef NDEBUG
       ,
       const detail::deallocation_request::debug_callback& debug_callback
@@ -1119,7 +1144,7 @@ class qsbr final {
 #ifndef NDEBUG
     if (debug_callback != nullptr) debug_callback(pointer);
 #endif
-    detail::free_aligned(pointer);
+    destroy_callback(pointer, size, ctx);
   }
   UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
@@ -1265,11 +1290,8 @@ inline qsbr_per_thread::qsbr_per_thread()
 UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
 inline void qsbr_per_thread::on_next_epoch_deallocate(
-    void* pointer
-#ifdef UNODB_DETAIL_WITH_STATS
-    ,
-    std::size_t size
-#endif
+    void* pointer, std::size_t size,
+    detail::destroy_callback_type destroy_callback, void* ctx
 #ifndef NDEBUG
     ,
     detail::deallocation_request::debug_callback dealloc_callback
@@ -1284,7 +1306,7 @@ inline void qsbr_per_thread::on_next_epoch_deallocate(
 
   if (UNODB_DETAIL_UNLIKELY(single_thread_mode)) {
     advance_last_seen_epoch(single_thread_mode, current_global_epoch);
-    qsbr::deallocate(pointer
+    qsbr::deallocate(pointer, size, destroy_callback, ctx
 #ifndef NDEBUG
                      ,
                      dealloc_callback
@@ -1295,7 +1317,7 @@ inline void qsbr_per_thread::on_next_epoch_deallocate(
 
   if (last_seen_epoch != current_global_epoch) {
     detail::dealloc_request_vector new_current_requests;
-    new_current_requests.emplace_back(pointer
+    new_current_requests.emplace_back(pointer, size, destroy_callback, ctx
 #ifndef NDEBUG
                                       ,
                                       current_global_epoch,
@@ -1312,11 +1334,11 @@ inline void qsbr_per_thread::on_next_epoch_deallocate(
     return;
   }
 
-  current_interval_dealloc_requests.emplace_back(pointer
+  current_interval_dealloc_requests.emplace_back(
+      pointer, size, destroy_callback, ctx
 #ifndef NDEBUG
-                                                 ,
-                                                 last_seen_epoch,
-                                                 std::move(dealloc_callback)
+      ,
+      last_seen_epoch, std::move(dealloc_callback)
 #endif
   );
 #ifdef UNODB_DETAIL_WITH_STATS
@@ -1457,14 +1479,14 @@ inline void deallocation_request::deallocate(
                          *dealloc_epoch == request_epoch.advance()) ||
                         *dealloc_epoch == request_epoch.advance(2))));
 
-  qsbr::deallocate(pointer
+  qsbr::deallocate(pointer, size, destroy_callback, ctx
 #ifndef NDEBUG
                    ,
                    dealloc_callback
 #endif
   );
 
-#ifndef NDEBUG
+#ifdef UNODB_DETAIL_QSBR_DEBUG
   instance_count.fetch_sub(1, std::memory_order_relaxed);
 #endif
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,6 +64,7 @@ add_db_test_target(test_art_key_view_full_chain)
 add_db_test_target(test_art_iter)
 add_db_test_target(test_art_scan)
 add_db_test_target(test_art_concurrency)
+add_db_test_target(test_art_allocator)
 # - Google Test with MSVC standard library tries to allocate memory in the
 # exception-thrown-as-expected-path.
 # - clang analyzer diagnoses potential memory leak in Google Test matcher
@@ -77,9 +78,24 @@ if (NOT MSVC AND NOT SANITIZE_ADDRESS AND NOT SANITIZE_THREAD
 endif()
 target_link_libraries(test_art_concurrency PRIVATE qsbr_test_utils)
 
+# Regression test: olc_db with custom allocator must link without libunodb_qsbr.
+# Intentionally links only unodb_util (header-only) and Threads, NOT unodb or
+# unodb_qsbr.  Does NOT use common_target_properties (which defines
+# UNODB_DETAIL_QSBR_DEBUG).  If this fails to link, the decoupling is broken.
+add_executable(test_olc_no_qsbr test_olc_no_qsbr.cpp)
+target_compile_features(test_olc_no_qsbr PUBLIC cxx_std_20)
+set_target_properties(test_olc_no_qsbr PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_definitions(test_olc_no_qsbr PRIVATE
+  "UNODB_SPINLOCK_LOOP_VALUE=${SPINLOCK_LOOP_VALUE}")
+target_compile_options(test_olc_no_qsbr PRIVATE
+  "$<${is_x86_64_any_msvc}:$<IF:${has_avx2},/arch:AVX2,/arch:AVX>>"
+  "$<${is_not_windows_x86_64}:$<IF:${has_avx2},-mavx2,-msse4.1>>")
+target_link_libraries(test_olc_no_qsbr PRIVATE unodb_util Threads::Threads)
+add_test(NAME test_olc_no_qsbr COMMAND test_olc_no_qsbr)
+
 if(COVERAGE)
   add_custom_target(tests_for_coverage ctest
-    DEPENDS test_key_encode_decode test_art test_art_key_view test_art_key_view_full_chain test_art_iter test_art_scan test_art_concurrency test_qsbr_ptr test_qsbr test_art_oom
+    DEPENDS test_key_encode_decode test_art test_art_key_view test_art_key_view_full_chain test_art_iter test_art_scan test_art_concurrency test_art_allocator test_olc_no_qsbr test_qsbr_ptr test_qsbr test_art_oom
             test_qsbr_oom)
   add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)
 endif()

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -168,6 +168,11 @@ class QSBRTestBase : public ::testing::Test {
   }
 #endif
 
+  static void test_destroy_callback(void* ptr, std::size_t /*size*/,
+                                    void* /*ctx*/) noexcept {
+    unodb::detail::free_aligned(ptr);
+  }
+
   static void qsbr_deallocate(void* ptr) {
 #ifdef UNODB_DETAIL_WITH_STATS
     const auto current_interval_total_dealloc_size_before =
@@ -179,14 +184,11 @@ class QSBRTestBase : public ::testing::Test {
         unodb::this_thread().current_interval_requests_empty();
 
     try {
-      unodb::this_thread().on_next_epoch_deallocate(ptr
-#ifdef UNODB_DETAIL_WITH_STATS
-                                                    ,
-                                                    1
-#endif
+      unodb::this_thread().on_next_epoch_deallocate(
+          ptr, 1, &test_destroy_callback, nullptr
 #ifndef NDEBUG
-                                                    ,
-                                                    check_ptr_on_qsbr_dealloc
+          ,
+          check_ptr_on_qsbr_dealloc
 #endif
       );
     } catch (...) {

--- a/test/test_art_allocator.cpp
+++ b/test/test_art_allocator.cpp
@@ -1,0 +1,55 @@
+// Copyright 2026 UnoDB contributors
+
+// Should be the first include
+#include "global.hpp"  // IWYU pragma: keep
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "art_allocator.hpp"
+#include "art_common.hpp"
+#include "gtest_utils.hpp"
+#include "mutex_art.hpp"
+#include "olc_art.hpp"
+#include "qsbr.hpp"
+
+namespace {
+
+// Exercise the custom allocator constructor and get_allocator() for each db
+// type. Also exercises default_defer_dealloc and default_destroy by using
+// olc_db with the default (non-QSBR) allocator and performing insert+remove.
+
+UNODB_TEST(ArtAllocator, DbCustomAllocatorConstructor) {
+  const unodb::allocator_type alloc{unodb::detail::default_allocator};
+  const unodb::db<std::uint64_t, unodb::value_view> db{alloc};
+  UNODB_EXPECT_TRUE(db.empty());
+  UNODB_EXPECT_EQ(db.get_allocator().alloc,
+                  unodb::detail::default_allocator.alloc);
+}
+
+UNODB_TEST(ArtAllocator, MutexDbCustomAllocatorConstructor) {
+  const unodb::allocator_type alloc{unodb::detail::default_allocator};
+  const unodb::mutex_db<std::uint64_t, unodb::value_view> db{alloc};
+  UNODB_EXPECT_TRUE(db.empty());
+  UNODB_EXPECT_EQ(db.get_allocator().alloc,
+                  unodb::detail::default_allocator.alloc);
+}
+
+UNODB_TEST(ArtAllocator, OlcDbDefaultAllocatorInsertRemove) {
+  const unodb::quiescent_state_on_scope_exit qsbr{};
+  const unodb::allocator_type alloc{unodb::detail::olc_default_allocator};
+  unodb::olc_db<std::uint64_t, unodb::value_view> db{alloc};
+  UNODB_EXPECT_TRUE(db.empty());
+
+  constexpr std::uint64_t key = 42;
+  const auto val_data = std::array{std::byte{0xAB}};
+  const unodb::value_view val{val_data};
+  UNODB_ASSERT_TRUE(db.insert(key, val));
+  UNODB_ASSERT_FALSE(db.empty());
+
+  UNODB_ASSERT_TRUE(db.remove(key));
+  UNODB_EXPECT_TRUE(db.empty());
+}
+
+}  // namespace

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -211,7 +211,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardOneLeaf) {
   verifier.insert(0, unodb::test::test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
-  typename TypeParam::value_view visited_val{};
+  unodb::value_view visited_val{};
   const auto fn = [&n, &visited_key, &visited_val](
                       const unodb::visitor<typename TypeParam::iterator>&
                           v) noexcept(noexcept(v.get_key())) {
@@ -233,7 +233,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromForwardOneLeaf) {
   verifier.insert(0, unodb::test::test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
-  typename TypeParam::value_view visited_val{};
+  unodb::value_view visited_val{};
   const auto fn = [&n, &visited_key, &visited_val](
                       const unodb::visitor<typename TypeParam::iterator>&
                           v) noexcept(noexcept(v.get_key())) {
@@ -255,7 +255,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardOneLeaf) {
   verifier.insert(0, unodb::test::test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
-  typename TypeParam::value_view visited_val{};
+  unodb::value_view visited_val{};
   const auto fn = [&n, &visited_key, &visited_val](
                       const unodb::visitor<typename TypeParam::iterator>&
                           v) noexcept(noexcept(v.get_key())) {
@@ -277,8 +277,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardTwoLeaves) {
   verifier.insert(0, unodb::test::test_values[0]);
   verifier.insert(1, unodb::test::test_values[1]);
   uint64_t n = 0;
-  std::vector<std::pair<std::uint64_t, typename TypeParam::value_view>>
-      visited{};
+  std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
              &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
     n++;
@@ -298,8 +297,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromForwardTwoLeaves) {
   verifier.insert(0, unodb::test::test_values[0]);
   verifier.insert(1, unodb::test::test_values[1]);
   uint64_t n = 0;
-  std::vector<std::pair<std::uint64_t, typename TypeParam::value_view>>
-      visited{};
+  std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
              &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
     n++;
@@ -319,8 +317,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardTwoLeaves) {
   verifier.insert(0, unodb::test::test_values[0]);
   verifier.insert(1, unodb::test::test_values[1]);
   uint64_t n = 0;
-  std::vector<std::pair<std::uint64_t, typename TypeParam::value_view>>
-      visited{};
+  std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
              &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
     n++;
@@ -597,7 +594,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseOneLeaf) {
   verifier.insert(0, unodb::test::test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
-  typename TypeParam::value_view visited_val{};
+  unodb::value_view visited_val{};
   const auto fn = [&n, &visited_key, &visited_val](
                       const unodb::visitor<typename TypeParam::iterator>&
                           v) noexcept(noexcept(v.get_key())) {
@@ -619,7 +616,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromReverseOneLeaf) {
   verifier.insert(0, unodb::test::test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
-  typename TypeParam::value_view visited_val{};
+  unodb::value_view visited_val{};
   const auto fn = [&n, &visited_key, &visited_val](
                       const unodb::visitor<typename TypeParam::iterator>&
                           v) noexcept(noexcept(v.get_key())) {
@@ -641,7 +638,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseOneLeaf) {
   verifier.insert(1, unodb::test::test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~1ULL};
-  typename TypeParam::value_view visited_val{};
+  unodb::value_view visited_val{};
   const auto fn = [&n, &visited_key, &visited_val](
                       const unodb::visitor<typename TypeParam::iterator>&
                           v) noexcept(noexcept(v.get_key())) {
@@ -663,8 +660,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseTwoLeaves) {
   verifier.insert(1, unodb::test::test_values[0]);
   verifier.insert(2, unodb::test::test_values[1]);
   uint64_t n = 0;
-  std::vector<std::pair<std::uint64_t, typename TypeParam::value_view>>
-      visited{};
+  std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
              &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
     n++;
@@ -684,8 +680,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromReverseTwoLeaves) {
   verifier.insert(1, unodb::test::test_values[0]);
   verifier.insert(2, unodb::test::test_values[1]);
   uint64_t n = 0;
-  std::vector<std::pair<std::uint64_t, typename TypeParam::value_view>>
-      visited{};
+  std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
              &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
     n++;
@@ -705,8 +700,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseTwoLeaves) {
   verifier.insert(1, unodb::test::test_values[0]);
   verifier.insert(2, unodb::test::test_values[1]);
   uint64_t n = 0;
-  std::vector<std::pair<std::uint64_t, typename TypeParam::value_view>>
-      visited{};
+  std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
              &visited](const unodb::visitor<typename TypeParam::iterator>& v) {
     n++;

--- a/test/test_olc_no_qsbr.cpp
+++ b/test/test_olc_no_qsbr.cpp
@@ -1,0 +1,50 @@
+// Copyright 2026 UnoDB contributors
+
+/// \file
+/// Regression test: olc_db with a custom allocator must not require
+/// libunodb_qsbr.  This executable is intentionally linked without
+/// unodb_qsbr to verify the QSBR link decoupling.
+
+// Should be the first include
+#include "global.hpp"  // IWYU pragma: keep
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+
+#include "art_allocator.hpp"
+#include "olc_art.hpp"
+
+namespace {
+
+void* test_alloc(std::size_t size, std::size_t alignment, void* /*ctx*/) {
+  return unodb::detail::allocate_aligned(size, alignment);
+}
+
+void test_dealloc(void* ptr, std::size_t /*size*/, void* /*ctx*/) noexcept {
+  unodb::detail::free_aligned(ptr);
+}
+
+// Immediate destroy -- no true deferral (verifies link decoupling, not GC).
+void test_defer(void* ptr, std::size_t size, unodb::destroy_callback_type cb,
+                void* ctx) noexcept {
+  cb(ptr, size, ctx);
+}
+
+}  // namespace
+
+int main() {
+  const unodb::allocator_type alloc{&test_alloc, &test_dealloc, &test_defer,
+                                    nullptr};
+  unodb::olc_db<std::uint64_t, std::uint64_t> db{alloc};
+
+  if (!db.empty()) return EXIT_FAILURE;
+
+  // Exercise alloc (insert) and defer_dealloc (remove).
+  if (!db.insert(42, 100)) return EXIT_FAILURE;
+  if (db.empty()) return EXIT_FAILURE;
+  if (!db.remove(42)) return EXIT_FAILURE;
+  if (!db.empty()) return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Decouples the allocator subsystem from QSBR, making `art_allocator.hpp` header-only and eliminating the transitive QSBR link dependency for consumers that don't use OLC.

## Changes (11 commits)

1. Add `allocator_type` struct and wire into db/mutex_db/olc_db
2. Route all alloc/dealloc/defer_dealloc through `allocator_type`
3. Drop `qsbr_value_view` from `olc_db` public API
4. Make `art_allocator.hpp` header-only, decouple QSBR
5. Move `olc_default_allocator` to `qsbr.cpp` to decouple link dependency
6. Add regression test for QSBR link decoupling
7. Guard QSBR asserts with `UNODB_DETAIL_QSBR_DEBUG`
8. Guard `deallocation_request::instance_count` with `UNODB_DETAIL_QSBR_DEBUG`
9. clang-format-21 fixes
10. Copyright header and clang-tidy warning fixes
11. Move `olc_default_allocator` extern to `art_allocator.hpp`

## Motivation

Closes #837. Enables downstream consumers to link against unodb's mutex_db without pulling in QSBR. Prerequisite for pluggable allocators (bulk load, arena allocation).

## Testing

- Local: pre-push checks pass (Debug+stats, Debug-no-stats, Release, examples, clang-tidy-21, ASan, TSan, UBSan)
- Fork CI: MSVC 9/9 ✅, Coverage 2/2 ✅
- Rebased cleanly onto master after PR #845 merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable/custom allocator support added across ART-based databases with new constructors and accessors.

* **Behavior**
  * All allocation, deallocation and deferred reclamation now use the database allocator (including QSBR-backed reclamation).
  * Value-view handling unified for iterator value access.

* **Tests**
  * New regression and unit tests validating custom allocator usage and non-QSBR scenarios.

* **Chores**
  * QSBR debug instrumentation moved under a dedicated compile-time flag; CI benchmark step condition refined.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unodb-dev/unodb/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->