### PR TITLE
Reset the heap failure injector on every armed-scope exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     "$<$<AND:${is_release_genex},${is_not_windows}>:$<IF:${coverage_on},-O0,-O3>>"
     # Misc
     "$<${coverage_on}:--coverage>")
-  target_link_options(${TARGET} INTERFACE "$<${coverage_on}:--coverage>")
+  target_link_options(${TARGET} PUBLIC "$<${coverage_on}:--coverage>")
   target_link_options(${TARGET} PRIVATE
     "$<${is_apple_clang_genex}:-Wl,-no_warn_duplicate_libraries>"
     "$<${is_darwin_clang_ge_21_x86_64}:-L/usr/local/opt/llvm/lib/c++>"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,18 @@ add_test_target(test_qsbr)
 target_link_libraries(test_qsbr PRIVATE qsbr_test_utils)
 add_db_test_target(test_key_encode_decode)
 
+# Tests the allocation failure injector itself. Deliberately does not link
+# unodb_test: with the replaced global operator new live, Google Test's own
+# allocations would feed the same counter as the code under test. Only
+# unodb::detail::allocate_aligned must trip the injector here, which also lets
+# this run in the configurations the OOM test targets are excluded from.
+add_executable(test_fault_injection test_fault_injection.cpp)
+common_target_properties(test_fault_injection)
+target_link_libraries(test_fault_injection
+  PRIVATE unodb_util Threads::Threads GTest::gtest_main ${Boost_LIBRARIES})
+set_clang_tidy_options(test_fault_injection "${DO_CLANG_TIDY}")
+add_sanitized_test(NAME test_fault_injection COMMAND test_fault_injection)
+
 add_db_test_target(test_art)
 target_compile_options(test_art PRIVATE "$<${is_msvc}:/bigobj>")
 
@@ -102,14 +114,14 @@ add_test(NAME test_olc_no_qsbr COMMAND test_olc_no_qsbr)
 if(COVERAGE)
   add_custom_target(tests_for_coverage ctest
     DEPENDS test_key_encode_decode test_art test_art_key_view test_art_key_view_full_chain test_art_iter test_art_scan test_art_concurrency test_art_allocator test_art_upsert test_olc_no_qsbr test_qsbr_ptr test_qsbr test_art_oom
-            test_qsbr_oom test_art_bulk_load)
+            test_qsbr_oom test_art_bulk_load test_fault_injection)
   add_coverage_target(TARGET coverage DEPENDENCY tests_for_coverage)
 endif()
 
 add_custom_target(valgrind_tests
+  # Targets with death tests will print their SIGABRT stacktrace under
+  # Valgrind. I have not found a way to disable it.
   COMMAND ${VALGRIND_COMMAND} ./test_qsbr_ptr;
-  # The death tests will print their SIGABRT stacktrace under Valgrind. I have
-  # not found a way to disable it.
   COMMAND ${VALGRIND_COMMAND} ./test_qsbr;
   COMMAND ${VALGRIND_COMMAND} ./test_key_encode_decode;
   COMMAND ${VALGRIND_COMMAND} ./test_art;
@@ -119,5 +131,6 @@ add_custom_target(valgrind_tests
   COMMAND ${VALGRIND_COMMAND} ./test_art_scan;
   COMMAND ${VALGRIND_COMMAND} ./test_art_concurrency;
   COMMAND ${VALGRIND_COMMAND} ./test_art_upsert;
-  COMMAND ${VALGRIND_COMMAND} ./test_art_bulk_load
-  DEPENDS test_qsbr_ptr test_qsbr test_key_encode_decode test_art test_art_key_view test_art_key_view_full_chain test_art_iter test_art_scan test_art_concurrency test_art_upsert test_art_bulk_load)
+  COMMAND ${VALGRIND_COMMAND} ./test_art_bulk_load;
+  COMMAND ${VALGRIND_COMMAND} ./test_fault_injection
+  DEPENDS test_qsbr_ptr test_qsbr test_key_encode_decode test_art test_art_key_view test_art_key_view_full_chain test_art_iter test_art_scan test_art_concurrency test_art_upsert test_art_bulk_load test_fault_injection)

--- a/test/gtest_utils.hpp
+++ b/test/gtest_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 UnoDB contributors
+// Copyright 2021-2026 UnoDB contributors
 #ifndef UNODB_DETAIL_GTEST_UTILS_HPP
 #define UNODB_DETAIL_GTEST_UTILS_HPP
 
@@ -155,6 +155,16 @@
     ASSERT_THROW(statement, expected_exception);          \
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()                  \
     UNODB_DETAIL_RESTORE_MSVC_WARNINGS()                  \
+  } while (0)
+
+/// Wrapper for Google Test `ASSERT_NO_THROW` macro.
+#define UNODB_ASSERT_NO_THROW(statement)     \
+  do {                                       \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)  \
+    UNODB_DETAIL_DISABLE_MSVC_WARNING(26818) \
+    ASSERT_NO_THROW(statement);              \
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
+    UNODB_DETAIL_RESTORE_MSVC_WARNINGS()     \
   } while (0)
 
 /// Wrapper for Google Test `ASSERT_TRUE` macro.

--- a/test/qsbr_gtest_utils.hpp
+++ b/test/qsbr_gtest_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 UnoDB contributors
+// Copyright 2022-2026 UnoDB contributors
 #ifndef UNODB_DETAIL_QSBR_GTEST_UTILS_HPP
 #define UNODB_DETAIL_QSBR_GTEST_UTILS_HPP
 
@@ -32,23 +32,19 @@ class QSBRTestBase : public ::testing::Test {
   }
 
   // QSBR operation wrappers
- private:
-  [[nodiscard]] static qsbr_state::type get_qsbr_state() noexcept {
-    return must_not_allocate(
-        []() noexcept { return unodb::qsbr::instance().get_state(); });
-  }
 
- protected:
   [[nodiscard]] static qsbr_thread_count_type get_qsbr_thread_count() noexcept {
     return must_not_allocate([]() noexcept {
-      return unodb::qsbr_state::get_thread_count(get_qsbr_state());
+      return unodb::qsbr_state::get_thread_count(
+          unodb::qsbr::instance().get_state());
     });
   }
 
   [[nodiscard]] static qsbr_thread_count_type
   get_qsbr_threads_in_previous_epoch() noexcept {
     return must_not_allocate([]() noexcept {
-      return unodb::qsbr_state::get_threads_in_previous_epoch(get_qsbr_state());
+      return unodb::qsbr_state::get_threads_in_previous_epoch(
+          unodb::qsbr::instance().get_state());
     });
   }
 

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -5,12 +5,10 @@
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <__new/exceptions.h>
 // IWYU pragma: no_include <array>
 // IWYU pragma: no_include <string>
 
 #include <cstdint>
-#include <new>  // IWYU pragma: keep
 #include <utility>
 #include <vector>
 
@@ -20,6 +18,7 @@
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "test_heap.hpp"
+#include "test_utils.hpp"
 
 // The OOM tests are dependent on the number of heap allocations in the test,
 // that's brittle and hardcoded. Suppose some op takes 5 heap allocations. The
@@ -29,12 +28,24 @@
 //
 // Changing the data structure in the main code or the test suite might perturb
 // this, causing tests to fail. If this happens you need to decide whether the
-// change in behavior was for a valid reason or not. If tests fail in that
-// "expected exception was not thrown", try incrementing the allocation counter
-// in the test. If they fail in that "exception was thrown but we weren't
-// expecting it", try decrementing it.
+// change in behavior was for a valid reason or not.
+//
+// oom_scan_test and bulk_load_oom_test fail differently: there fail_limit is
+// only an upper bound, so their UNODB_ASSERT_LE / FAIL() forms always mean
+// increment, and a too-high limit is silently tolerated.
 namespace {
 
+/// Exercise \a test at each expected allocation-failure point.
+///
+/// The assertions hold only when the operation makes exactly fail_limit - 1
+/// injectable allocations, so recalibrate from that invariant rather than from
+/// a lookup table. A mid-loop failure, "Value of: ... throws_bad_alloc(...) /
+/// Actual: false / Expected: true", means the operation now makes fewer
+/// allocations than the limit assumes - a decrement. A failure on the last
+/// iteration, which expected false and got true, means the operation still
+/// reaches its fail_limit-th allocation - an increment. Neither message names
+/// the failing iteration, but the two shapes are monotone in fail_limit and
+/// mutually exclusive, so stepping or bisecting on them converges.
 template <class TypeParam, typename Init, typename Test, typename CheckAfterOOM,
           typename CheckAfterSuccess>
 void oom_test(unsigned fail_limit, Init init, Test test,
@@ -45,9 +56,8 @@ void oom_test(unsigned fail_limit, Init init, Test test,
     unodb::test::tree_verifier<TypeParam> verifier;
     init(verifier);
 
-    unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-    UNODB_ASSERT_THROW(test(verifier), std::bad_alloc);
-    unodb::test::allocation_failure_injector::reset();
+    UNODB_ASSERT_TRUE(unodb::test::throws_bad_alloc(
+        fail_n, [&test, &verifier] { test(verifier); }));
 
     verifier.check_present_values();
     check_after_oom(verifier);
@@ -56,9 +66,8 @@ void oom_test(unsigned fail_limit, Init init, Test test,
   unodb::test::tree_verifier<TypeParam> verifier;
   init(verifier);
 
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-  test(verifier);
-  unodb::test::allocation_failure_injector::reset();
+  UNODB_ASSERT_FALSE(unodb::test::throws_bad_alloc(
+      fail_n, [&test, &verifier] { test(verifier); }));
 
   verifier.check_present_values();
   check_after_success(verifier);
@@ -95,30 +104,32 @@ void oom_remove_test(unsigned fail_limit, Init init, std::uint64_t k,
       });
 }
 
-// The scan allocation count cannot be hardcoded: it comes from the iterator's
-// std::stack/deque and key buffer, whose allocation counts are
-// standard-library-dependent (libc++ vs libstdc++ debug mode). So fail_limit is
-// only an upper bound: inject at each point until the scan completes without
-// OOM, asserting the tree stays intact on every path that did throw.
+/// Exercise a scan across its implementation-defined allocation points.
+///
+/// The count cannot be hardcoded: it comes from the iterator's std::stack/deque
+/// and key buffer, whose allocation counts are standard-library-dependent
+/// (libc++ vs libstdc++ debug mode). So fail_limit is only an upper bound:
+/// inject at each point until the scan completes without OOM. The scan is
+/// read-only, so the tree must be intact after every injection point, whether
+/// that iteration threw (the strong guarantee) or completed.
+///
+/// UNODB_ASSERT_GT(fail_n, 1U) is the exception to the upper-bound adjustment
+/// rule: reported as "Expected: (fail_n) > (1U), actual: 1 vs 1", it can only
+/// fire when the scan makes no injectable allocation at all, so the test
+/// exercises nothing. No fail_limit value repairs that - fix the scan, not the
+/// limit.
 template <class TypeParam, typename ScanOp>
-void oom_scan_test(unsigned fail_limit, ScanOp scan_op) {
+void oom_scan_test(unsigned fail_limit, const ScanOp& scan_op) {
   unodb::test::tree_verifier<TypeParam> verifier;
   verifier.insert_key_range(0, 16);
 
   unsigned fail_n = 1;
   for (; fail_n <= fail_limit; ++fail_n) {
-    unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-    try {
-      scan_op(verifier.get_db());
-    } catch (const std::bad_alloc&) {
-      unodb::test::allocation_failure_injector::reset();
-      verifier.check_present_values();  // strong guarantee: tree intact
-      continue;
-    }
-    // Scan completed without OOM: past all of its allocations.
-    unodb::test::allocation_failure_injector::reset();
+    const bool completed = !unodb::test::throws_bad_alloc(
+        fail_n, [&scan_op, &verifier] { scan_op(verifier.get_db()); });
     verifier.check_present_values();
-    break;
+    // Scan completed without OOM: past all of its allocations.
+    if (completed) break;
   }
   // Scan completed within fail_limit, making >= 1 injectable allocation.
   UNODB_ASSERT_LE(fail_n, fail_limit);
@@ -137,10 +148,17 @@ using ARTTypes =
 
 UNODB_TYPED_TEST_SUITE(ARTOOMTest, ARTTypes)
 
-UNODB_TYPED_TEST(ARTOOMTest, CtorDoesNotAllocate) {
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
+// The guard must be declared before the tree so that reverse destruction order
+// leaves the destructor inside the armed window; swapping the two lines still
+// compiles and passes while pinning nothing at all - the constructor would run
+// before the guard arms, and the destructor after the guard's own destructor
+// disarmed. Note that the destructor half is enforced differently: the
+// destructors of all three tested types are noexcept, so a violation there
+// terminates the process rather than failing this test, per the noexcept-frame
+// warning on fail_on_nth_allocation_guard.
+UNODB_TYPED_TEST(ARTOOMTest, CtorAndDtorDoNotAllocate) {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
   const TypeParam tree;
-  unodb::test::allocation_failure_injector::reset();
 }
 
 UNODB_TYPED_TEST(ARTOOMTest, SingleNodeTreeEmptyValue) {
@@ -703,24 +721,22 @@ void bulk_load_oom_test(
   for (fail_n = 1; fail_n <= fail_limit; ++fail_n) {
     TypeParam test_db;
 
-    unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-    try {
-      test_db.bulk_load(kv.begin(), kv.end());
-      // Success: we've found the limit
-      unodb::test::allocation_failure_injector::reset();
+    const bool loaded = !unodb::test::throws_bad_alloc(
+        fail_n, [&test_db, &kv] { test_db.bulk_load(kv.begin(), kv.end()); });
+    if (loaded) {  // Success: we've found the limit
       UNODB_ASSERT_FALSE(test_db.empty());
       for (const auto& [k, v] : kv) {
-        UNODB_ASSERT_TRUE(TypeParam::key_found(test_db.get(k)));
+        const auto result = test_db.get(k);
+        UNODB_ASSERT_TRUE(TypeParam::key_found(result));
+        unodb::test::detail::assert_value_eq<TypeParam>(result, v);
       }
       return;
-    } catch (const std::bad_alloc&) {
-      unodb::test::allocation_failure_injector::reset();
-      // Strong guarantee: tree must be empty after failed bulk_load
-      UNODB_ASSERT_TRUE(test_db.empty());
-#ifdef UNODB_DETAIL_WITH_STATS
-      UNODB_ASSERT_EQ(test_db.get_current_memory_use(), 0);
-#endif
     }
+    // Strong guarantee: tree must be empty after failed bulk_load
+    UNODB_ASSERT_TRUE(test_db.empty());
+#ifdef UNODB_DETAIL_WITH_STATS
+    UNODB_ASSERT_EQ(test_db.get_current_memory_use(), 0);
+#endif
   }
   FAIL() << "bulk_load did not succeed within " << fail_limit << " allocations";
 }
@@ -734,40 +750,41 @@ UNODB_TYPED_TEST(ARTOOMTest, BulkLoadSingleKey) {
 
 // Tree that creates one inode4 (4 leaves + 1 inode4)
 UNODB_TYPED_TEST(ARTOOMTest, BulkLoadInode4) {
-  constexpr auto val = unodb::test::test_values[0];
   std::vector<std::pair<std::uint64_t, unodb::value_view>> kv;
   kv.reserve(4);
-  for (std::uint64_t i = 0; i < 4; ++i) kv.emplace_back(i << 56U, val);
+  for (std::uint64_t i = 0; i < 4; ++i)
+    kv.emplace_back(i << 56U, unodb::test::get_test_value<TypeParam>(i));
   bulk_load_oom_test<TypeParam>(10, kv);
 }
 
 // Tree that creates an inode16 (10 leaves + 1 inode16)
 UNODB_TYPED_TEST(ARTOOMTest, BulkLoadInode16) {
-  constexpr auto val = unodb::test::test_values[0];
   std::vector<std::pair<std::uint64_t, unodb::value_view>> kv;
   kv.reserve(10);
-  for (std::uint64_t i = 0; i < 10; ++i) kv.emplace_back(i << 56U, val);
+  for (std::uint64_t i = 0; i < 10; ++i)
+    kv.emplace_back(i << 56U, unodb::test::get_test_value<TypeParam>(i));
   bulk_load_oom_test<TypeParam>(15, kv);
 }
 
 // Tree that creates an inode48 (20 leaves + 1 inode48)
 UNODB_TYPED_TEST(ARTOOMTest, BulkLoadInode48) {
-  constexpr auto val = unodb::test::test_values[0];
   std::vector<std::pair<std::uint64_t, unodb::value_view>> kv;
   kv.reserve(20);
-  for (std::uint64_t i = 0; i < 20; ++i) kv.emplace_back(i << 56U, val);
+  for (std::uint64_t i = 0; i < 20; ++i)
+    kv.emplace_back(i << 56U, unodb::test::get_test_value<TypeParam>(i));
   bulk_load_oom_test<TypeParam>(30, kv);
 }
 
 // Tree with nested inodes (two inode4s under one root inode4)
 UNODB_TYPED_TEST(ARTOOMTest, BulkLoadNested) {
-  constexpr auto val = unodb::test::test_values[0];
   std::vector<std::pair<std::uint64_t, unodb::value_view>> kv;
   kv.reserve(8);
   for (std::uint64_t i = 0; i < 4; ++i)
-    kv.emplace_back((1ULL << 56U) | (i << 48U), val);
+    kv.emplace_back((1ULL << 56U) | (i << 48U),
+                    unodb::test::get_test_value<TypeParam>(i));
   for (std::uint64_t i = 0; i < 4; ++i)
-    kv.emplace_back((2ULL << 56U) | (i << 48U), val);
+    kv.emplace_back((2ULL << 56U) | (i << 48U),
+                    unodb::test::get_test_value<TypeParam>(i + 4));
   bulk_load_oom_test<TypeParam>(20, kv);
 }
 

--- a/test/test_art_upsert.cpp
+++ b/test/test_art_upsert.cpp
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <new>  // NOLINT(misc-include-cleaner)
 #include <random>
 #include <stdexcept>
 #include <tuple>
@@ -23,11 +22,11 @@
 #include "olc_art.hpp"  // NOLINT(misc-include-cleaner)
 #include "qsbr.hpp"
 #include "qsbr_test_utils.hpp"
-#include "test_heap.hpp"  // NOLINT(misc-include-cleaner)
 
 #ifndef NDEBUG
 #include "sync.hpp"
 #include "sync_point_test_utils.hpp"
+#include "test_utils.hpp"
 #include "thread_sync.hpp"
 #endif
 
@@ -1697,12 +1696,10 @@ UNODB_TYPED_TEST(UpsertOOMTest, InsertPathOom) {
   with_qsbr<TypeParam>([&] { UNODB_ASSERT_TRUE(db.insert(k0, v0)); });
 
   // Inject failure, upsert key 1 (insert path)
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  with_qsbr<TypeParam>([&] {
-    UNODB_ASSERT_THROW(std::ignore = db.upsert(k1, v1, keep_fn),
-                       std::bad_alloc);
-  });
-  unodb::test::allocation_failure_injector::reset();
+  UNODB_ASSERT_TRUE(with_qsbr<TypeParam>([&] {
+    return unodb::test::throws_bad_alloc(
+        1, [&] { std::ignore = db.upsert(k1, v1, keep_fn); });
+  }));
 
   // Verify key 1 absent, key 0 still present
   with_qsbr<TypeParam>(
@@ -1727,14 +1724,12 @@ UNODB_TYPED_TEST(UpsertOOMTest, EraseShrinkOom) {
   const auto k_erase = verifier.coerce_key(std::size_t{2});
 
   // Inject failure, upsert-erase key 2 (triggers shrink allocation)
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(1);
-  with_qsbr<TypeParam>([&] {
-    UNODB_ASSERT_THROW(
-        std::ignore = db.upsert(
-            k_erase, unodb::test::get_test_value<TypeParam>(2), erase_fn),
-        std::bad_alloc);
-  });
-  unodb::test::allocation_failure_injector::reset();
+  UNODB_ASSERT_TRUE(with_qsbr<TypeParam>([&] {
+    return unodb::test::throws_bad_alloc(1, [&] {
+      std::ignore = db.upsert(
+          k_erase, unodb::test::get_test_value<TypeParam>(2), erase_fn);
+    });
+  }));
 
   // Verify key 2 still present
   ASSERT_VALUE_FOR_KEY(TypeParam, db, k_erase,

--- a/test/test_fault_injection.cpp
+++ b/test/test_fault_injection.cpp
@@ -1,0 +1,219 @@
+// Copyright 2026 UnoDB contributors
+
+#ifndef NDEBUG
+
+// Should be the first include
+#include "global.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_include <__new/exceptions.h>
+// IWYU pragma: no_include <gtest/gtest.h>
+// IWYU pragma: no_include <string>
+
+#include <atomic>
+#include <new>  // IWYU pragma: keep
+#include <stdexcept>
+#include <thread>
+#include <tuple>
+#include <type_traits>
+
+#include "gtest_utils.hpp"
+#include "heap.hpp"
+#include "test_heap.hpp"
+#include "test_utils.hpp"
+
+// Pins the allocation failure injector's scope discipline. Deliberately drives
+// unodb::detail::allocate_aligned rather than the replaced global operator new,
+// which this target does not link: nothing else in the process then perturbs
+// the allocation counter, so the armed windows below are deterministic.
+namespace {
+
+static_assert(noexcept(unodb::test::throws_bad_alloc(
+    1, static_cast<void (*)() noexcept>(nullptr))));
+
+/// Exercise one deterministic allocation through the failure injector.
+void allocate_and_free() {
+  unodb::detail::free_aligned(unodb::detail::allocate_aligned(8));
+}
+
+UNODB_TEST(HeapFaultInjection, MustNotAllocateVoidDisarmsOnNormalReturn) {
+  const auto test_action = [thread = std::thread{}]() noexcept {
+    static_cast<void>(thread);
+  };
+  static_assert(!std::is_copy_constructible_v<decltype(test_action)>);
+
+  UNODB_ASSERT_NO_THROW(unodb::test::must_not_allocate(test_action));
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+// The injector must be disarmed once must_not_allocate's action has violated
+// its pin, so that the failure does not spread to everything after it.
+// Asserting directly on the injected throw, and on the trailing allocation
+// surviving, is safe here only because this target does not link the replaced
+// global operator new, so Google Test's own allocations are not injected;
+// elsewhere use throws_bad_alloc.
+UNODB_TEST(HeapFaultInjection, MustNotAllocateResetsOnViolation) {
+  UNODB_ASSERT_THROW(
+      unodb::test::must_not_allocate([] { allocate_and_free(); }),
+      std::bad_alloc);
+
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+// The non-void instantiation, which the rewrite collapsed into the void one's
+// single armed return: it must pin, disarm and forward the value alike.
+UNODB_TEST(HeapFaultInjection, MustNotAllocateNonVoidPinsAndForwards) {
+  const auto test_action = [thread = std::thread{}]() noexcept {
+    static_cast<void>(thread);
+    return 42;
+  };
+  static_assert(!std::is_copy_constructible_v<decltype(test_action)>);
+
+  UNODB_ASSERT_EQ(unodb::test::must_not_allocate(test_action), 42);
+
+  UNODB_ASSERT_THROW(std::ignore = unodb::test::must_not_allocate([] {
+                       allocate_and_free();
+                       return 42;
+                     }),
+                     std::bad_alloc);
+
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+// Same for a guard the injected failure unwinds out of. Passing the armed scope
+// as the asserted statement keeps the handler outside it by construction: the
+// guard is destroyed as the injected failure unwinds, before Google Test's
+// handler runs.
+UNODB_TEST(HeapFaultInjection, GuardResetsWhenInjectedFailureEscapes) {
+  UNODB_ASSERT_THROW(
+      {
+        UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
+        allocate_and_free();
+      },
+      std::bad_alloc);
+
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+// The nth allocation is counted from the guard's scope entry, not from whatever
+// the counter happened to hold. The raw arm below is what makes a stale count
+// reachable at all: maybe_fail() advances the counter only while armed, so an
+// allocation made with the injector disarmed cannot dirty it.
+UNODB_TEST(HeapFaultInjection, GuardCountsFromScopeEntry) {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(100);
+  allocate_and_free();
+
+  {
+    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(2);
+    // Distinguishes counting from scope entry from counting from the stale
+    // value: without the guard constructor's reset, the stale count trips the
+    // injector one allocation early.
+    UNODB_ASSERT_NO_THROW(allocate_and_free());
+    UNODB_ASSERT_THROW(allocate_and_free(), std::bad_alloc);
+  }
+
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+// throws_bad_alloc reports both outcomes and leaves the injector disarmed on
+// each: the trailing allocation would fault if the guard had not reset.
+UNODB_TEST(HeapFaultInjection, ThrowsBadAllocReportsOutcomeAndDisarms) {
+  const auto test_action = [thread = std::thread{}] {
+    static_cast<void>(thread);
+    allocate_and_free();
+  };
+  static_assert(!std::is_copy_constructible_v<decltype(test_action)>);
+
+  UNODB_ASSERT_TRUE(unodb::test::throws_bad_alloc(1, test_action));
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+
+  UNODB_ASSERT_FALSE(unodb::test::throws_bad_alloc(2, allocate_and_free));
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+/// Throw an exception that throws_bad_alloc() must propagate.
+[[noreturn]] void throw_not_bad_alloc() {
+  throw std::runtime_error{"not bad_alloc"};
+}
+static_assert(!noexcept(unodb::test::throws_bad_alloc(1, throw_not_bad_alloc)));
+
+// An exception that is not std::bad_alloc is neither swallowed nor reported as
+// completion; on that path only the guard destructor disarms. Throwing here is
+// safe because this target does not link the replaced global operator new, so
+// building the exception cannot consume the pin.
+UNODB_TEST(HeapFaultInjection, ThrowsBadAllocDisarmsOnOtherException) {
+  UNODB_ASSERT_THROW(
+      std::ignore = unodb::test::throws_bad_alloc(1, throw_not_bad_alloc),
+      std::runtime_error);
+
+  UNODB_ASSERT_NO_THROW(allocate_and_free());
+}
+
+// The guard cannot nest: it cannot restore an enclosing armed scope's
+// allocation count, so an inner guard would silently cancel the outer pin. A
+// same-scope nest is already a compile error, the macro hardcoding its variable
+// name, so separate functions are what reach the cross-call nest the assert
+// actually catches. Both guards live in the death test's child process, leaving
+// this process's injector state untouched.
+// LCOV_EXCL_START
+/// Enter an armed scope from the nesting death-test helper.
+void armed_scope() noexcept { UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1); }
+
+/// Trigger the cross-call nested-scope assertion.
+void nested_armed_scopes() noexcept {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
+  armed_scope();
+}
+static_assert(noexcept(nested_armed_scopes()));
+// LCOV_EXCL_STOP
+
+UNODB_TEST(HeapFaultInjectionDeathTest, NestedGuardAborts) {
+  UNODB_ASSERT_DEATH({ nested_armed_scopes(); }, "must not nest");
+}
+
+// LCOV_EXCL_START
+/// Trigger the process-wide overlapping-scope assertion across two threads.
+void concurrently_armed_scopes() {
+  std::atomic<bool> first_armed{false};
+  std::atomic<bool> first_may_exit{false};
+  std::thread first{[&first_armed, &first_may_exit]() noexcept {
+    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
+    first_armed.store(true, std::memory_order_release);
+    while (!first_may_exit.load(std::memory_order_acquire))
+      std::this_thread::yield();
+  }};
+  while (!first_armed.load(std::memory_order_acquire))
+    std::this_thread::yield();
+
+  {
+    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
+  }
+
+  first_may_exit.store(true, std::memory_order_release);
+  first.join();
+}
+// LCOV_EXCL_STOP
+
+UNODB_TEST(HeapFaultInjectionDeathTest, ConcurrentGuardAborts) {
+  UNODB_ASSERT_DEATH({ concurrently_armed_scopes(); }, "must not overlap");
+}
+
+// The guard is 1-based because 0 is the injector's disarmed value: a zero-armed
+// scope would pin nothing while every helper built on it reported the
+// reassuring answer - must_not_allocate returning normally, throws_bad_alloc
+// returning false. That is a wrong answer rather than a skipped check, which is
+// what the assert exists to prevent.
+// LCOV_EXCL_START
+/// Trigger the assertion that rejects the disarmed value as a failure point.
+void zero_armed_scope() noexcept {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(0);
+}
+static_assert(noexcept(zero_armed_scope()));
+// LCOV_EXCL_STOP
+
+UNODB_TEST(HeapFaultInjectionDeathTest, ZeroFailNAborts) {
+  UNODB_ASSERT_DEATH({ zero_armed_scope(); }, "1-based");
+}
+
+}  // namespace
+
+#endif  // #ifndef NDEBUG

--- a/test/test_qsbr.cpp
+++ b/test/test_qsbr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2025 UnoDB contributors
+// Copyright 2020-2026 UnoDB contributors
 
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
@@ -26,6 +26,37 @@ using QSBRDeathTest = unodb::test::QSBRTestBase;
 
 using unodb::detail::thread_syncs;
 
+/// Notify a test thread when the current scope exits.
+class [[nodiscard]] notify_thread_on_scope_exit final {
+ public:
+  /// Create a notifier for \a sync.
+  constexpr explicit notify_thread_on_scope_exit(
+      unodb::detail::thread_sync& sync) noexcept
+      : sync_to_notify{sync} {}
+
+  /// Notify the waiting thread.
+  ~notify_thread_on_scope_exit() noexcept(false) { sync_to_notify.notify(); }
+
+  /// Copy construction is disabled.
+  notify_thread_on_scope_exit(const notify_thread_on_scope_exit&) = delete;
+
+  /// Move construction is disabled.
+  notify_thread_on_scope_exit(notify_thread_on_scope_exit&&) = delete;
+
+  /// Copy assignment is disabled.
+  notify_thread_on_scope_exit& operator=(const notify_thread_on_scope_exit&) =
+      delete;
+
+  /// Move assignment is disabled.
+  notify_thread_on_scope_exit& operator=(notify_thread_on_scope_exit&&) =
+      delete;
+
+ private:
+  /// Synchronization primitive to notify.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  unodb::detail::thread_sync& sync_to_notify;
+};
+
 void active_pointer_ops(void* raw_ptr) noexcept {
   unodb::qsbr_ptr<void> active_ptr{raw_ptr};
   unodb::qsbr_ptr<void> active_ptr2{active_ptr};
@@ -51,23 +82,32 @@ UNODB_TEST_F(QSBR, SingleThreadPauseResume) {
 
 UNODB_TEST_F(QSBR, TwoThreads) {
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
-  unodb::qsbr_thread second_thread(
-      []() noexcept { UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2); });
+  unodb::qsbr_thread second_thread([]() noexcept {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[0]};
+    UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2);
+  });
+  thread_syncs[0].wait();
   join(second_thread);
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
 }
 
 UNODB_TEST_F(QSBR, TwoThreadsSecondQuitPaused) {
-  unodb::qsbr_thread second_thread([]()
+  unodb::qsbr_thread second_thread(
+      []()
 #ifndef UNODB_DETAIL_WITH_STATS
-                                       noexcept
+          noexcept
 #endif
-                                   { qsbr_pause(); });
+      {
+        const notify_thread_on_scope_exit notify_parent{thread_syncs[0]};
+        qsbr_pause();
+      });
+  thread_syncs[0].wait();
   join(second_thread);
 }
 
 UNODB_TEST_F(QSBR, TwoThreadsSecondPaused) {
   unodb::qsbr_thread second_thread([] {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[0]};
     UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2);
     UNODB_ASSERT_FALSE(is_qsbr_paused());
     qsbr_pause();
@@ -76,6 +116,7 @@ UNODB_TEST_F(QSBR, TwoThreadsSecondPaused) {
     unodb::this_thread().qsbr_resume();
     UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2);
   });
+  thread_syncs[0].wait();
   join(second_thread);
 }
 
@@ -99,9 +140,9 @@ UNODB_TEST_F(QSBR, TwoThreadsFirstPaused) {
 UNODB_TEST_F(QSBR, TwoThreadsBothPaused) {
   unodb::qsbr_thread second_thread([] {
     UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2);
-    thread_syncs[0].notify();  // 1 ->
     qsbr_pause();
-    thread_syncs[1].wait();  // 2 <-
+    thread_syncs[0].notify();  // 1 ->
+    thread_syncs[1].wait();    // 2 <-
     UNODB_EXPECT_EQ(get_qsbr_thread_count(), 0);
     unodb::this_thread().qsbr_resume();
     thread_syncs[0].notify();  // 3 ->
@@ -118,8 +159,11 @@ UNODB_TEST_F(QSBR, TwoThreadsBothPaused) {
 UNODB_TEST_F(QSBR, TwoThreadsSequential) {
   qsbr_pause();
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
-  unodb::qsbr_thread second_thread(
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); });
+  unodb::qsbr_thread second_thread([]() noexcept {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[0]};
+    UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
+  });
+  thread_syncs[0].wait();
   join(second_thread);
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
   unodb::this_thread().qsbr_resume();
@@ -130,8 +174,11 @@ UNODB_TEST_F(QSBR, TwoThreadsDefaultCtor) {
   qsbr_pause();
   unodb::qsbr_thread second_thread{};
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
-  second_thread = unodb::qsbr_thread{
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); }};
+  second_thread = unodb::qsbr_thread{[]() noexcept {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[0]};
+    UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
+  }};
+  thread_syncs[0].wait();
   join(second_thread);
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
   unodb::this_thread().qsbr_resume();
@@ -141,8 +188,11 @@ UNODB_TEST_F(QSBR, SecondThreadAddedWhileFirstPaused) {
   qsbr_pause();
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
 
-  unodb::qsbr_thread second_thread(
-      []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); });
+  unodb::qsbr_thread second_thread([]() noexcept {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[0]};
+    UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
+  });
+  thread_syncs[0].wait();
   join(second_thread);
 
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
@@ -178,9 +228,11 @@ UNODB_TEST_F(QSBR, ThreeThreadsInitialPaused) {
   thread_syncs[0].wait();
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1);
   unodb::qsbr_thread third_thread([] {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[2]};
+    const notify_thread_on_scope_exit notify_second_thread{thread_syncs[1]};
     UNODB_ASSERT_EQ(get_qsbr_thread_count(), 2);
-    thread_syncs[1].notify();
   });
+  thread_syncs[2].wait();
   join(second_thread);
   join(third_thread);
   UNODB_ASSERT_EQ(get_qsbr_thread_count(), 0);
@@ -884,6 +936,7 @@ UNODB_TEST_F(QSBR, ResetStats) {
 
 UNODB_TEST_F(QSBR, GettersConcurrentWithQuiescentState) {
   unodb::qsbr_thread second_thread{[] {
+    const notify_thread_on_scope_exit notify_parent{thread_syncs[1]};
     quiescent();
 
     thread_syncs[0].notify();  // 1 -> & v
@@ -906,6 +959,7 @@ UNODB_TEST_F(QSBR, GettersConcurrentWithQuiescentState) {
   quiescent();
   quiescent();
 
+  thread_syncs[1].wait();
   join(second_thread);
 }
 

--- a/test/test_qsbr_oom.cpp
+++ b/test/test_qsbr_oom.cpp
@@ -1,21 +1,19 @@
-// Copyright 2022-2025 UnoDB contributors
+// Copyright 2022-2026 UnoDB contributors
 
 #ifndef NDEBUG
 
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <__new/exceptions.h>
 // IWYU pragma: no_include <gtest/gtest.h>
 // IWYU pragma: no_include <array>
 // IWYU pragma: no_include <string>
-
-#include <new>  // IWYU pragma: keep
 
 #include "gtest_utils.hpp"
 #include "qsbr.hpp"
 #include "qsbr_gtest_utils.hpp"
 #include "test_heap.hpp"
+#include "test_utils.hpp"
 #include "thread_sync.hpp"
 
 namespace {
@@ -32,14 +30,10 @@ template <typename Test, typename AfterOOM>
 void oom_test(unsigned fail_limit, Test test, AfterOOM after_oom) {
   unsigned fail_n;
   for (fail_n = 1; fail_n < fail_limit; ++fail_n) {
-    unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-    UNODB_ASSERT_THROW(test(), std::bad_alloc);
-    unodb::test::allocation_failure_injector::reset();
+    UNODB_ASSERT_TRUE(unodb::test::throws_bad_alloc(fail_n, test));
     after_oom();
   }
-  unodb::test::allocation_failure_injector::fail_on_nth_allocation(fail_n);
-  test();
-  unodb::test::allocation_failure_injector::reset();
+  UNODB_ASSERT_FALSE(unodb::test::throws_bad_alloc(fail_n, test));
 }
 
 using QSBROOMTest = unodb::test::QSBRTestBase;
@@ -59,11 +53,35 @@ UNODB_TEST_F(QSBROOMTest, StartThread) {
   oom_test(
       4 + std_thread_thread_alloc_count,
       [&second_thread] {
-        second_thread = unodb::qsbr_thread{
-            []() noexcept { UNODB_EXPECT_EQ(get_qsbr_thread_count(), 2); }};
+        // The operation under test is the thread creation itself, so the child
+        // necessarily runs inside the armed window. It must therefore not arm a
+        // guard of its own: read the state directly rather than through
+        // get_qsbr_thread_count(), which pins with must_not_allocate. The read
+        // runs armed, but the comparison must not: Google Test allocates while
+        // building a failure message, and this frame is noexcept, so an armed
+        // injector would turn the diagnostic into std::terminate. Pausing is
+        // thread-local, so it neither disturbs the parent's arming nor exempts
+        // the child's exit path. The child blocks after the comparison until
+        // the parent releases it from inside the join pin, so teardown cannot
+        // fall between the two armed scopes.
+        second_thread = unodb::qsbr_thread{[]() noexcept {
+          const auto thread_count = unodb::qsbr_state::get_thread_count(
+              unodb::qsbr::instance().get_state());
+          {
+            UNODB_DETAIL_PAUSE_HEAP_TRACKING_GUARD();
+            UNODB_EXPECT_EQ(thread_count, 2);
+          }
+          unodb::detail::thread_syncs[0].notify();
+          unodb::detail::thread_syncs[1].wait();
+        }};
       },
       []() noexcept { UNODB_ASSERT_EQ(get_qsbr_thread_count(), 1); });
-  join(second_thread);
+  UNODB_ASSERT_TRUE(second_thread.joinable());
+  unodb::detail::thread_syncs[0].wait();
+  unodb::test::must_not_allocate([&second_thread] {
+    unodb::detail::thread_syncs[1].notify();
+    second_thread.join();
+  });
 }
 
 UNODB_TEST_F(QSBROOMTest, DeferredDeallocation) {

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 UnoDB contributors
+// Copyright 2022-2026 UnoDB contributors
 #ifndef UNODB_DETAIL_TEST_UTILS_HPP
 #define UNODB_DETAIL_TEST_UTILS_HPP
 
@@ -12,6 +12,13 @@
 // Should be the first include
 #include "global.hpp"
 
+#include <type_traits>
+
+#ifndef NDEBUG
+#include <cstdint>
+#include <new>
+#endif
+
 #include "test_heap.hpp"
 
 namespace unodb::test {
@@ -19,9 +26,28 @@ namespace unodb::test {
 /// Test that given action does not allocate heap memory.
 ///
 /// This function configures the allocation failure injector to fail on the
-/// first allocation, executes the provided test action, and then resets
-/// the injector state. If the action tries to allocate memory, it will throw
-/// `std::bad_alloc`. If it completes successfully, we know it didn't allocate.
+/// first allocation and executes the provided test action. If the action tries
+/// to allocate memory, it will throw `std::bad_alloc`. If it completes
+/// successfully, we know it didn't allocate. The injector is reset on every
+/// exit from the pinned scope: a normal return, a fatal Google Test assertion
+/// inside \a test_action, and the injected `std::bad_alloc` alike. Under
+/// `NDEBUG` the injector compiles away, so the pin is not enforced and
+/// \a test_action simply runs: the check is skipped rather than answered
+/// wrongly.
+///
+/// \warning Armed scopes must not nest on one thread: doing so trips
+/// unodb::test::fail_on_nth_allocation_guard's debug assert, which aborts the
+/// process instead of reporting a test failure.
+///
+/// \warning A `noexcept` \a test_action does not unwind: the injected
+/// `std::bad_alloc` crosses its own `noexcept` boundary, so a violated pin
+/// terminates the process instead of producing an observable `std::bad_alloc`.
+/// The QSBR accessors pass such actions deliberately, as CONTRIBUTING.md asks
+/// for `noexcept` on anything that cannot throw in a release build, which is
+/// what these are once this guard compiles away.
+///
+/// \warning An assertion inside \a test_action runs armed: its failure escapes
+/// as `std::bad_alloc`, losing the diagnostic. Assert on the result instead.
 ///
 /// \warning This function affects global state. No other threads should
 /// allocate memory during execution of this function, as the allocation
@@ -32,19 +58,72 @@ namespace unodb::test {
 /// its execution.
 /// \return The result of test_action (if non-void)
 template <typename TestAction>
-std::invoke_result_t<TestAction> must_not_allocate(
-    TestAction test_action) noexcept(noexcept(test_action())) {
-  if constexpr (!std::is_void_v<std::invoke_result_t<TestAction>>) {
-    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(1);
-    const auto result = test_action();
-    UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR();
-    return result;
-  } else {
-    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(1);
-    test_action();
-    UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR();
-  }
+  requires(!std::is_void_v<std::invoke_result_t<const TestAction&>>)
+[[nodiscard]]
+std::invoke_result_t<const TestAction&> must_not_allocate(
+    const TestAction& test_action) noexcept(noexcept(test_action())) {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
+  return test_action();
 }
+
+/// \overload
+template <typename TestAction>
+  requires std::is_void_v<std::invoke_result_t<const TestAction&>>
+void must_not_allocate(const TestAction& test_action) noexcept(
+    noexcept(test_action())) {
+  UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(1);
+  test_action();
+}
+
+#ifndef NDEBUG
+
+// C26440 overlooks the deliberately propagated non-bad_alloc path.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
+
+/// Run \a action with the allocation failure injector armed to fail allocation
+/// number \a fail_n, and report whether it threw `std::bad_alloc`.
+///
+/// Keeps the armed scope around \a action alone: the guard is destroyed while
+/// the injected failure unwinds, so the handler below, and the caller's
+/// assertion on the result, both run disarmed. Asserting on the result
+/// afterwards, rather than wrapping \a action in an assertion, matters: a
+/// failing assertion builds its message with the injector still armed at its
+/// trip point, so the diagnostic would be replaced by an escaping
+/// `std::bad_alloc`.
+///
+/// Declared in debug builds only. Under `NDEBUG` the injector compiles away,
+/// where this would arm nothing and report `false` for every \a fail_n --- a
+/// wrong answer rather than a skipped check, unlike must_not_allocate(). Every
+/// call site must therefore sit inside `#ifndef NDEBUG`, which the absent
+/// declaration enforces at compile time.
+///
+/// \warning An assertion inside \a action runs armed past the trip point, so
+/// its failure escapes as `std::bad_alloc` and is reported here as the expected
+/// outcome, leaving the check unmade. Pause across such assertions.
+///
+/// \warning Arms a process-wide injector; concurrent allocations can interfere.
+///
+/// \warning Must not call must_not_allocate() or be called from it.
+///
+/// \tparam Action Type of the action callable
+/// \param fail_n The 1-based number of the allocation that should fail
+/// \param action Operation under test
+/// \return Whether \a action threw `std::bad_alloc`
+template <typename Action>
+[[nodiscard]] bool throws_bad_alloc(
+    std::uint64_t fail_n, const Action& action) noexcept(noexcept(action())) {
+  try {
+    UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(fail_n);
+    action();
+  } catch (const std::bad_alloc&) {
+    return true;
+  }
+  return false;
+}
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+
+#endif  // !NDEBUG
 
 }  // namespace unodb::test
 

--- a/test_heap.hpp
+++ b/test_heap.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 UnoDB contributors
+// Copyright 2023-2026 UnoDB contributors
 #ifndef UNODB_DETAIL_TEST_HEAP_HPP
 #define UNODB_DETAIL_TEST_HEAP_HPP
 
@@ -18,6 +18,7 @@
 #ifndef NDEBUG
 
 #include <atomic>
+#include <cassert>  // Avoid cyclical dependency with assert.hpp
 #include <cstdint>
 #include <iostream>
 #include <new>  // IWYU pragma: keep
@@ -133,6 +134,74 @@ struct [[nodiscard]] pause_heap_faults final {
   pause_heap_faults& operator=(pause_heap_faults&&) = delete;
 };
 
+/// Lexically scoped guard that fails the nth heap allocation and resets the
+/// injector on every exit from the scope, including the injected failure
+/// itself and a fatal test assertion.
+///
+/// Only one guard may be active in the process, which a debug atomic asserts.
+///
+/// A violated pin is reported by throwing `std::bad_alloc`, so any `noexcept`
+/// frame inside the armed scope turns the violation into `std::terminate`
+/// rather than an observable exception.  That includes a destructor run at
+/// scope exit, which is why pinning one is a deliberate choice and not a free
+/// extra check.
+///
+/// The injector state is process-wide, so a concurrent guard aborts rather than
+/// resetting another guard's arming. Other threads still must not allocate: a
+/// foreign allocation either consumes the pin, which passes the check
+/// vacuously, or trips it on the wrong thread. Other threads may run as long as
+/// they do not allocate.
+///
+/// This guard cannot restore an enclosing scope's state on exit: the arming is
+/// a counting policy, and the enclosing scope's allocation count cannot
+/// meaningfully account for what the inner scope allocated.
+///
+/// Past the trip point every allocation fails, so a test assertion inside the
+/// armed scope loses its diagnostic to an escaping `std::bad_alloc`.  Evaluate
+/// assertions outside the scope, or pause across them.
+///
+/// \note Do not instantiate directly: use
+/// UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(n) instead.
+struct [[nodiscard]] fail_on_nth_allocation_guard final {
+ public:
+  /// Arm the injector to fail allocation number \a n for this process.
+  explicit fail_on_nth_allocation_guard(std::uint64_t n) noexcept {
+    assert(n != 0 &&
+           "fail_on_nth_allocation_guard is 1-based; 0 disarms the injector");
+    const auto was_active = active.exchange(true, std::memory_order_acquire);
+    assert(!was_active &&
+           "must_not_allocate/throws_bad_alloc scopes must not nest; guards "
+           "must not overlap");
+    allocation_failure_injector::reset();
+    allocation_failure_injector::fail_on_nth_allocation(n);
+  }
+
+  /// Disarm the injector.
+  ~fail_on_nth_allocation_guard() noexcept {
+    allocation_failure_injector::reset();
+    active.store(false, std::memory_order_release);
+  }
+
+  /// Copy construction is disabled.
+  fail_on_nth_allocation_guard(const fail_on_nth_allocation_guard&) = delete;
+
+  /// Move construction is disabled.
+  fail_on_nth_allocation_guard(fail_on_nth_allocation_guard&&) = delete;
+
+  /// Copy assignment is disabled.
+  fail_on_nth_allocation_guard& operator=(const fail_on_nth_allocation_guard&) =
+      delete;
+
+  /// Move assignment is disabled.
+  fail_on_nth_allocation_guard& operator=(fail_on_nth_allocation_guard&&) =
+      delete;
+
+ private:
+  /// Whether a guard is active in this process.
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+  inline static std::atomic<bool> active{false};
+};
+
 }  // namespace unodb::test
 
 /// \addtogroup test-internals
@@ -158,7 +227,14 @@ struct [[nodiscard]] pause_heap_faults final {
 /// To be used for specific allocations that are outside of the tested code,
 /// such as constructing test diagnostic messages.
 #define UNODB_DETAIL_PAUSE_HEAP_TRACKING_GUARD() \
-  unodb::test::pause_heap_faults guard {}
+  const unodb::test::pause_heap_faults guard {}
+
+/// Fail the nth heap allocation in the current scope, disarming the injector
+/// on every exit from it.
+/// \hideinitializer
+/// \param n The 1-based number of the allocation that should fail.
+#define UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(n) \
+  const unodb::test::fail_on_nth_allocation_guard heap_fault_guard { n }
 
 /// \}
 
@@ -169,6 +245,7 @@ struct [[nodiscard]] pause_heap_faults final {
 #define UNODB_DETAIL_RESET_ALLOCATION_FAILURE_INJECTOR()
 #define UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION(n)
 #define UNODB_DETAIL_PAUSE_HEAP_TRACKING_GUARD()
+#define UNODB_DETAIL_FAIL_ON_NTH_ALLOCATION_GUARD(n)
 
 #endif  // !NDEBUG
 


### PR DESCRIPTION
(LLM agent)

## Summary

- replace manual allocation-injector reset sites with an RAII guard
- keep OOM assertions and post-checks outside armed scopes
- reject nested and concurrent guards with a process-wide atomic claim
- add focused fault-injection coverage

## Testing

- ./check.sh
- debug test_fault_injection target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fault-injection coverage for allocation failures, exception handling, guard behavior, and invalid usage.
  * Expanded out-of-memory testing for tree operations, scans, bulk loads, and thread-state handling.
  * Improved multithreaded synchronization coverage, including thread lifecycle and scope-exit notifications.
  * Integrated fault-injection tests with sanitized, coverage, and Valgrind test runs.
  * Added reusable checks for non-throwing operations, failed allocations, result handling, and exception-safe cleanup.
  * Improved coverage instrumentation propagation across linked test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->