### PR TITLE
fix: scan_from backtrack across sibling subtrees (#850)

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -2335,7 +2335,10 @@ typename db<Key, Value>::iterator& db<Key, Value>::iterator::seek(
           // do a left-most descent under that right-sibling. If there
           // is no such parent, we will wind up with an empty stack
           // (iterator at the end) and return that state.
-          if (!empty()) pop();
+          //
+          // Note: The current node (where gte_key_byte failed) was
+          // never pushed, so the stack top is already the first
+          // ancestor to check for a right-sibling.
           while (!empty()) {
             const auto& centry = top();
             const auto cnode{centry.node};  // possible parent from the stack
@@ -2364,11 +2367,14 @@ typename db<Key, Value>::iterator& db<Key, Value>::iterator::seek(
       // immediate predecessor of the desired key in the data.
       auto nxt = inode->lte_key_byte(node_type, remaining_key[0]);
       if (!nxt) {
-        // Pop off the current entry until we find one with a
-        // left-sibling and then do a right-most descent under that
-        // left-sibling.  In the extreme case there is no such
-        // previous entry and we will wind up with an empty stack.
-        if (!empty()) pop();
+        // Pop off entries until we find one with a left-sibling and
+        // then do a right-most descent under that left-sibling.  In
+        // the extreme case there is no such previous entry and we
+        // will wind up with an empty stack.
+        //
+        // Note: The current node (where lte_key_byte failed) was
+        // never pushed, so the stack top is already the first
+        // ancestor to check for a left-sibling.
         while (!empty()) {
           const auto& centry = top();
           const auto cnode{centry.node};  // possible parent from stack

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -3418,7 +3418,9 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
           if (UNODB_DETAIL_UNLIKELY(
                   !node_critical_section.try_read_unlock()))  // unlock node
             return false;                                     // LCOV_EXCL_LINE
-          if (!empty()) pop();
+          // Note: The current node (where gte_key_byte failed) was
+          // never pushed, so the stack top is already the first
+          // ancestor to check for a right-sibling.
           while (!empty()) {
             const auto& centry = top();
             const auto cnode{centry.node};  // a possible parent from the stack.
@@ -3495,7 +3497,9 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
         if (UNODB_DETAIL_UNLIKELY(
                 !node_critical_section.try_read_unlock()))  // unlock node
           return false;                                     // LCOV_EXCL_LINE
-        if (!empty()) pop();
+        // Note: The current node (where lte_key_byte failed) was
+        // never pushed, so the stack top is already the first
+        // ancestor to check for a left-sibling.
         while (!empty()) {
           const auto& centry = top();
           const auto cnode{centry.node};  // a possible parent from stack

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -1077,4 +1077,44 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeC143) {
   do_scan_range_test<TypeParam>(823, 247, 999);
 }
 
+// Regression test for T-5bec51c4: scan_from fails to backtrack across
+// sibling subtrees when the seek key exceeds all children in a subtree.
+// Keys {100,200,300,400,500} encoded as 8-byte BE branch at byte 6:
+//   child 0x00 → {100,200}, child 0x01 → {300,400,500}.
+// seek(250) enters child 0x00, finds no child >= 0xFA at byte 7,
+// must backtrack to byte 6 and descend child 0x01 to find 300.
+UNODB_TYPED_TEST(ARTScanTest, scanFromBacktrackAcrossSiblingSubtrees) {
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();
+  for (const std::uint64_t k : {100U, 200U, 300U, 400U, 500U})
+    verifier.insert(k, unodb::test::test_values[0]);
+  // FWD: scan_from(250) should find 300, 400, 500.
+  {
+    std::vector<std::uint64_t> results;
+    db.scan_from(
+        250, [&results](const unodb::visitor<typename TypeParam::iterator>& v) {
+          results.push_back(decode(v.get_key()));
+          return false;
+        });
+    UNODB_ASSERT_EQ(3U, results.size());
+    UNODB_EXPECT_EQ(300U, results[0]);
+    UNODB_EXPECT_EQ(400U, results[1]);
+    UNODB_EXPECT_EQ(500U, results[2]);
+  }
+  // REV: scan_from(250, fn, false) should find 200, 100.
+  {
+    std::vector<std::uint64_t> results;
+    db.scan_from(
+        250,
+        [&results](const unodb::visitor<typename TypeParam::iterator>& v) {
+          results.push_back(decode(v.get_key()));
+          return false;
+        },
+        false /*fwd*/);
+    UNODB_ASSERT_EQ(2U, results.size());
+    UNODB_EXPECT_EQ(200U, results[0]);
+    UNODB_EXPECT_EQ(100U, results[1]);
+  }
+}
+
 }  // namespace

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -1115,6 +1115,33 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromBacktrackAcrossSiblingSubtrees) {
     UNODB_EXPECT_EQ(200U, results[0]);
     UNODB_EXPECT_EQ(100U, results[1]);
   }
+  // FWD scan_range: [250, 501) should find 300, 400, 500.
+  {
+    std::vector<std::uint64_t> results;
+    db.scan_range(
+        250, 501,
+        [&results](const unodb::visitor<typename TypeParam::iterator>& v) {
+          results.push_back(decode(v.get_key()));
+          return false;
+        });
+    UNODB_ASSERT_EQ(3U, results.size());
+    UNODB_EXPECT_EQ(300U, results[0]);
+    UNODB_EXPECT_EQ(400U, results[1]);
+    UNODB_EXPECT_EQ(500U, results[2]);
+  }
+  // REV scan_range: [250, 99) should find 200, 100.
+  {
+    std::vector<std::uint64_t> results;
+    db.scan_range(
+        250, 99,
+        [&results](const unodb::visitor<typename TypeParam::iterator>& v) {
+          results.push_back(decode(v.get_key()));
+          return false;
+        });
+    UNODB_ASSERT_EQ(2U, results.size());
+    UNODB_EXPECT_EQ(200U, results[0]);
+    UNODB_EXPECT_EQ(100U, results[1]);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
  scan_from (and scan_range) fails to find keys when the seek target falls beyond all children in a subtree, requiring backtrack to a sibling subtree at a higher level.

  Reproducer: Insert 5 keys {100, 200, 300, 400, 500} as 8-byte big-endian uint64. The ART branches at byte 6: child 0x00 holds {100, 200}, child 0x01 holds {300, 400, 500}. scan_from(250) enters child 0x00, finds no child ≥ 0xFA at byte 7, and should backtrack to byte 6 to try child
  0x01. Instead it returns end (no results).

  Root cause: In seek(), when gte_key_byte() (FWD) or lte_key_byte() (REV) returns nothing, the backtrack code did if (!empty()) pop(); before the while-loop. The current node was never pushed onto the stack, so the stack top is already the first ancestor to check for a sibling. The
  spurious pop() discarded that ancestor.

  Fix: Remove the incorrect pop() in 4 places — FWD and REV paths in both art.hpp and olc_art.hpp. Add regression test covering both directions.

  Fixes #850


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for providing a custom memory allocator via a new constructor and accessor.

* **Bug Fixes**
  * Corrected iterator/scan behavior when backtracking across sibling subtrees so forward and reverse range scans return the correct sequences.

* **Tests**
  * Added a regression test covering cross-subtree scanning and backtracking scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unodb-dev/unodb/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->