### PR TITLE
Msvc llvm fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,11 +164,20 @@ set(MSVC_CXX_WARNING_FLAGS "/Wall" "/wd4324" "/wd5030" "/wd5072" "/wd4623"
 # Flags for both MSVC cl and clang-cl compilers
 set(ANY_MSVC_CXX_FLAGS "/permissive-")
 
-# clang-cl warning flags that cl does not understand
+# clang-cl warning flags that cl does not understand. clang-cl maps /Wall to
+# -Weverything, so these disable -Weverything warnings that do not apply:
+# - "-Wpadded": informational; much of our padding is deliberate
+#   alignas(hardware_destructive_interference_size) cache-line separation. The cl
+#   equivalents C4820 and C4324 are already disabled above.
+# - "-Wunique-object-duplication": fires on inline/function-local-static mutable
+#   externals that could be duplicated across a shared library boundary. UnoDB
+#   links as a static library on Windows (PE/COFF), so this is a false positive
+#   here. Remove this suppression if UnoDB is ever built as a Windows DLL.
 set(MSVC_CLANG_WARNING_FLAGS "-Wno-c++20-compat" "-Wno-c++98-compat"
   "-Wno-c++98-compat-pedantic" "-Wno-exit-time-destructors"
   "-Wno-ctad-maybe-unsupported" "-Wno-global-constructors"
-  "-Wno-unsafe-buffer-usage" "-Wno-switch-default")
+  "-Wno-unsafe-buffer-usage" "-Wno-switch-default" "-Wno-padded"
+  "-Wno-unique-object-duplication")
 
 # cl flags that clang-cl does not understand
 set(MSVC_CXX_FLAGS "/external:anglebrackets" "/external:W0")

--- a/benchmark/micro_benchmark.cpp
+++ b/benchmark/micro_benchmark.cpp
@@ -198,7 +198,7 @@ void dense_iter_keyrange_fwd_scan(benchmark::State& state) {
 #endif  // UNODB_DETAIL_WITH_STATS
 }
 
-void dense_tree_sparse_deletes_args(benchmark::internal::Benchmark* b) {
+void dense_tree_sparse_deletes_args(unodb::benchmark::Benchmark* b) {
   for (auto i = 1000; i <= 5000000; i *= 8) {
     b->Args({i, 800});
     b->Args({i, i});
@@ -287,7 +287,7 @@ void dense_tree_increasing_keys(benchmark::State& state) {
                           dense_tree_increasing_keys_delete_insert_pairs * 2);
 }
 
-void dense_insert_value_lengths_args(benchmark::internal::Benchmark* b) {
+void dense_insert_value_lengths_args(unodb::benchmark::Benchmark* b) {
   for (auto i = 100; i <= 1000000; i *= 8)
     for (auto j = 0; j < static_cast<int64_t>(unodb::benchmark::values.size());
          ++j)

--- a/benchmark/micro_benchmark_concurrency.hpp
+++ b/benchmark/micro_benchmark_concurrency.hpp
@@ -17,21 +17,16 @@ static constexpr auto small_concurrent_tree_size = 70000;
 // Do not OOM on a 16GB Linux test server
 static constexpr auto large_concurrent_tree_size = 2000000;
 
-constexpr void concurrency_ranges(::benchmark::internal::Benchmark* b,
-                                  int max_concurrency) {
+constexpr void concurrency_ranges(Benchmark* b, int max_concurrency) {
   for (auto i = 1; i <= max_concurrency; i *= 2)
     b->Args({i, small_concurrent_tree_size});
   for (auto i = 1; i <= max_concurrency; i *= 2)
     b->Args({i, large_concurrent_tree_size});
 }
 
-constexpr void concurrency_ranges16(::benchmark::internal::Benchmark* b) {
-  concurrency_ranges(b, 16);
-}
+constexpr void concurrency_ranges16(Benchmark* b) { concurrency_ranges(b, 16); }
 
-constexpr void concurrency_ranges32(::benchmark::internal::Benchmark* b) {
-  concurrency_ranges(b, 32);
-}
+constexpr void concurrency_ranges32(Benchmark* b) { concurrency_ranges(b, 32); }
 
 template <typename T>
 [[nodiscard]] ::benchmark::Counter to_counter(T value) {

--- a/benchmark/micro_benchmark_key_view.cpp
+++ b/benchmark/micro_benchmark_key_view.cpp
@@ -280,15 +280,15 @@ key_view_set gen_kl256(std::size_t n) {
 
 // Sizes
 
-void kv_sizes(benchmark::internal::Benchmark* b) {
+void kv_sizes(unodb::benchmark::Benchmark* b) {
   for (auto n : {1 << 10, 1 << 14, 1 << 18}) b->Arg(n);
 }
 
-void u64_sizes(benchmark::internal::Benchmark* b) {
+void u64_sizes(unodb::benchmark::Benchmark* b) {
   for (auto n : {1 << 12, 1 << 15, 1 << 18}) b->Arg(n);
 }
 
-void kl_sizes(benchmark::internal::Benchmark* b) { b->Arg(1024); }
+void kl_sizes(unodb::benchmark::Benchmark* b) { b->Arg(1024); }
 
 // Registration: db
 

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -30,16 +30,33 @@
 
 // TODO(laurynas): std::uint64_t-specific
 
+// Google Benchmark's BENCHMARK() macro expands __COUNTER__, which clang 21
+// flags as a C2y extension (-Wc2y-extensions) under clang-cl /Wall. Suppress it
+// around the benchmark registrations these macros bracket; the third-party
+// macro is not ours to change. The clang-21-specific macro avoids
+// -Wunknown-warning-option on older clang.
 #define UNODB_START_BENCHMARKS()           \
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26409) \
-  UNODB_DETAIL_DISABLE_MSVC_WARNING(26426)
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26426) \
+  UNODB_DETAIL_DISABLE_CLANG_21_WARNING("-Wc2y-extensions")
 
-#define UNODB_BENCHMARK_MAIN()         \
-  UNODB_DETAIL_RESTORE_MSVC_WARNINGS() \
-  UNODB_DETAIL_RESTORE_MSVC_WARNINGS() \
+#define UNODB_BENCHMARK_MAIN()             \
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+  UNODB_DETAIL_RESTORE_CLANG_21_WARNINGS() \
   BENCHMARK_MAIN()
 
 namespace unodb::benchmark {
+
+// Google Benchmark 1.9.0 promoted internal::Benchmark to the public
+// benchmark::Benchmark and deprecated this spelling. The bundled submodule and
+// distro packages (<= 1.8.3) only provide the internal name, so we keep using
+// it via this alias; referencing the deprecated name once here, with the
+// warning suppressed, keeps all use sites clean across every supported
+// Benchmark version.
+UNODB_DETAIL_DISABLE_CLANG_WARNING("-Wdeprecated-declarations")
+using Benchmark = ::benchmark::internal::Benchmark;
+UNODB_DETAIL_RESTORE_CLANG_WARNINGS()
 
 // Benchmarked tree types (u64 keys)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized benchmark helper function signatures to use a unified benchmark pointer type across micro-benchmarks.
  * Added a benchmark type alias to reduce deprecation warnings during compilation.
* **Chores**
  * Expanded compiler warning suppression for Clang-cl builds (including padding and unique-object duplication) and added targeted suppression/restoration for newer Clang warnings in the benchmark macros.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->