### PR TITLE
Reclaim OLC-deferred nodes through the allocator's dealloc

### DIFF
--- a/art_allocator.hpp
+++ b/art_allocator.hpp
@@ -20,8 +20,9 @@
 
 namespace unodb {
 
-/// Callback invoked when a deferred deallocation is safe to execute.
-using destroy_callback_type = void (*)(void* ptr, std::size_t size, void* ctx);
+/// Non-throwing callback invoked when deferred deallocation is safe to execute.
+using destroy_callback_type = void (*)(void* ptr, std::size_t size,
+                                       void* ctx) noexcept;
 
 /// Pluggable allocator for ART trees.
 ///
@@ -34,10 +35,14 @@ using destroy_callback_type = void (*)(void* ptr, std::size_t size, void* ctx);
 struct allocator_type {
   /// Allocate `size` bytes with the given `alignment`. May throw on failure.
   void* (*alloc)(std::size_t size, std::size_t alignment, void* ctx);
-  /// Free a previously allocated block of `size` bytes at `ptr`.
-  void (*dealloc)(void* ptr, std::size_t size, void* ctx);
+  /// Free a previously allocated block of `size` bytes at `ptr` without
+  /// throwing.
+  void (*dealloc)(void* ptr, std::size_t size, void* ctx) noexcept;
   /// Schedule deferred deallocation of `ptr` (`size` bytes). Calls
-  /// `destroy_callback` when reclamation is safe.
+  /// `destroy_callback` when reclamation is safe. `destroy_callback` is
+  /// \a dealloc, so the allocation is reclaimed through the same allocator;
+  /// it may run on another thread and after the deferring one has exited, so
+  /// \a dealloc and \a ctx must outlive all pending deferrals.
   void (*defer_dealloc)(void* ptr, std::size_t size,
                         destroy_callback_type destroy_callback, void* ctx);
   /// Opaque context forwarded to all callbacks.
@@ -56,12 +61,6 @@ inline void* default_alloc(std::size_t size, std::size_t alignment,
 inline void default_dealloc(void* ptr, std::size_t /*size*/,
                             void* /*ctx*/) noexcept {
   free_aligned(ptr);
-}
-
-/// Default destroy callback: frees via default_dealloc.
-/// Passed as the destroy_callback argument to defer_dealloc.
-inline void default_destroy(void* ptr, std::size_t size, void* ctx) noexcept {
-  default_dealloc(ptr, size, ctx);
 }
 
 /// The default allocator instance without deferred deallocation.

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -1134,7 +1134,7 @@ class db_inode_qsbr_deleter
     static_assert(std::is_trivially_destructible_v<INode>);
 
     const auto& alloc = this->get_db().get_allocator();
-    alloc.defer_dealloc(inode_ptr, sizeof(INode), &default_destroy, alloc.ctx);
+    alloc.defer_dealloc(inode_ptr, sizeof(INode), alloc.dealloc, alloc.ctx);
 
 #ifdef UNODB_DETAIL_WITH_STATS
     this->get_db().template decrement_inode_count<INode>();
@@ -1160,7 +1160,7 @@ class db_leaf_qsbr_deleter {
   void operator()(leaf_type* to_delete) const noexcept {
     const auto leaf_size = to_delete->get_size();
     const auto& alloc = db_instance.get_allocator();
-    alloc.defer_dealloc(to_delete, leaf_size, &default_destroy, alloc.ctx);
+    alloc.defer_dealloc(to_delete, leaf_size, alloc.dealloc, alloc.ctx);
 
 #ifdef UNODB_DETAIL_WITH_STATS
     db_instance.decrement_leaf_count(leaf_size);

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -454,7 +454,8 @@ namespace detail {
 
 /// Function type for destroy callbacks invoked when deferred deallocation is
 /// safe.  Matches the signature in art_allocator.hpp.
-using destroy_callback_type = void (*)(void* ptr, std::size_t size, void* ctx);
+using destroy_callback_type = void (*)(void* ptr, std::size_t size,
+                                       void* ctx) noexcept;
 
 /// Pending deallocation request for QSBR-managed memory.
 class [[nodiscard]] deallocation_request final {

--- a/test/test_art_allocator.cpp
+++ b/test/test_art_allocator.cpp
@@ -6,18 +6,26 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 
 #include "art_allocator.hpp"
 #include "art_common.hpp"
 #include "gtest_utils.hpp"
+#include "heap.hpp"
 #include "mutex_art.hpp"
 #include "olc_art.hpp"
 #include "qsbr.hpp"
 
 namespace {
 
+static_assert(std::is_nothrow_invocable_v<unodb::destroy_callback_type, void*,
+                                          std::size_t, void*>);
+static_assert(
+    std::is_nothrow_invocable_v<decltype(unodb::allocator_type::dealloc), void*,
+                                std::size_t, void*>);
+
 // Exercise the custom allocator constructor and get_allocator() for each db
-// type. Also exercises default_destroy through the QSBR-based
+// type. Also exercises deferred reclamation through the QSBR-based
 // olc_default_allocator by performing insert+remove on olc_db.
 
 UNODB_TEST(ArtAllocator, DbCustomAllocatorConstructor) {
@@ -50,6 +58,60 @@ UNODB_TEST(ArtAllocator, OlcDbDefaultAllocatorInsertRemove) {
 
   UNODB_ASSERT_TRUE(db.remove(key));
   UNODB_EXPECT_TRUE(db.empty());
+}
+
+// A deferred node must be reclaimed through the allocator's own dealloc, not
+// through the built-in heap: an allocator serving memory from a private heap
+// would otherwise have its removed nodes freed by the wrong deallocator.
+
+/// Counts allocator callbacks for one test allocator.
+struct counting_arena final {
+  /// Number of allocation callbacks.
+  std::size_t allocs{0};
+  /// Number of deallocation callbacks.
+  std::size_t deallocs{0};
+};
+
+/// Allocate through the counting allocator.
+[[nodiscard]] void* counting_alloc(std::size_t size, std::size_t alignment,
+                                   void* ctx) {
+  ++static_cast<counting_arena*>(ctx)->allocs;
+  return unodb::detail::allocate_aligned(size, alignment);
+}
+
+/// Deallocate through the counting allocator.
+void counting_dealloc(void* ptr, std::size_t /*size*/, void* ctx) noexcept {
+  ++static_cast<counting_arena*>(ctx)->deallocs;
+  unodb::detail::free_aligned(ptr);
+}
+
+/// Execute a deferred deallocation immediately.
+void immediate_defer(void* ptr, std::size_t size,
+                     unodb::destroy_callback_type destroy_callback,
+                     void* ctx) noexcept {
+  destroy_callback(ptr, size, ctx);
+}
+
+UNODB_TEST(ArtAllocator, OlcDbDeferredFreeUsesAllocatorDealloc) {
+  counting_arena arena{};
+  const unodb::allocator_type alloc{.alloc = &counting_alloc,
+                                    .dealloc = &counting_dealloc,
+                                    .defer_dealloc = &immediate_defer,
+                                    .ctx = &arena};
+  {
+    unodb::olc_db<std::uint64_t, unodb::value_view> db{alloc};
+
+    constexpr std::uint64_t first_key = 42;
+    constexpr std::uint64_t second_key = 43;
+    const auto val_data = std::array{std::byte{0xAB}};
+    UNODB_ASSERT_TRUE(db.insert(first_key, unodb::value_view{val_data}));
+    UNODB_ASSERT_TRUE(db.insert(second_key, unodb::value_view{val_data}));
+    UNODB_ASSERT_EQ(arena.allocs, 3);
+
+    UNODB_ASSERT_TRUE(db.remove(first_key));
+    UNODB_ASSERT_EQ(arena.deallocs, 2);
+  }
+  UNODB_ASSERT_EQ(arena.deallocs, arena.allocs);
 }
 
 }  // namespace


### PR DESCRIPTION
(LLM agent)

## Summary

- route deferred OLC leaf and inode reclamation through the configured allocator
- remove the unused default destroy callback and document callback lifetime requirements
- verify custom-allocator reclamation for both leaves and internal nodes

## Testing

- `./check.sh`
- `cmake --build build/debug --target test_art_allocator -j 10`
- `ctest --test-dir build/debug --output-on-failure -R '^test_art_allocator$'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom allocators now correctly handle deferred reclamation of removed data structures.
  * Configured deallocation callbacks are used consistently during asynchronous cleanup.
  * Deallocation callbacks must complete without throwing, improving cleanup reliability.

* **Tests**
  * Added coverage verifying custom allocation and deallocation callbacks are invoked and resources are fully reclaimed.

* **Documentation**
  * Clarified that callbacks and their associated context must remain valid during deferred execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->