### PR TITLE
Fix dead compile-time size/alignment invariant static_asserts

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -63,6 +63,8 @@ static_assert(std::is_empty_v<node_header>);
 /// Node pointer type for non-thread-safe ART.
 using node_ptr = basic_node_ptr<node_header>;
 
+static_assert(sizeof(node_ptr) == sizeof(void*));
+
 struct impl_helpers;
 
 /// Type definitions bundle for all internal node types.

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -250,12 +250,6 @@ struct [[nodiscard]] basic_art_key final {
     std::array<std::byte, sizeof(KeyType)> key_bytes;
   };
 
-  /// Compile-time assertions for type invariants.
-  static void static_asserts() {
-    static_assert(std::is_trivially_copyable_v<basic_art_key<KeyType>>);
-    static_assert(sizeof(basic_art_key<KeyType>) == sizeof(KeyType));
-  }
-
   /// Dump key in lexicographic byte-wise order to stream \a os.
   [[gnu::cold]] UNODB_DETAIL_NOINLINE void dump(std::ostream& os) const {
     dump_key(os, key);
@@ -272,6 +266,15 @@ struct [[nodiscard]] basic_art_key final {
     return os;
   }
 };  // class basic_art_key
+
+// basic_art_key<KeyType> is a zero-overhead wrapper around KeyType (a union of
+// KeyType and an equally-sized byte overlay). Checked with representative
+// integral and key_view types: sizeof/traits of the enclosing class are
+// unavailable at class scope.
+static_assert(std::is_trivially_copyable_v<basic_art_key<std::uint64_t>>);
+static_assert(sizeof(basic_art_key<std::uint64_t>) == sizeof(std::uint64_t));
+static_assert(std::is_trivially_copyable_v<basic_art_key<key_view>>);
+static_assert(sizeof(basic_art_key<key_view>) == sizeof(key_view));
 
 /// Number of key bytes consumed along some path in the tree.
 ///

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -523,11 +523,16 @@ class [[nodiscard]] basic_node_ptr {
   /// Mask for pointer bits.
   static constexpr auto ptr_bit_mask = ~tag_bit_mask;
 
-  /// Compile-time assertions for type invariants.
-  static void static_asserts() {
-    static_assert(sizeof(basic_node_ptr<Header>) == sizeof(void*));
-    static_assert(alignof(header_type) - 1 > lowest_non_tag_bit);
-  }
+  // Node type tags occupy the low bits of pointers to nodes. Nodes are
+  // heap-allocated via alignment_for_new<T>() (>=
+  // __STDCPP_DEFAULT_NEW_ALIGNMENT__), so their alignment leaves the tag bits
+  // free even when the header base is under-aligned (e.g. the empty
+  // node_header, or the 4-aligned non-OLC leaf). The wrapper's own size is
+  // checked at the node_ptr / olc_node_ptr alias definitions, where a concrete
+  // Header is in scope.
+  static_assert(
+      alignment_for_new<Header>() >= lowest_non_tag_bit,
+      "Node allocation alignment must leave the node type tag bits free");
 };
 
 /// Expandable buffer for binary comparable keys.

--- a/in_fake_critical_section.hpp
+++ b/in_fake_critical_section.hpp
@@ -146,6 +146,13 @@ class [[nodiscard]] in_fake_critical_section final {
   T value;
 };
 
+// in_fake_critical_section<T> must be a zero-overhead, layout-compatible
+// stand-in for a bare T (and for in_critical_section<T>) in the templatized
+// node code. Checked with a representative type: sizeof of the enclosing class
+// is unavailable at class scope.
+static_assert(sizeof(in_fake_critical_section<std::size_t>) ==
+              sizeof(std::size_t));
+
 }  // namespace unodb
 
 #endif  // UNODB_DETAIL_IN_FAKE_CRITICAL_SECTION_HPP

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -105,6 +105,8 @@ using olc_inode_defs =
 
 using olc_node_ptr = basic_node_ptr<olc_node_header>;
 
+static_assert(sizeof(olc_node_ptr) == sizeof(void*));
+
 template <typename, typename, class>
 class db_inode_qsbr_deleter;  // IWYU pragma: keep
 


### PR DESCRIPTION
(LLM agent)

## Summary

Started from a TODO to add `static_assert(sizeof(in_fake_critical_section<T>) == sizeof(T))`. Investigating where to put it surfaced two latent problems in the existing `static void static_asserts()` "compile-time invariant" holders, so this PR fixes all three consistently using the codebase's *working* static_assert idioms.

### 1. `in_fake_critical_section<T>` — the original ask
It is used as a drop-in for `in_critical_section<T>` in the templatized single-threaded/OLC node code, so it must be layout-compatible with a bare `T`. Added the size assert at namespace scope (it cannot sit at class scope — `sizeof` of the enclosing class is an incomplete type there).

### 2. `basic_art_key` / `basic_node_ptr` `static_asserts()` were dead
Each held its invariants in a `static void static_asserts()` member that is never called, and neither class template is ever explicitly instantiated. A class-template member body is only instantiated when odr-used, so those dependent `static_assert`s **never fired** — verified: a deliberately-false assert inside a never-called `static_asserts()` compiles clean. Moved them to the codebase's working idioms (namespace-scope after the class, as in `optimistic_lock.hpp`).

### 3. `basic_node_ptr` alignment invariant was also mis-formulated
`alignof(header_type) - 1 > lowest_non_tag_bit` (== 8) is false for **both** real headers — the empty `node_header` (`alignof == 1` → `0 > 8`) and `olc_node_header` (`alignof == 8` → `7 > 8`) — so it would have failed the build had it ever compiled. Tag-bit safety does not come from the header, nor even the node types (the non-OLC `basic_leaf` is only `alignof == 4`); it comes from the allocator, which places every node at `alignment_for_new<T>() = max(alignof(T), __STDCPP_DEFAULT_NEW_ALIGNMENT__)`. Reformulated to a class-scope assert on `alignment_for_new<Header>() >= lowest_non_tag_bit` (fires on every `basic_node_ptr<Header>` instantiation), and moved the pointer-size check to the `node_ptr` / `olc_node_ptr` alias sites where a concrete `Header` is in scope.

## Verification
These are compile-time-only changes (added `static_assert`s + removal of dead, never-referenced methods), so header compilation with the real types is the complete evidence:
- All library headers compile clean with the real ART/OLC types on clang (GCC sanity-checked too).
- Every one of the 6 asserts was shown to **fire** on a violated invariant (each temporarily perturbed → compile error → reverted) — the exact property the old dead methods lacked.
- clang-format clean; no remaining references to the removed `static_asserts()` methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added compile-time checks to validate pointer and wrapper type sizes.
  * Strengthened build-time validation for key layouts, alignment, and node-type tagging.
* **Refactor**
  * Moved internal type invariants to clearer class-level checks without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->